### PR TITLE
Remove calls to getAddress, as they create excessive overhead.

### DIFF
--- a/src/entities/token.ts
+++ b/src/entities/token.ts
@@ -15,7 +15,7 @@ export class Token {
         name?: string,
     ) {
         this.chainId = chainId;
-        this.address = getAddress(address);
+        this.address = address.toLowerCase();
         this.decimals = decimals;
         this.symbol = symbol;
         this.name = name;

--- a/src/utils/pool.ts
+++ b/src/utils/pool.ts
@@ -1,10 +1,9 @@
-import { getAddress } from '@ethersproject/address';
 /**
  * Extracts a pool's address from its poolId
  * @param poolId - a bytes32 string of the pool's ID
  * @returns the pool's address
  */
 export const getPoolAddress = (poolId: string): string => {
-    if(poolId.length !== 66) throw new Error('Invalid poolId length');
-    return getAddress(poolId.slice(0, 42));
+    if (poolId.length !== 66) throw new Error('Invalid poolId length');
+    return poolId.slice(0, 42).toLowerCase();
 };


### PR DESCRIPTION
Seeing a 40% reduction in pool parsing time by removing calls to `getAddress`