### PR TITLE
Implement an unsafe fast parse ether function for use in pool parsing

### DIFF
--- a/src/entities/pool/stable.ts
+++ b/src/entities/pool/stable.ts
@@ -1,10 +1,10 @@
-import { parseEther } from '@ethersproject/units';
 import { PoolType, SwapKind } from '../../types';
 import { Token, TokenAmount, BigintIsh } from '../../entities/';
 import { BasePool } from './';
 import { SubgraphPool } from '../../poolProvider';
 import { BONE, getPoolAddress } from '../../utils';
 import { _calculateInvariant, _calcOutGivenIn } from './stableMath';
+import { unsafeFastParseEther } from '../../utils/ether';
 
 export class StablePoolToken extends TokenAmount {
     public readonly rate: bigint;
@@ -36,13 +36,13 @@ export class StablePool implements BasePool {
             return new StablePoolToken(
                 token,
                 tokenAmount.amount,
-                parseEther(t.priceRate).toString(),
+                unsafeFastParseEther(t.priceRate),
             );
         });
         const stablePool = new StablePool(
             pool.id,
             BigInt(pool.amp),
-            BigInt(parseEther(pool.swapFee).toString()),
+            BigInt(unsafeFastParseEther(pool.swapFee)),
             poolTokens,
         );
         return stablePool;
@@ -80,7 +80,10 @@ export class StablePool implements BasePool {
     }
 
     public swapGivenIn(tokenIn: Token, tokenOut: Token, swapAmount: TokenAmount): TokenAmount {
-        if (tokenIn === this.tokens[this.bptIndex].token || tokenOut === this.tokens[this.bptIndex].token) {
+        if (
+            tokenIn === this.tokens[this.bptIndex].token ||
+            tokenOut === this.tokens[this.bptIndex].token
+        ) {
             throw new Error('BPT swap not implemented yet');
             // swapWithBpt()
         } else {
@@ -97,7 +100,7 @@ export class StablePool implements BasePool {
             const balancesNoBpt = tokensNoBpt.map(t => t.scale18);
 
             const invariant = _calculateInvariant(this.amp, balancesNoBpt);
-            
+
             const tokenOutScale18 = _calcOutGivenIn(
                 this.amp,
                 balancesNoBpt,
@@ -110,7 +113,6 @@ export class StablePool implements BasePool {
             // TODO: Scale rate back down in TokenAmountRate class
             return TokenAmount.fromScale18Amount(tokenOut, tokenOutScale18);
         }
-
     }
 
     public subtractSwapFeeAmount(amount: TokenAmount): TokenAmount {

--- a/src/entities/pool/weighted.ts
+++ b/src/entities/pool/weighted.ts
@@ -1,10 +1,10 @@
-import { parseEther } from '@ethersproject/units';
 import { PoolType, SwapKind } from '../../types';
 import { Token, TokenAmount, BigintIsh } from '../../entities/';
 import { BasePool } from './';
 import { SubgraphPool } from '../../poolProvider';
 import { BONE, getPoolAddress } from '../../utils';
 import { _calcOutGivenIn } from './weightedMath';
+import { unsafeFastParseEther } from '../../utils/ether';
 
 export class WeightedPoolToken extends TokenAmount {
     public readonly weight: bigint;
@@ -30,16 +30,13 @@ export class WeightedPool implements BasePool {
             if (!t.weight) throw new Error('Weighted pool token does not have a weight');
             const token = new Token(1, t.address, t.decimals, t.symbol, t.name);
             const tokenAmount = TokenAmount.fromHumanAmount(token, t.balance);
-            return new WeightedPoolToken(
-                token,
-                tokenAmount.amount,
-                parseEther(t.weight).toString(),
-            );
+
+            return new WeightedPoolToken(token, tokenAmount.amount, unsafeFastParseEther(t.weight));
         });
         const weightedPool = new WeightedPool(
             pool.id,
             pool.poolTypeVersion,
-            BigInt(parseEther(pool.swapFee).toString()),
+            BigInt(unsafeFastParseEther(pool.swapFee)),
             poolTokens,
         );
         return weightedPool;
@@ -88,7 +85,7 @@ export class WeightedPool implements BasePool {
             tOut.scale18,
             tOut.weight,
             amountWithFee.scale18,
-            this.poolTypeVersion
+            this.poolTypeVersion,
         );
 
         return TokenAmount.fromScale18Amount(tokenOut, tokenOutScale18);

--- a/src/utils/ether.ts
+++ b/src/utils/ether.ts
@@ -1,0 +1,14 @@
+export function unsafeFastParseEther(value: string): string {
+    const parts = value.split('.');
+    parts[0] = parts[0] || '';
+    parts[1] = parts[1] || '';
+
+    const zerosToAdd = 18 - parts[1].length;
+    let etherValue = `${parts[0] !== '0' ? parts[0] : ''}${parts[1]}`;
+
+    for (let i = 0; i < zerosToAdd; i++) {
+        etherValue += '0';
+    }
+
+    return etherValue;
+}


### PR DESCRIPTION
This is debatable, but implementing a less robust `unsafe` ether parse has a meaningful reduction in parse time.