### PR TITLE
Add unsafeFastParseUnits, prefer map.get over array.find

### DIFF
--- a/src/entities/pools/metaStable/index.ts
+++ b/src/entities/pools/metaStable/index.ts
@@ -1,64 +1,70 @@
 import { PoolType, SwapKind } from '../../../types';
-import { Token, TokenAmount, BigintIsh } from '../../';
+import { BigintIsh, Token, TokenAmount } from '../../';
 import { BasePool } from '../';
-import { MathSol, WAD, getPoolAddress, unsafeFastParseEther } from '../../../utils';
-import { _calculateInvariant, _calcOutGivenIn, _calcInGivenOut } from '../stable/math';
+import { ALMOST_ONE, getPoolAddress, MathSol, unsafeFastParseEther, WAD } from '../../../utils';
+import { _calcInGivenOut, _calcOutGivenIn, _calculateInvariant } from '../stable/math';
 import { RawMetaStablePool } from '../../../data/types';
 
-const ALMOST_ONE = unsafeFastParseEther('0.99');
-
-export class StablePoolToken extends TokenAmount {
+class StablePoolToken extends TokenAmount {
     public readonly rate: bigint;
     public readonly scale18: bigint;
+    public readonly index: number;
 
-    public constructor(token: Token, amount: BigintIsh, rate: BigintIsh) {
+    public constructor(token: Token, amount: BigintIsh, rate: BigintIsh, index: number) {
         super(token, amount);
         this.rate = BigInt(rate);
         this.scale18 = (this.amount * this.scalar * this.rate) / WAD;
+        this.index = index;
     }
 }
 
 export class MetaStablePool implements BasePool {
-    readonly id: string;
-    readonly address: string;
-    readonly poolType: PoolType = PoolType.MetaStable;
-    amp: bigint;
-    swapFee: bigint;
-    tokens: StablePoolToken[];
+    public readonly id: string;
+    public readonly address: string;
+    public readonly poolType: PoolType = PoolType.MetaStable;
+    public readonly amp: bigint;
+    public readonly swapFee: bigint;
+    public readonly tokens: StablePoolToken[];
+
+    private readonly tokenMap: Map<string, StablePoolToken>;
+    private readonly tokenIndexMap: Map<string, number>;
 
     static fromRawPool(pool: RawMetaStablePool): MetaStablePool {
-        const orderedTokens = pool.tokens.sort((a, b) => a.index - b.index);
-        const poolTokens = orderedTokens.map(t => {
+        const poolTokens: StablePoolToken[] = [];
+
+        for (const t of pool.tokens) {
             if (!t.priceRate) throw new Error('Meta Stable pool token does not have a price rate');
             const token = new Token(1, t.address, t.decimals, t.symbol, t.name);
             const tokenAmount = TokenAmount.fromHumanAmount(token, t.balance);
-            return new StablePoolToken(
-                token,
-                tokenAmount.amount,
-                unsafeFastParseEther(t.priceRate),
+            poolTokens.push(
+                new StablePoolToken(
+                    token,
+                    tokenAmount.amount,
+                    unsafeFastParseEther(t.priceRate),
+                    t.index,
+                ),
             );
-        });
+        }
+
         const amp = BigInt(pool.amp) * 1000n;
-        const stablePool = new MetaStablePool(
-            pool.id,
-            amp,
-            unsafeFastParseEther(pool.swapFee),
-            poolTokens,
-        );
-        return stablePool;
+
+        return new MetaStablePool(pool.id, amp, unsafeFastParseEther(pool.swapFee), poolTokens);
     }
 
     constructor(id: string, amp: bigint, swapFee: bigint, tokens: StablePoolToken[]) {
         this.id = id;
-        this.tokens = tokens;
         this.address = getPoolAddress(id);
         this.amp = amp;
         this.swapFee = swapFee;
+
+        this.tokens = tokens.sort((a, b) => a.index - b.index);
+        this.tokenMap = new Map(this.tokens.map(token => [token.token.address, token]));
+        this.tokenIndexMap = new Map(this.tokens.map(token => [token.token.address, token.index]));
     }
 
     public getNormalizedLiquidity(tokenIn: Token, tokenOut: Token): bigint {
-        const tIn = this.tokens.find(t => t.token.address === tokenIn.address);
-        const tOut = this.tokens.find(t => t.token.address === tokenOut.address);
+        const tIn = this.tokenMap.get(tokenIn.address);
+        const tOut = this.tokenMap.get(tokenOut.address);
 
         if (!tIn || !tOut) throw new Error('Pool does not contain the tokens provided');
         // TODO: Fix stable normalized liquidity calc
@@ -66,14 +72,16 @@ export class MetaStablePool implements BasePool {
     }
 
     public swapGivenIn(tokenIn: Token, tokenOut: Token, swapAmount: TokenAmount): TokenAmount {
-        const tInIndex = this.tokens.findIndex(t => t.token.address === tokenIn.address);
-        const tOutIndex = this.tokens.findIndex(t => t.token.address === tokenOut.address);
+        const tInIndex = this.tokenIndexMap.get(tokenIn.address);
+        const tOutIndex = this.tokenIndexMap.get(tokenOut.address);
 
-        if (tInIndex < 0 || tOutIndex < 0)
+        if (typeof tInIndex !== 'number' || typeof tOutIndex !== 'number') {
             throw new Error('Pool does not contain the tokens provided');
+        }
 
-        if (swapAmount.amount > this.tokens[tInIndex].amount)
+        if (swapAmount.amount > this.tokens[tInIndex].amount) {
             throw new Error('Swap amount exceeds the pool limit');
+        }
 
         const amountInWithFee = this.subtractSwapFeeAmount(swapAmount);
         const amountInWithRate = amountInWithFee.mulDownFixed(this.tokens[tInIndex].rate);
@@ -91,20 +99,21 @@ export class MetaStablePool implements BasePool {
         );
 
         const amountOut = TokenAmount.fromScale18Amount(tokenOut, tokenOutScale18);
-        const amountOutWithRate = amountOut.divDownFixed(this.tokens[tOutIndex].rate);
 
-        return amountOutWithRate;
+        return amountOut.divDownFixed(this.tokens[tOutIndex].rate);
     }
 
     public swapGivenOut(tokenIn: Token, tokenOut: Token, swapAmount: TokenAmount): TokenAmount {
-        const tInIndex = this.tokens.findIndex(t => t.token.address === tokenIn.address);
-        const tOutIndex = this.tokens.findIndex(t => t.token.address === tokenOut.address);
+        const tInIndex = this.tokenIndexMap.get(tokenIn.address);
+        const tOutIndex = this.tokenIndexMap.get(tokenOut.address);
 
-        if (tInIndex < 0 || tOutIndex < 0)
+        if (typeof tInIndex !== 'number' || typeof tOutIndex !== 'number') {
             throw new Error('Pool does not contain the tokens provided');
+        }
 
-        if (swapAmount.amount > this.tokens[tOutIndex].amount)
+        if (swapAmount.amount > this.tokens[tOutIndex].amount) {
             throw new Error('Swap amount exceeds the pool limit');
+        }
 
         const amountOutWithRate = swapAmount.mulDownFixed(this.tokens[tOutIndex].rate);
 
@@ -123,9 +132,8 @@ export class MetaStablePool implements BasePool {
 
         const amountIn = TokenAmount.fromScale18Amount(tokenIn, tokenInScale18, true);
         const amountInWithFee = this.addSwapFeeAmount(amountIn);
-        const amountInWithRate = amountInWithFee.divDownFixed(this.tokens[tInIndex].rate);
 
-        return amountInWithRate;
+        return amountInWithFee.divDownFixed(this.tokens[tInIndex].rate);
     }
 
     public subtractSwapFeeAmount(amount: TokenAmount): TokenAmount {
@@ -138,8 +146,8 @@ export class MetaStablePool implements BasePool {
     }
 
     public getLimitAmountSwap(tokenIn: Token, tokenOut: Token, swapKind: SwapKind): bigint {
-        const tIn = this.tokens.find(t => t.token.address === tokenIn.address);
-        const tOut = this.tokens.find(t => t.token.address === tokenOut.address);
+        const tIn = this.tokenMap.get(tokenIn.address);
+        const tOut = this.tokenMap.get(tokenOut.address);
 
         if (!tIn || !tOut) throw new Error('Pool does not contain the tokens provided');
 

--- a/src/entities/pools/weighted/index.ts
+++ b/src/entities/pools/weighted/index.ts
@@ -5,63 +5,75 @@ import { MathSol, WAD, getPoolAddress, unsafeFastParseEther } from '../../../uti
 import { _calcOutGivenIn, _calcInGivenOut } from './math';
 import { RawWeightedPool } from '../../../data/types';
 
-export class WeightedPoolToken extends TokenAmount {
+class WeightedPoolToken extends TokenAmount {
     public readonly weight: bigint;
+    public readonly index: number;
 
-    public constructor(token: Token, amount: BigintIsh, weight: BigintIsh) {
+    public constructor(token: Token, amount: BigintIsh, weight: BigintIsh, index: number) {
         super(token, amount);
         this.weight = BigInt(weight);
+        this.index = index;
     }
 }
 
 export class WeightedPool implements BasePool {
-    readonly id: string;
-    readonly address: string;
-    readonly poolType: PoolType = PoolType.Weighted;
-    readonly poolTypeVersion: number;
-    swapFee: bigint;
-    tokens: WeightedPoolToken[];
+    public readonly id: string;
+    public readonly address: string;
+    public readonly poolType: PoolType = PoolType.Weighted;
+    public readonly poolTypeVersion: number;
+    public readonly swapFee: bigint;
+    public readonly tokens: WeightedPoolToken[];
+
+    private readonly tokenMap: Map<string, WeightedPoolToken>;
     private readonly MAX_IN_RATIO = 300000000000000000n; // 0.3
     private readonly MAX_OUT_RATIO = 300000000000000000n; // 0.3
 
     static fromRawPool(pool: RawWeightedPool): WeightedPool {
-        const poolTokens = pool.tokens.map(t => {
-            if (!t.weight) throw new Error('Weighted pool token does not have a weight');
+        const poolTokens: WeightedPoolToken[] = [];
+
+        for (const t of pool.tokens) {
+            if (!t.weight) {
+                throw new Error('Weighted pool token does not have a weight');
+            }
+
             const token = new Token(1, t.address, t.decimals, t.symbol, t.name);
             const tokenAmount = TokenAmount.fromHumanAmount(token, t.balance);
 
-            return new WeightedPoolToken(token, tokenAmount.amount, unsafeFastParseEther(t.weight));
-        });
-        const weightedPool = new WeightedPool(
+            poolTokens.push(
+                new WeightedPoolToken(
+                    token,
+                    tokenAmount.amount,
+                    unsafeFastParseEther(t.weight),
+                    t.index,
+                ),
+            );
+        }
+
+        return new WeightedPool(
             pool.id,
             pool.poolTypeVersion,
             unsafeFastParseEther(pool.swapFee),
             poolTokens,
         );
-        return weightedPool;
     }
 
     constructor(id: string, poolTypeVersion: number, swapFee: bigint, tokens: WeightedPoolToken[]) {
         this.id = id;
         this.poolTypeVersion = poolTypeVersion;
-        this.tokens = tokens;
         this.address = getPoolAddress(id);
         this.swapFee = swapFee;
+        this.tokens = tokens;
+        this.tokenMap = new Map(tokens.map(token => [token.token.address, token]));
     }
 
     public getNormalizedLiquidity(tokenIn: Token, tokenOut: Token): bigint {
-        const tIn = this.tokens.find(t => t.token.address === tokenIn.address);
-        const tOut = this.tokens.find(t => t.token.address === tokenOut.address);
+        const { tIn, tOut } = this.getRequiredTokenPair(tokenIn, tokenOut);
 
-        if (!tIn || !tOut) throw new Error('Pool does not contain the tokens provided');
         return (tIn.amount * tOut.weight) / (tIn.weight + tOut.weight);
     }
 
     public getLimitAmountSwap(tokenIn: Token, tokenOut: Token, swapKind: SwapKind): bigint {
-        const tIn = this.tokens.find(t => t.token.address === tokenIn.address);
-        const tOut = this.tokens.find(t => t.token.address === tokenOut.address);
-
-        if (!tIn || !tOut) throw new Error('Pool does not contain the tokens provided');
+        const { tIn, tOut } = this.getRequiredTokenPair(tokenIn, tokenOut);
 
         if (swapKind === SwapKind.GivenIn) {
             return (tIn.amount * this.MAX_IN_RATIO) / WAD;
@@ -71,12 +83,11 @@ export class WeightedPool implements BasePool {
     }
 
     public swapGivenIn(tokenIn: Token, tokenOut: Token, swapAmount: TokenAmount): TokenAmount {
-        const tIn = this.tokens.find(t => t.token.address === tokenIn.address);
-        const tOut = this.tokens.find(t => t.token.address === tokenOut.address);
+        const { tIn, tOut } = this.getRequiredTokenPair(tokenIn, tokenOut);
 
-        if (!tIn || !tOut) throw new Error('Pool does not contain the tokens provided');
-        if (swapAmount.amount > this.getLimitAmountSwap(tokenIn, tokenOut, SwapKind.GivenIn))
+        if (swapAmount.amount > this.getLimitAmountSwap(tokenIn, tokenOut, SwapKind.GivenIn)) {
             throw new Error('Swap amount exceeds the pool limit');
+        }
 
         const amountWithFee = this.subtractSwapFeeAmount(swapAmount);
 
@@ -89,18 +100,15 @@ export class WeightedPool implements BasePool {
             this.poolTypeVersion,
         );
 
-        const tokenOutAmount = TokenAmount.fromScale18Amount(tokenOut, tokenOutScale18);
-
-        return tokenOutAmount;
+        return TokenAmount.fromScale18Amount(tokenOut, tokenOutScale18);
     }
 
     public swapGivenOut(tokenIn: Token, tokenOut: Token, swapAmount: TokenAmount): TokenAmount {
-        const tIn = this.tokens.find(t => t.token.address === tokenIn.address);
-        const tOut = this.tokens.find(t => t.token.address === tokenOut.address);
+        const { tIn, tOut } = this.getRequiredTokenPair(tokenIn, tokenOut);
 
-        if (!tIn || !tOut) throw new Error('Pool does not contain the tokens provided');
-        if (swapAmount.amount > this.getLimitAmountSwap(tokenIn, tokenOut, SwapKind.GivenOut))
+        if (swapAmount.amount > this.getLimitAmountSwap(tokenIn, tokenOut, SwapKind.GivenOut)) {
             throw new Error('Swap amount exceeds the pool limit');
+        }
 
         const tokenInScale18 = _calcInGivenOut(
             tIn.scale18,
@@ -112,9 +120,8 @@ export class WeightedPool implements BasePool {
         );
 
         const tokenInAmount = TokenAmount.fromScale18Amount(tokenIn, tokenInScale18, true);
-        const amountWithFee = this.addSwapFeeAmount(tokenInAmount);
 
-        return amountWithFee;
+        return this.addSwapFeeAmount(tokenInAmount);
     }
 
     public subtractSwapFeeAmount(amount: TokenAmount): TokenAmount {
@@ -124,5 +131,19 @@ export class WeightedPool implements BasePool {
 
     public addSwapFeeAmount(amount: TokenAmount): TokenAmount {
         return amount.divUpFixed(MathSol.complementFixed(this.swapFee));
+    }
+
+    private getRequiredTokenPair(
+        tokenIn: Token,
+        tokenOut: Token,
+    ): { tIn: WeightedPoolToken; tOut: WeightedPoolToken } {
+        const tIn = this.tokenMap.get(tokenIn.address);
+        const tOut = this.tokenMap.get(tokenOut.address);
+
+        if (!tIn || !tOut) {
+            throw new Error('Pool does not contain the tokens provided');
+        }
+
+        return { tIn, tOut };
     }
 }

--- a/src/entities/tokenAmount.ts
+++ b/src/entities/tokenAmount.ts
@@ -1,7 +1,6 @@
 import { Token } from './token';
-import { parseUnits } from '@ethersproject/units';
 import _Decimal from 'decimal.js-light';
-import { WAD } from '../utils';
+import { unsafeFastParseUnits, WAD } from '../utils';
 import { HumanAmount } from '../types';
 
 export type BigintIsh = bigint | string | number;
@@ -18,7 +17,7 @@ export class TokenAmount {
     }
 
     public static fromHumanAmount(token: Token, humanAmount: HumanAmount) {
-        const rawAmount = parseUnits(humanAmount, token.decimals).toString();
+        const rawAmount = unsafeFastParseUnits(humanAmount, token.decimals);
         return new TokenAmount(token, rawAmount);
     }
 

--- a/src/utils/ether.ts
+++ b/src/utils/ether.ts
@@ -1,9 +1,13 @@
 export const unsafeFastParseEther = (value: string): bigint => {
+    return unsafeFastParseUnits(value, 18);
+};
+
+export const unsafeFastParseUnits = (value: string, decimals: number): bigint => {
     const parts = value.split('.');
     parts[0] = parts[0] || '';
     parts[1] = parts[1] || '';
 
-    const zerosToAdd = 18 - parts[1].length;
+    const zerosToAdd = decimals - parts[1].length;
     let etherValue = `${parts[0] !== '0' ? parts[0] : ''}${parts[1]}`;
 
     for (let i = 0; i < zerosToAdd; i++) {

--- a/src/utils/math.ts
+++ b/src/utils/math.ts
@@ -1,7 +1,10 @@
+import { unsafeFastParseEther } from './ether';
+
 export const WAD = 1000000000000000000n;
 export const RAY = 1000000000000000000000000000n;
 export const TWO_WAD = 2000000000000000000n;
 export const FOUR_WAD = 4000000000000000000n;
+export const ALMOST_ONE = unsafeFastParseEther('0.99');
 
 const _require = (b: boolean, message: string) => {
     if (!b) throw new Error(message);


### PR DESCRIPTION
Refactor pass to squeeze as many `ms` outta this thing as possible.

- Add `unsafeFastParseUnits`, removing `parseUnits` call in `TokenAmount.fromHumanAmount`, pretty significant reduction in pool parsing time, seeing consistent times under `10ms` now, from `20ms+`.
- Refactor the pool entities, removing `array.find` and `array.findIndex` calls, preferring the more performant `map.get`.
- Added stricter modifiers to pool entity props