### PR TITLE
add limits calc to swap entity

### DIFF
--- a/src/entities/percent.ts
+++ b/src/entities/percent.ts
@@ -1,0 +1,40 @@
+import _Decimal from 'decimal.js-light';
+import { formatEther, parseEther } from '@ethersproject/units';
+import { HumanAmount } from '../types';
+
+export type BigintIsh = bigint | string | number;
+
+export class Percent {
+    public value: bigint;
+
+    public static fromHumanPercent(percent: HumanAmount) {
+        const rawValue = parseEther(new _Decimal(percent).div(100).toString()).toString();
+        return new Percent(rawValue);
+    }
+
+    public static fromHumanDecimal(decimal: HumanAmount) {
+        const rawValue = parseEther(decimal).toString();
+        return new Percent(rawValue);
+    }
+
+    public static fromRawValue(rawValue: BigintIsh) {
+        return new Percent(rawValue);
+    }
+
+    protected constructor(value: BigintIsh) {
+        this.value = BigInt(value);
+    }
+
+    public toPercentSignificant(significantDigits: number = 6): string {
+        return new _Decimal(formatEther(this.value))
+            .times(100)
+            .toSignificantDigits(significantDigits)
+            .toString();
+    }
+
+    public toDecimalSignificant(significantDigits: number = 6): string {
+        return new _Decimal(formatEther(this.value))
+            .toSignificantDigits(significantDigits)
+            .toString();
+    }
+}

--- a/src/entities/tokenAmount.ts
+++ b/src/entities/tokenAmount.ts
@@ -1,6 +1,7 @@
 import { Token } from './token';
 import _Decimal from 'decimal.js-light';
-import { unsafeFastParseUnits, WAD } from '../utils';
+import { parseUnits } from '@ethersproject/units';
+import { WAD } from '../utils';
 import { HumanAmount } from '../types';
 
 export type BigintIsh = bigint | string | number;
@@ -17,7 +18,7 @@ export class TokenAmount {
     }
 
     public static fromHumanAmount(token: Token, humanAmount: HumanAmount) {
-        const rawAmount = unsafeFastParseUnits(humanAmount, token.decimals);
+        const rawAmount = parseUnits(humanAmount, token.decimals).toString();
         return new TokenAmount(token, rawAmount);
     }
 


### PR DESCRIPTION
I also removed the `unsafeFastParseUnits` from the `TokenAmount` entity. Think it's fine to make the assumption for parsing subgraph pools, but probably not great to include here in such a low level class.