### PR TITLE
Expose data types, allow for importing of RawPool, etc.

### DIFF
--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -1,2 +1,3 @@
 export * from './enrichers/onChainPoolDataEnricher';
 export * from './providers/subgraphPoolProvider';
+export * from './types';


### PR DESCRIPTION
The scaffold project imports `RawPool` and other types from data/types.ts, add it to the export so i can import it from the top level normally.