### PR TITLE
Remove the while loop from getCandidatePaths

### DIFF
--- a/src/pathGraph/pathGraphTypes.ts
+++ b/src/pathGraph/pathGraphTypes.ts
@@ -30,7 +30,6 @@ export interface PathGraphTraversalConfig {
     maxNonBoostedPathDepth: number;
     maxNonBoostedHopTokensInBoostedPath: number;
     approxPathsToReturn: number;
-    pathSearchTimeoutMs: number;
     poolIdsToInclude?: string[];
 }
 


### PR DESCRIPTION
The while loop being present here is a left over of the previous implementation that's no longer relevant. I somehow forgot to remove it when refactoring.

For instances where there were less paths available than `approxPathsToReturn`, it was forever looping, which is where the timeout came into play. By removing the while loop entirely the timeout is no longer needed as the amount of loops is deterministic based on `maxPathsPerTokenPair` and should resolve very quickly.