### PR TITLE
Re-export of viem types causing build errors in consuming project

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,9 @@
 import { BigintIsh, Token, BasePool, BasePoolFactory } from './entities';
 import { PoolDataEnricher, PoolDataProvider } from './data/types';
 import { PathGraphTraversalConfig } from './pathGraph/pathGraphTypes';
-import { Address, Hex } from 'viem';
 
-export { Address, Hex };
+export type Address = `0x${string}`;
+export type Hex = `0x${string}`;
 
 export type SwapInputRawAmount = BigintIsh;
 


### PR DESCRIPTION
Not entirely sure why, but when trying to build a next project using `b-sdk`, I get errors because of the re-export of types from viem. The types are straightforward, so figure just redefining them is also fine. This ok for you?

<img width="1139" alt="Screenshot 2023-05-19 at 13 43 56" src="https://github.com/balancer/b-sdk/assets/91405705/622ce75d-7bb2-4bb5-bf84-5aa92f3204d8">
<img width="1143" alt="Screenshot 2023-05-19 at 13 43 43" src="https://github.com/balancer/b-sdk/assets/91405705/161a1de6-4189-4f04-a2f4-1d7bbfbb8278">
