### PR TITLE
[WIP] Global pool models

### DIFF
--- a/src/schema/pool-join-exit.service.ts
+++ b/src/schema/pool-join-exit.service.ts
@@ -1,0 +1,77 @@
+import { Address, BalancerBasePool, BalancerPoolType } from "./pool-schema";
+import { Token } from "../entities";
+import {
+  BalancerJoinBptOutAndPriceImpactForTokensInOutput,
+  PoolJoinContractCallData,
+  PoolJoinData,
+  PoolService,
+} from "./service-schema";
+
+//TODO: should we pass in the class instances here or is an object easier to manage?
+interface TokenAmount {
+  address: Address;
+  amount: BigInt;
+  decimals: number; //TODO: is this needed?
+}
+
+// the below is simply a reference impl. There is likely to be some shared logic
+// that can be lifted into the BalancerPoolJoinExitService so that the individual PoolService's
+// are as minimal as possible
+export class BalancerPoolJoinExitService {
+  constructor(private readonly services: PoolService[]) {}
+
+  // given an array of token balances, determine the max proportional investable amount
+  public async getMaxProportionalForUserBalances(
+    pool: BalancerBasePool,
+    userInvestTokenBalances: TokenAmount[]
+  ): Promise<TokenAmount[]> {
+    const service = this.getServiceForPool(pool);
+
+    return service.getMaxProportionalForUserBalances(
+      pool,
+      userInvestTokenBalances
+    );
+  }
+
+  public async getProportionalSuggestionForFixedAmount(
+    pool: BalancerBasePool,
+    fixedAmount: TokenAmount,
+    tokensIn: Token[]
+  ): Promise<TokenAmount[]> {
+    const service = this.getServiceForPool(pool);
+
+    return service.getProportionalSuggestionForFixedAmount(
+      pool,
+      fixedAmount,
+      tokensIn
+    );
+  }
+
+  public async getBptOutAndPriceImpactForTokensIn(
+    pool: BalancerBasePool,
+    tokenAmountsIn: TokenAmount[]
+  ): Promise<BalancerJoinBptOutAndPriceImpactForTokensInOutput> {
+    const service = this.getServiceForPool(pool);
+
+    return service.getBptOutAndPriceImpactForTokensIn(pool, tokenAmountsIn);
+  }
+
+  public async getContractCallData(
+    pool: BalancerBasePool,
+    data: PoolJoinData
+  ): Promise<PoolJoinContractCallData> {
+    const service = this.getServiceForPool(pool);
+
+    return service.getContractCallData(pool, data);
+  }
+
+  private getServiceForPool(pool: BalancerBasePool): PoolService {
+    for (const service of this.services) {
+      if (service.supportsPool(pool)) {
+        return service;
+      }
+    }
+
+    throw new Error("Unsupported pool");
+  }
+}

--- a/src/schema/pool-schema.ts
+++ b/src/schema/pool-schema.ts
@@ -1,0 +1,231 @@
+// Typescript typing is more flexible than graphql, some models are more verbose than needed
+// to ensure compatability with graphql schema limitations
+
+type ID = string;
+type Address = string;
+type Integer = number;
+type Decimal = string;
+
+enum BalancerNetwork {
+  MAINNET = "1",
+  ARBITRUM = "42161",
+  POLYGON = "137",
+}
+
+enum BalancerPoolType {
+  ComposableStablePool = "ComposableStablePool",
+  WeightedPool = "WeightedPool",
+  LinearPool = "LinearPool",
+  LiquidityBootstrappingPool = "LiquidityBootstrappingPool",
+}
+
+enum BalancerVaultVersion {
+  TWO = "TWO",
+}
+
+enum BalancerPoolOwnerType {
+  DAO = "DAO",
+  ZERO_ADDRESS = "ZERO_ADDRESS",
+  EXTERNAL = "EXTERNAL",
+}
+
+enum BalancerJoinType {
+  PROPORTIONAL = "PROPORTIONAL",
+  SINGLE_ASSET = "SINGLE_ASSET",
+  ANY_TOKENS = "ANY_TOKENS",
+}
+
+enum BalancerWithdrawType {
+  PROPORTIONAL = "PROPORTIONAL",
+  SINGLE_ASSET = "SINGLE_ASSET",
+  ANY_TOKENS = "ANY_TOKENS",
+}
+
+enum BalancerPoolTokenType {
+  // this type would need to be built in a way that there is no overlaps,
+  // ie: a token cannot have more than one type. Could be a better name than "type"
+  STABLE_BPT = "STABLE_BPT",
+  LINEAR_BPT = "LINEAR_BPT",
+  WETH = "WETH",
+  STANDARD = "STANDARD", // could be a better name here, a token that is not a nested bpt
+}
+
+interface BalancerPool {
+  id: ID; // ID will become address in v2.1/3, but still needed for backwards compatability
+  address: Address;
+  chain: BalancerNetwork;
+  vault: Address;
+  vaultVersion: BalancerVaultVersion;
+  poolType: BalancerPoolType;
+  poolTypeVersion: number;
+  name: string;
+  symbol: string;
+  decimals: number;
+  owner: BalancerPoolOwnerType;
+  ownerAddress: Address;
+  factory?: Address;
+  createTime: number;
+  joinConfig: BalancerPoolJoinConfig;
+  exitConfig: any; //TODO: similar to join, but for exit
+
+  totalShares: BigInt;
+  holdersCount: BigInt;
+  swapsCount: BigInt;
+  swapFee: BigInt;
+  swapsEnabled: boolean;
+  inRecoveryMode: boolean;
+
+  usdData: BalancerPoolDataUSD;
+  apr: BalancerPoolApr;
+
+  // tokens
+  tokens: BalancerPoolToken[];
+}
+
+interface BalancerPoolToken {
+  address: String;
+  balance: BigInt;
+  decimals: Integer;
+  name: string;
+  symbol: string;
+  index: Integer;
+  totalBalance: BigInt; //the total balance in the pool, regardless of nesting
+
+  // identifies the token as WETH, nested stable BPT, nested linear BPT or "standard"
+  type: BalancerPoolTokenType;
+}
+
+interface BalancerWeightedPoolToken extends BalancerPoolToken {
+  weight: BigInt;
+}
+
+interface BalancerStablePoolToken extends BalancerPoolToken {
+  priceRate: BigInt;
+}
+
+// USD data is data that changes at a high frequency and needs to be refetched often
+interface BalancerPoolDataUSD {
+  id: ID;
+  poolId: ID;
+
+  totalLiquidityUSD: Decimal;
+  volume24hUSD: Decimal;
+  swapFees24hUSD: Decimal;
+  yieldCapture24hUSD: Decimal;
+
+  totalShares24hAgo: BigInt;
+  totalLiquidityUSD24hAgo: Decimal;
+  volume48hUSD: Decimal;
+  swapFees48hUSD: Decimal;
+  yieldCapture48hUSD: Decimal;
+}
+
+interface BalancerPoolJoinConfig {
+  supportedTypes: BalancerJoinType[];
+
+  poolTokenConfigs: {
+    poolTokenIndex: number;
+    poolTokenAddress: Address;
+    // Leaf tokens are tokens that represent the last node in the graph. These are most often the
+    // "normal" tokens that users hold in their wallet ie: USDC/USDT/DAI instead of bbausd
+    // We consider the main token of a linear pool the leaf token.
+    leafTokens: Address[];
+    nestedStructure: (
+      | BalancerPoolNodeStableBpt
+      | BalancerPoolNodeLinearBpt
+      | BalancerPoolNodeStandardToken
+    )[];
+  }[];
+
+  // the ui doesn't use proportional joins, it uses EXACT_TOKENS_IN_FOR_BPT_OUT to allow the
+  // user to configure any amount for each pool token, but additionally provides a proportional estimation.
+  // This concept could maybe use a better name.
+  // Since it's possible not all tokens are being used for a given join, this path is not always the
+  // "most efficient" for a given combination of tokens, but for the sake of limiting the scope, we
+  // provide a "generic" path that works for any given combination.
+  steps: BalancerPoolJoinStep[];
+}
+
+interface BalancerPoolGraphBaseToken {
+  address: Address;
+}
+
+interface BalancerPoolNodeStandardToken extends BalancerPoolGraphBaseToken {
+  __typename: "BalancerPoolNodeStandardToken";
+}
+
+interface BalancerPoolNodeLinearBpt extends BalancerPoolGraphBaseToken {
+  __typename: "BalancerPoolNodeLinearBpt";
+  poolId: ID;
+  //TODO: may be better to use an array of children here, would see on implementation if this is too verbose
+  mainToken: BalancerPoolNodeStandardToken;
+  wrappedToken: BalancerPoolNodeStandardToken;
+}
+
+interface BalancerPoolNodeStableBpt extends BalancerPoolGraphBaseToken {
+  __typename: "BalancerPoolNodeStableBpt";
+  poolId: ID;
+  children: (BalancerPoolNodeStandardToken | BalancerPoolNodeLinearBpt)[];
+}
+
+export type BalancerPoolJoinStep =
+  | BalancerPoolJoinBatchSwapStep
+  | PoolJoinMintBptStep;
+
+// Currently, there should only ever be one batchSwap step that swaps any linear main tokens for the
+// corresponding linear phantom BPT
+export interface BalancerPoolJoinBatchSwapStep {
+  __typename: "BalancerPoolJoinBatchSwapStep";
+  swaps: {
+    poolId: ID;
+    tokenIn: Address;
+    tokenOut: Address;
+  }[];
+  tokensIn: Address[];
+  tokensOut: Address[];
+}
+
+// The mint BPT step is a standard join step. At least one mint step will always occur on the pool itself.
+// Additionally, a second mint step will be present if there is a nested stable BPT in the pool.
+export interface PoolJoinMintBptStep {
+  __typename: "PoolJoinMintBptStep";
+  poolId: ID;
+  tokensIn: Address[];
+}
+
+interface BalancerPoolApr {
+  apr: BalancerPoolAprValue;
+  swapApr: Decimal; // we make the assumption swap apr will never have a range
+  nativeRewardApr: BalancerPoolAprValue;
+  thirdPartyApr: BalancerPoolAprValue;
+  items: BalancerPoolAprItem[];
+  hasRewardApr: boolean;
+}
+
+// All APR values are represented as the union of a range or a total. While range is only supported on BAL emissions
+// we model it in such a way to allow for a generic ui implementation.
+type BalancerPoolAprValue = BalancerPoolAprRange | BalancerPoolAprTotal;
+
+interface BalancerPoolAprRange {
+  __typename: "BalancerPoolAprRange";
+  min: Decimal;
+  max: Decimal;
+}
+
+interface BalancerPoolAprTotal {
+  __typename: "BalancerPoolAprTotal";
+  total: Decimal;
+}
+
+interface BalancerPoolAprItem {
+  id: ID;
+  title: string;
+  apr: BalancerPoolAprValue;
+  subItems: BalancerPoolAprSubItem[];
+}
+
+interface BalancerPoolAprSubItem {
+  id: ID;
+  title: string;
+  apr: BalancerPoolAprValue;
+}

--- a/src/schema/pool-schema.ts
+++ b/src/schema/pool-schema.ts
@@ -1,10 +1,10 @@
 // Typescript typing is more flexible than graphql, some models are more verbose than needed
 // to ensure compatability with graphql schema limitations
 
-type ID = string;
-type Address = string;
-type Integer = number;
-type Decimal = string;
+export type ID = string;
+export type Address = string;
+export type Integer = number;
+export type Decimal = string;
 
 enum BalancerNetwork {
   MAINNET = "1",
@@ -12,7 +12,7 @@ enum BalancerNetwork {
   POLYGON = "137",
 }
 
-enum BalancerPoolType {
+export enum BalancerPoolType {
   StablePool = "StablePool",
   MetaStablePool = "MetaStablePool",
   ComposableStablePool = "ComposableStablePool",
@@ -53,7 +53,7 @@ enum BalancerPoolTokenType {
   STANDARD = "STANDARD", // could be a better name here, a token that is not a nested bpt
 }
 
-interface BalancerBasePool {
+export interface BalancerBasePool {
   id: ID;
   address: Address;
   chain: BalancerNetwork;

--- a/src/schema/pool-schema.ts
+++ b/src/schema/pool-schema.ts
@@ -67,7 +67,7 @@ interface BalancerPool {
   createTime: number;
   // TODO: can we model to facilitate price impact calculations?
   joinConfig: BalancerPoolJoinConfig;
-  exitConfig: BalancerPoolTokenExitConfig;
+  exitConfig: BalancerPoolExitConfig;
 
   totalShares: BigInt;
   holdersCount: BigInt;
@@ -252,7 +252,7 @@ interface BalancerPoolExitConfig {
   supportedTypes: BalancerPoolExitType[];
 
   // configs for each pool token
-  poolTokenConfigs: BalancerPoolTokenJoinConfig[];
+  poolTokenConfigs: BalancerPoolTokenExitConfig[];
 
   proportionalSteps: BalancerPoolExitStep[];
 

--- a/src/schema/pool-schema.ts
+++ b/src/schema/pool-schema.ts
@@ -29,7 +29,7 @@ enum BalancerPoolOwnerType {
   EXTERNAL = "EXTERNAL",
 }
 
-enum BalancerJoinType {
+enum BalancerPoolJoinType {
   PROPORTIONAL = "PROPORTIONAL",
   SINGLE_ASSET = "SINGLE_ASSET",
   ANY_TOKENS = "ANY_TOKENS",
@@ -121,56 +121,85 @@ interface BalancerPoolDataUSD {
 }
 
 interface BalancerPoolJoinConfig {
-  supportedTypes: BalancerJoinType[];
+  supportedTypes: BalancerPoolJoinType[];
 
-  poolTokenConfigs: {
-    poolTokenIndex: number;
-    poolTokenAddress: Address;
-    // Leaf tokens are tokens that represent the last node in the graph. These are most often the
-    // "normal" tokens that users hold in their wallet ie: USDC/USDT/DAI instead of bbausd
-    // We consider the main token of a linear pool the leaf token.
-    leafTokens: Address[];
-    nestedStructure: (
-      | BalancerPoolNodeStableBpt
-      | BalancerPoolNodeLinearBpt
-      | BalancerPoolNodeStandardToken
-    )[];
-  }[];
+  // configs for each pool token
+  poolTokenConfigs: BalancerPoolTokenJoinConfig[];
 
   // the ui doesn't use proportional joins, it uses EXACT_TOKENS_IN_FOR_BPT_OUT to allow the
-  // user to configure any amount for each pool token, but additionally provides a proportional estimation.
-  // This concept could maybe use a better name.
+  // user to configure any amount for each pool token, this concept could maybe use a better name.
+  // Additionally, the ui provides a proportional estimation when applicable.
+  //
   // Since it's possible not all tokens are being used for a given join, this path is not always the
   // "most efficient" for a given combination of tokens, but for the sake of limiting the scope, we
   // provide a "generic" path that works for any given combination.
   steps: BalancerPoolJoinStep[];
+
+  // Leaf tokens are tokens that represent the last node in the tree. These are most often the
+  // "normal" tokens that users hold in their wallet ie: USDC/USDT/DAI instead of bbausd
+  // We consider the main token of a linear pool the leaf token.
+  leafTokens: Address[];
 }
 
-interface BalancerPoolGraphBaseToken {
+interface BalancerPoolTokenJoinConfig {
+  poolTokenIndex: number;
+  poolTokenAddress: Address;
+  // To scope this, we support the following options:
+  // - Standard token (the pool token is not a nested bpt)
+  // - Linear pool main token (the pool token is a nested linear bpt)
+  // - Stable BPT (the pool token is a nested stable bpt)
+  // - Leaf tokens of a nested stable BPT (the pool token is a nested stable bpt)
+  options: BalancerPoolTokenJoinConfigOptions[];
+}
+
+type BalancerPoolTokenJoinConfigOptions =
+  | BalancerPoolTokenConfigStandardToken
+  | BalancerPoolTokenConfigLinearMainToken
+  | BalancerPoolTokenConfigStableBpt
+  | BalancerPoolTokenConfigStableBptLeafTokens;
+
+interface BalancerPoolConfigBaseToken {
   address: Address;
 }
 
-interface BalancerPoolNodeStandardToken extends BalancerPoolGraphBaseToken {
-  __typename: "BalancerPoolNodeStandardToken";
+interface BalancerPoolTokenConfigStandardToken
+  extends BalancerPoolConfigBaseToken {
+  __typename: "BalancerPoolTokenConfigStandardToken";
 }
 
-interface BalancerPoolNodeLinearBpt extends BalancerPoolGraphBaseToken {
-  __typename: "BalancerPoolNodeLinearBpt";
+interface BalancerPoolConfigLinearBpt extends BalancerPoolConfigBaseToken {
+  __typename: "BalancerPoolConfigLinearBpt";
   poolId: ID;
-  //TODO: may be better to use an array of children here, would see on implementation if this is too verbose
-  mainToken: BalancerPoolNodeStandardToken;
-  wrappedToken: BalancerPoolNodeStandardToken;
 }
 
-interface BalancerPoolNodeStableBpt extends BalancerPoolGraphBaseToken {
-  __typename: "BalancerPoolNodeStableBpt";
+interface BalancerPoolTokenConfigLinearMainToken
+  extends BalancerPoolConfigBaseToken {
+  __typename: "BalancerPoolTokenConfigLinearMainToken";
   poolId: ID;
-  children: (BalancerPoolNodeStandardToken | BalancerPoolNodeLinearBpt)[];
+}
+
+interface BalancerPoolConfigLinearWrappedToken
+  extends BalancerPoolConfigBaseToken {
+  __typename: "BalancerPoolConfigLinearWrappedToken";
+  poolId: ID;
+}
+
+interface BalancerPoolTokenConfigStableBpt extends BalancerPoolConfigBaseToken {
+  __typename: "BalancerPoolConfigStableBpt";
+  poolId: ID;
+}
+
+interface BalancerPoolTokenConfigStableBptLeafTokens
+  extends BalancerPoolConfigBaseToken {
+  __typename: "BalancerPoolTokenConfigStableBptLeafTokens";
+  poolId: ID;
+  // the leaf tokens of this stable bpt
+  leafTokens: Address[];
 }
 
 export type BalancerPoolJoinStep =
   | BalancerPoolJoinBatchSwapStep
-  | PoolJoinMintBptStep;
+  | BalancerPoolJoinMintBptStep;
 
 // Currently, there should only ever be one batchSwap step that swaps any linear main tokens for the
 // corresponding linear phantom BPT
@@ -187,8 +216,8 @@ export interface BalancerPoolJoinBatchSwapStep {
 
 // The mint BPT step is a standard join step. At least one mint step will always occur on the pool itself.
 // Additionally, a second mint step will be present if there is a nested stable BPT in the pool.
-export interface PoolJoinMintBptStep {
-  __typename: "PoolJoinMintBptStep";
+export interface BalancerPoolJoinMintBptStep {
+  __typename: "BalancerPoolJoinMintBptStep";
   poolId: ID;
   tokensIn: Address[];
 }

--- a/src/schema/service-schema.ts
+++ b/src/schema/service-schema.ts
@@ -1,0 +1,105 @@
+import { Token } from "../entities";
+import { Address, BalancerBasePool, Decimal } from "./pool-schema";
+import { BatchSwapStep, SwapKind } from "../types";
+
+//TODO: should we pass in the class instances here or is an object easier to maange?
+interface TokenAmount {
+  address: Address;
+  amount: BigInt;
+  decimals: number; //TODO: is this needed?
+}
+
+export interface PoolService {
+  supportsPool(pool: BalancerBasePool): boolean;
+  supportsProportional(pool: BalancerBasePool): boolean;
+
+  // given an array of token balances, determine the max proportional investable amount
+  getMaxProportionalForUserBalances(
+    pool: BalancerBasePool,
+    userInvestTokenBalances: TokenAmount[]
+  ): Promise<TokenAmount[]>;
+
+  getProportionalSuggestionForFixedAmount(
+    pool: BalancerBasePool,
+    fixedAmount: TokenAmount,
+    tokensIn: Token[]
+  ): Promise<TokenAmount[]>;
+
+  getBptOutAndPriceImpactForTokensIn(
+    pool: BalancerBasePool,
+    tokenAmountsIn: TokenAmount[]
+  ): Promise<BalancerJoinBptOutAndPriceImpactForTokensInOutput>;
+
+  getContractCallData(
+    pool: BalancerBasePool,
+    data: PoolJoinData
+  ): Promise<PoolJoinContractCallData>;
+}
+
+export type PoolJoinData =
+  | PoolJoinInit
+  | PoolJoinExactTokensInForBPTOut
+  | PoolJoinTokenInForExactBPTOut
+  | PoolJoinAllTokensInForExactBPTOut;
+
+interface PoolJoinBase {
+  maxAmountsIn: TokenAmount[];
+  zapIntoMasterchefFarm?: boolean;
+  zapIntoGauge?: boolean;
+  userAddress: string;
+  wethIsEth: boolean;
+  slippage: string;
+}
+
+export interface PoolJoinInit extends PoolJoinBase {
+  kind: "Init";
+  tokenAmountsIn: TokenAmount[];
+}
+
+export interface PoolJoinExactTokensInForBPTOut extends PoolJoinBase {
+  kind: "ExactTokensInForBPTOut";
+  tokenAmountsIn: TokenAmount[];
+  minimumBpt: BigInt;
+}
+
+export interface PoolJoinTokenInForExactBPTOut extends PoolJoinBase {
+  kind: "TokenInForExactBPTOut";
+  tokenInAddress: string;
+  bptAmountOut: BigInt;
+}
+
+export interface PoolJoinAllTokensInForExactBPTOut extends PoolJoinBase {
+  kind: "AllTokensInForExactBPTOut";
+  bptAmountOut: BigInt;
+}
+
+export type PoolJoinContractCallData =
+  | PoolJoinPoolContractCallData
+  | PoolJoinBatchSwapContractCallData
+  | PoolJoinBatchRelayerContractCallData;
+
+export interface PoolJoinPoolContractCallData {
+  type: "JoinPool";
+  assets: string[];
+  maxAmountsIn: BigInt[];
+  userData: string;
+}
+
+export interface PoolJoinBatchSwapContractCallData {
+  type: "BatchSwap";
+  kind: SwapKind;
+  swaps: BatchSwapStep[];
+  assets: string[];
+  limits: BigInt[];
+}
+
+export interface PoolJoinBatchRelayerContractCallData {
+  type: "BatchRelayer";
+  calls: string[];
+  ethValue?: string;
+}
+
+export interface BalancerJoinBptOutAndPriceImpactForTokensInOutput {
+  minBptReceived: BigInt;
+  priceImpactPercent: Decimal;
+}


### PR DESCRIPTION
Don't merge this, would like to use this as a collaborative space for @johngrantuk @brunoguerios. 

I'd like us to strive for a global model to represent pools moving forward, a model that should be leveraged across the entire stack. The introduction of the API allows us to define a more flexible model than is available via the subgraph alone.

Key areas of focus:
- The data model should facilitates “stupid” UIs 
  - So much of the code we end up writing is in transforming data from one form to another. It is error-prone and increases complexity. If we can front load more of this work in the API, it will allow consuming applications to be significantly lighter (simpler).
- BasePool model with extension for specific pool types rather than a single pool model with a ton of different optional fields
  - B-SDK: https://github.com/balancer/b-sdk/blob/main/src/data/types.ts#L18-L87
  - Beets API: https://github.com/beethovenxfi/beethovenx-backend/blob/v3-main/modules/pool/pool.gql
- The pool model itself should tell you what tokens you can use for invest/withdraw, as opposed to having to do a traversal of nested tokens.
  - Additionally, the pool model should itself say what tokens can be invested/withdrawn proportionally in a model that is easy to parse and traverse.
- In what format do we pass `numbers` when passing data between layers of the tech stack (API / frontend / SDK)? We decide on a standard and stick to it.
- Composable pool support - Id propose we enforce a maximum nesting of 2 levels (Composable/Weighted → Composable → Linear), anything deeper we don’t support.
- Future proof - in scenarios where key architecture components change, how do we model in such a way that it can be accommodated.