### PR TITLE
Add name property to pools subgraph query

### DIFF
--- a/src/data/providers/subgraphPoolProvider.ts
+++ b/src/data/providers/subgraphPoolProvider.ts
@@ -229,6 +229,7 @@ export class SubgraphPoolProvider implements PoolDataProvider {
                     address
                     poolType
                     poolTypeVersion
+                    name
                     tokens {
                         address
                         balance

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -28,6 +28,7 @@ export type RawPool =
 export interface RawBasePool {
     id: Hex;
     address: Address;
+    name: string;
     poolType: SupportedRawPoolTypes | string;
     poolTypeVersion: number;
     swapFee: HumanAmount;


### PR DESCRIPTION
Pretty self explanatory, the subgraph query to retrieve pools was missing the `name` property.