### PR TITLE
Add token rates to pool enricher using multicall

### DIFF
--- a/src/abi/index.ts
+++ b/src/abi/index.ts
@@ -2,3 +2,4 @@ export * from './vault';
 export * from './balancerQueries';
 export * from './sorQueries';
 export * from './erc20';
+export * from './tokenRates';

--- a/src/abi/tokenRates.ts
+++ b/src/abi/tokenRates.ts
@@ -1,0 +1,20 @@
+export const tokenRatesFragmentAbi = [
+    {
+        inputs: [],
+        name: 'getTokenRates',
+        outputs: [
+            {
+                internalType: 'uint256',
+                name: 'rate0',
+                type: 'uint256',
+            },
+            {
+                internalType: 'uint256',
+                name: 'rate1',
+                type: 'uint256',
+            },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+    },
+] as const;

--- a/src/data/enrichers/onChainPoolDataEnricher.ts
+++ b/src/data/enrichers/onChainPoolDataEnricher.ts
@@ -169,6 +169,7 @@ export class OnChainPoolDataEnricher implements PoolDataEnricher {
                     address: a,
                     ...call,
                 })),
+                blockNumber: options.block,
             });
             tokenRates = results.map((r) => r.result);
         }

--- a/src/data/enrichers/onChainPoolDataEnricher.ts
+++ b/src/data/enrichers/onChainPoolDataEnricher.ts
@@ -1,5 +1,4 @@
 import { Address, createPublicClient, formatUnits, Hex, http } from 'viem';
-import { polygon } from 'viem/chains';
 import { sorQueriesAbi, tokenRatesFragmentAbi } from '../../abi/';
 import {
     GetPoolsResponse,
@@ -10,6 +9,7 @@ import {
 } from '../types';
 
 import {
+    CHAINS,
     getPoolAddress,
     poolHasActualSupply,
     poolHasPercentFee,
@@ -71,6 +71,7 @@ export class OnChainPoolDataEnricher implements PoolDataEnricher {
     private readonly config: OnChainPoolDataQueryConfig;
 
     constructor(
+        private readonly chainId: number,
         private readonly rpcUrl: string,
         private readonly sorQueriesAddress: Address,
         config?: Partial<OnChainPoolDataQueryConfig>,
@@ -111,8 +112,8 @@ export class OnChainPoolDataEnricher implements PoolDataEnricher {
         } = this.getPoolDataQueryParams(data);
 
         const client = createPublicClient({
-            chain: polygon, // TODO: get chain by id
             transport: http(this.rpcUrl),
+            chain: CHAINS[this.chainId],
         });
 
         const [

--- a/src/sor.ts
+++ b/src/sor.ts
@@ -36,7 +36,7 @@ export class SmartOrderRouter {
             new SubgraphPoolProvider(chainId, SUBGRAPH_URLS[chainId]);
         poolDataEnrichers =
             poolDataEnrichers ||
-            new OnChainPoolDataEnricher(rpcUrl, BALANCER_SOR_QUERIES_ADDRESS);
+            new OnChainPoolDataEnricher(chainId, rpcUrl, BALANCER_SOR_QUERIES_ADDRESS);
         this.poolDataService = new PoolDataService(
             Array.isArray(poolDataProviders)
                 ? poolDataProviders

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,5 +1,19 @@
-import { Address } from 'viem';
+import { Address, Chain } from 'viem';
 import { Token } from '../entities/token';
+import {
+    arbitrum,
+    avalanche,
+    baseGoerli,
+    bsc,
+    gnosis,
+    goerli,
+    mainnet,
+    optimism,
+    polygon,
+    polygonZkEvm,
+    zkSync,
+    zkSyncTestnet,
+} from 'viem/chains';
 
 export const ZERO_ADDRESS: Address =
     '0x0000000000000000000000000000000000000000';
@@ -47,6 +61,21 @@ export enum ChainId {
     AVALANCHE = 43114,
     BASE_GOERLI = 84531,
 }
+
+export const CHAINS: Record<number, Chain> = {
+    [ChainId.MAINNET]: mainnet,
+    [ChainId.GOERLI]: goerli,
+    [ChainId.OPTIMISM]: optimism,
+    [ChainId.BSC]: bsc,
+    [ChainId.GNOSIS_CHAIN]: gnosis,
+    [ChainId.POLYGON]: polygon,
+    [ChainId.ZKSYNC_TESTNET]: zkSyncTestnet,
+    [ChainId.ZKSYNC]: zkSync,
+    [ChainId.ZKEVM]: polygonZkEvm,
+    [ChainId.ARBITRUM_ONE]: arbitrum,
+    [ChainId.AVALANCHE]: avalanche,
+    [ChainId.BASE_GOERLI]: baseGoerli,
+};
 
 export const SUBGRAPH_URLS = {
     [ChainId.MAINNET]:

--- a/test/gyroEV2Pool.integration.test.ts
+++ b/test/gyroEV2Pool.integration.test.ts
@@ -65,6 +65,7 @@ describe('gyroEV2: WMATIC-stMATIC integration tests', () => {
             },
         );
         const onChainPoolDataEnricher = new OnChainPoolDataEnricher(
+            chainId,
             rpcUrl,
             SOR_QUERIES,
             {

--- a/test/gyroEV2Pool.integration.test.ts
+++ b/test/gyroEV2Pool.integration.test.ts
@@ -2,25 +2,25 @@
 import dotenv from 'dotenv';
 dotenv.config();
 
-import testPools from './lib/testData/gyroETestPool.json';
-import { expectToBeCloseToDelta } from './lib/utils/helpers';
 import { ChainId } from '../src/utils';
-import { RawGyroEPool } from '../src/data/types';
 import {
     BasePool,
+    OnChainPoolDataEnricher,
+    SmartOrderRouter,
+    SubgraphPoolProvider,
     SwapKind,
     SwapOptions,
     Token,
     sorGetSwapsWithPools,
-    sorParseRawPools,
 } from '../src';
 import { parseEther } from 'viem';
 import { GyroEPool, GyroEPoolToken } from '../src/entities/pools/gyroE';
 
+const SOR_QUERIES = '0x1814a3b3e4362caf4eb54cd85b82d39bd7b34e41';
+
 describe('gyroEV2: WMATIC-stMATIC integration tests', () => {
     const chainId = ChainId.POLYGON;
     const rpcUrl = process.env['POLYGON_RPC_URL'] || '';
-    const rawPool = { ...testPools }.pools[2] as RawGyroEPool;
     const WMATIC = new Token(
         chainId,
         '0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270',
@@ -34,12 +34,58 @@ describe('gyroEV2: WMATIC-stMATIC integration tests', () => {
         'stMATIC',
     );
     const swapOptions: SwapOptions = {
-        block: 42173266n,
+        block: 44215395n,
     };
+    let sor: SmartOrderRouter;
+
+    beforeAll(() => {
+        const subgraphPoolDataService = new SubgraphPoolProvider(
+            chainId,
+            undefined,
+            {
+                poolIdIn: [
+                    '0xf0ad209e2e969eaaa8c882aac71f02d8a047d5c2000200000000000000000b49',
+                ],
+                gqlAdditionalPoolQueryFields: `
+                alpha
+                beta
+                c
+                s
+                lambda
+                tauAlphaX
+                tauAlphaY
+                tauBetaX
+                tauBetaY
+                u
+                v
+                w
+                z
+                dSq
+                `,
+            },
+        );
+        const onChainPoolDataEnricher = new OnChainPoolDataEnricher(
+            rpcUrl,
+            SOR_QUERIES,
+            {
+                loadTokenRatesForPools: {
+                    poolTypes: ['GyroE'],
+                    poolTypeVersions: [2],
+                },
+            },
+        );
+
+        sor = new SmartOrderRouter({
+            chainId,
+            poolDataProviders: subgraphPoolDataService,
+            poolDataEnrichers: onChainPoolDataEnricher,
+            rpcUrl: rpcUrl,
+        });
+    });
 
     let pools: BasePool[];
-    beforeEach(() => {
-        pools = sorParseRawPools(chainId, [rawPool]);
+    beforeEach(async () => {
+        pools = await sor.fetchAndCachePools(swapOptions.block);
     });
 
     describe('ExactIn', () => {
@@ -47,7 +93,7 @@ describe('gyroEV2: WMATIC-stMATIC integration tests', () => {
         test('should return no swaps when above limit', async () => {
             const tokenIn = WMATIC;
             const tokenOut = stMATIC;
-            const swapAmount = parseEther('33.33333333333333');
+            const swapAmount = parseEther('11206540');
             const swapInfo = await sorGetSwapsWithPools(
                 tokenIn,
                 tokenOut,
@@ -62,7 +108,7 @@ describe('gyroEV2: WMATIC-stMATIC integration tests', () => {
         test('token > LSD, getSwaps result should match queryBatchSwap', async () => {
             const tokenIn = WMATIC;
             const tokenOut = stMATIC;
-            const gyroPool = GyroEPool.fromRawPool(chainId, rawPool);
+            const gyroPool = pools[0] as GyroEPool;
             const { tIn } = gyroPool.getRequiredTokenPair(tokenIn, tokenOut);
             const swapAmount = new GyroEPoolToken(
                 tokenIn,
@@ -86,7 +132,7 @@ describe('gyroEV2: WMATIC-stMATIC integration tests', () => {
         test('LSD > token, getSwaps result should match queryBatchSwap', async () => {
             const tokenIn = stMATIC;
             const tokenOut = WMATIC;
-            const gyroPool = GyroEPool.fromRawPool(chainId, rawPool);
+            const gyroPool = pools[0] as GyroEPool;
             const { tIn } = gyroPool.getRequiredTokenPair(tokenIn, tokenOut);
             const swapAmount = new GyroEPoolToken(
                 tokenIn,
@@ -115,7 +161,7 @@ describe('gyroEV2: WMATIC-stMATIC integration tests', () => {
         test('should return no swaps when above limit', async () => {
             const tokenIn = WMATIC;
             const tokenOut = stMATIC;
-            const swapAmount = parseEther('100');
+            const swapAmount = parseEther('303106');
             const swapInfo = await sorGetSwapsWithPools(
                 tokenIn,
                 tokenOut,
@@ -130,7 +176,7 @@ describe('gyroEV2: WMATIC-stMATIC integration tests', () => {
         test('token > LSD, getSwaps result should match queryBatchSwap', async () => {
             const tokenIn = WMATIC;
             const tokenOut = stMATIC;
-            const gyroPool = GyroEPool.fromRawPool(chainId, rawPool);
+            const gyroPool = pools[0] as GyroEPool;
             const { tOut } = gyroPool.getRequiredTokenPair(tokenIn, tokenOut);
             const swapAmount = new GyroEPoolToken(
                 tokenOut,
@@ -154,7 +200,7 @@ describe('gyroEV2: WMATIC-stMATIC integration tests', () => {
         test('LSD > token, getSwaps result should match queryBatchSwap', async () => {
             const tokenIn = stMATIC;
             const tokenOut = WMATIC;
-            const gyroPool = GyroEPool.fromRawPool(chainId, rawPool);
+            const gyroPool = pools[0] as GyroEPool;
             const { tOut } = gyroPool.getRequiredTokenPair(tokenIn, tokenOut);
             const swapAmount = new GyroEPoolToken(
                 tokenOut,
@@ -173,11 +219,7 @@ describe('gyroEV2: WMATIC-stMATIC integration tests', () => {
 
             const onchain = await swapInfo?.query(rpcUrl, swapOptions.block);
             expect(swapAmount.amount).toEqual(swapInfo?.outputAmount.amount);
-            expectToBeCloseToDelta(
-                onchain?.amount as bigint,
-                swapInfo?.inputAmount.amount as bigint,
-                1,
-            );
+            expect(onchain).toEqual(swapInfo?.inputAmount);
         });
     });
 });

--- a/test/lib/testData/gyroETestPool.json
+++ b/test/lib/testData/gyroETestPool.json
@@ -123,26 +123,24 @@
             "name": "Gyroscope ECLP WMATIC/stMATIC",
             "symbol": "ECLP-WMATIC-stMATIC",
             "poolType": "GyroE",
-            "poolTypeVersion": 2,
             "baseToken": null,
             "principalToken": null,
             "swapFee": "0.0002",
             "swapEnabled": true,
             "isInRecoveryMode": null,
             "isPaused": false,
-            "totalShares": "5.366644050391084161",
+            "totalShares": "1502367.123408841174649829",
             "wrappedIndex": null,
             "mainIndex": null,
             "tokensList": [
                 "0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270",
                 "0x3a58a54c066fdc0f2d55fc9c89f0415c92ebf3c4"
             ],
-            "tokenRates": ["1.000000000000000000", "1.068845920992504905"],
             "tokens": [
                 {
                     "symbol": "WMATIC",
                     "address": "0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270",
-                    "balance": "1.123393517620917161",
+                    "balance": "303205.800416722356931284",
                     "decimals": 18,
                     "name": "Wrapped Matic",
                     "index": 0
@@ -150,7 +148,7 @@
                 {
                     "symbol": "stMATIC",
                     "address": "0x3a58a54c066fdc0f2d55fc9c89f0415c92ebf3c4",
-                    "balance": "3.973745355066743187",
+                    "balance": "1120036.78624505376428293",
                     "decimals": 18,
                     "name": "Staked MATIC (PoS)",
                     "index": 1

--- a/test/sor.test.ts
+++ b/test/sor.test.ts
@@ -19,6 +19,7 @@ describe('SmartOrderRouter', () => {
         const rpcUrl = process.env['ETHEREUM_RPC_URL'] || '';
         const subgraphPoolDataService = new SubgraphPoolProvider(chainId);
         const onChainPoolDataEnricher = new OnChainPoolDataEnricher(
+            chainId,
             rpcUrl,
             SOR_QUERIES,
         );


### PR DESCRIPTION
I didn't push to the working branch so I don't "polute" it. I'd rather keep things separate until we consider this one ready to go.

I added tokenRates to the pool enricher by using the multicall available on viem and I tried keeping consistency with we already have on the code, but I'm not sure this case should be handled differently.
I tried to keep it flexible, so any pool that provides this type of function could be called (instead of enforcing it to be GyroE v2 pools).

Let me know what you think.