### PR TITLE
drop in replacement for pool data via multicall

### DIFF
--- a/debug/multicall.ts
+++ b/debug/multicall.ts
@@ -1,16 +1,21 @@
-import { fetchAdditionalPoolData } from '../src/data/onChainPoolDataViaMulticall';
 import { OnChainPoolDataViaMulticallEnricher } from '../src/data/enrichers/onChainPoolDataViaMulticallEnricher';
 import { createPublicClient, http } from 'viem';
+// rome-ignore lint/correctness/noUnusedVariables: <this is a test file>
 import { mainnet, polygonZkEvm } from 'viem/chains';
 
+const chain = polygonZkEvm;
+const rpc = 'https://rpc.ankr.com/polygon_zkevm';
+
+// rome-ignore lint/correctness/noUnusedVariables: <this is a test file>
 const client = createPublicClient({
-    chain: mainnet,
+    chain,
     transport: http(),
 });
 
 const poolsQuery = `{
-    pools(first: 10, orderBy: id, orderDirection: desc, where: { totalShares_gt: 0, poolType_contains: "Weighted" }) {
+    pools(first: 10, orderBy: id, orderDirection: desc, where: { totalShares_gt: 0, poolType_contains: "ComposableStable" }) {
         id
+        address
         poolType
         wrappedIndex
         tokens {
@@ -21,9 +26,9 @@ const poolsQuery = `{
     }
 }`;
 
-// 'https://api.studio.thegraph.com/query/24660/balancer-polygon-zk-v2/version/latest',
 const pools = await fetch(
-    'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-v2',
+    'https://api.studio.thegraph.com/query/24660/balancer-polygon-zk-v2/version/latest',
+    // 'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-v2',
     {
         method: 'POST',
         headers: {
@@ -35,9 +40,7 @@ const pools = await fetch(
     .then((res) => res.json())
     .then((res) => res.data);
 
-// const data = await fetchAdditionalPoolData(pools.pools, client);
-
-const onChainEnricher = new OnChainPoolDataViaMulticallEnricher(1, '');
+const onChainEnricher = new OnChainPoolDataViaMulticallEnricher(chain.id, rpc);
 const data = await onChainEnricher.fetchAdditionalPoolData(pools);
 const enrichered = onChainEnricher.enrichPoolsWithData(pools.pools, data);
 

--- a/debug/multicall.ts
+++ b/debug/multicall.ts
@@ -1,0 +1,44 @@
+import { fetchAdditionalPoolData } from '../src/data/onChainPoolDataViaMulticall';
+import { OnChainPoolDataViaMulticallEnricher } from '../src/data/enrichers/onChainPoolDataViaMulticallEnricher';
+import { createPublicClient, http } from 'viem';
+import { mainnet, polygonZkEvm } from 'viem/chains';
+
+const client = createPublicClient({
+    chain: mainnet,
+    transport: http(),
+});
+
+const poolsQuery = `{
+    pools(first: 10, orderBy: id, orderDirection: desc, where: { totalShares_gt: 0, poolType_contains: "Weighted" }) {
+        id
+        poolType
+        wrappedIndex
+        tokens {
+            address
+            decimals
+            index
+        }
+    }
+}`;
+
+// 'https://api.studio.thegraph.com/query/24660/balancer-polygon-zk-v2/version/latest',
+const pools = await fetch(
+    'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-v2',
+    {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ query: poolsQuery }),
+    },
+)
+    .then((res) => res.json())
+    .then((res) => res.data);
+
+// const data = await fetchAdditionalPoolData(pools.pools, client);
+
+const onChainEnricher = new OnChainPoolDataViaMulticallEnricher(1, '');
+const data = await onChainEnricher.fetchAdditionalPoolData(pools);
+const enrichered = onChainEnricher.enrichPoolsWithData(pools.pools, data);
+
+console.log(enrichered, data.length);

--- a/src/data/enrichers/onChainPoolDataEnricher.ts
+++ b/src/data/enrichers/onChainPoolDataEnricher.ts
@@ -18,7 +18,7 @@ import {
 } from '../../utils';
 import { HumanAmount, SwapOptions } from '../../types';
 
-interface OnChainPoolData {
+export interface OnChainPoolData {
     id: string;
     balances: readonly bigint[];
     totalSupply: bigint;

--- a/src/data/enrichers/onChainPoolDataViaMulticallEnricher.ts
+++ b/src/data/enrichers/onChainPoolDataViaMulticallEnricher.ts
@@ -80,13 +80,16 @@ export class OnChainPoolDataViaMulticallEnricher implements PoolDataEnricher {
                               formatUnits(tokenRate, 18) as HumanAmount,
                       )
                     : undefined,
-                balances: data?.balances,
-                totalSupply: data?.totalSupply,
-                weights: data?.weights,
-                wrappedTokenRate: data?.wrappedTokenRate,
-                linearTargets: data?.linearTargets,
-                scalingFactors: data?.scalingFactors,
-                rate: data?.poolRate,
+                lowerTarget: data?.linearTargets
+                    ? data.linearTargets[0]
+                    : 'lowerTarget' in pool
+                    ? pool.lowerTarget
+                    : undefined,
+                upperTarget: data?.linearTargets
+                    ? data.linearTargets[0]
+                    : 'upperTarget' in pool
+                    ? pool.upperTarget
+                    : undefined,
                 inRecoveryMode: data?.inRecoveryMode || false,
                 isPaused: data?.isPaused || false,
                 queryFailed: data?.queryFailed,

--- a/src/data/enrichers/onChainPoolDataViaMulticallEnricher.ts
+++ b/src/data/enrichers/onChainPoolDataViaMulticallEnricher.ts
@@ -1,0 +1,122 @@
+import { createPublicClient, formatUnits, http, PublicClient } from 'viem';
+import {
+    GetPoolsResponse,
+    PoolDataEnricher,
+    RawPool,
+    RawPoolTokenWithRate,
+    RawWeightedPoolToken,
+} from '../types';
+
+import { CHAINS } from '../../utils';
+import { HumanAmount } from '../../types';
+import { fetchAdditionalPoolData } from '../onChainPoolDataViaMulticall';
+import { OnChainPoolData } from './onChainPoolDataEnricher';
+
+export class OnChainPoolDataViaMulticallEnricher implements PoolDataEnricher {
+    private readonly client: PublicClient;
+
+    constructor(
+        private readonly chainId: number,
+        private readonly rpcUrl: string,
+    ) {
+        this.client = createPublicClient({
+            transport: http(this.rpcUrl),
+            chain: CHAINS[this.chainId],
+        });
+    }
+
+    public async fetchAdditionalPoolData(
+        data: GetPoolsResponse,
+    ): Promise<OnChainPoolData[]> {
+        return fetchAdditionalPoolData(data.pools, this.client);
+    }
+
+    public enrichPoolsWithData(
+        pools: RawPool[],
+        additionalPoolData: OnChainPoolData[],
+    ): RawPool[] {
+        return pools.map((pool) => {
+            const data = additionalPoolData.find((item) => item.id === pool.id);
+
+            return {
+                ...pool,
+                tokens: pool.tokens
+                    .sort((a, b) => a.index - b.index)
+                    .map((token) => {
+                        return {
+                            ...token,
+                            balance:
+                                data?.balances && data.balances.length > 0
+                                    ? (formatUnits(
+                                          data.balances[token.index],
+                                          token.decimals,
+                                      ) as HumanAmount)
+                                    : token.balance,
+                            priceRate: this.getPoolTokenRate({
+                                pool,
+                                token: token as RawPoolTokenWithRate,
+                                data,
+                                index: token.index,
+                            }),
+                            weight: data?.weights
+                                ? formatUnits(data.weights[token.index], 18)
+                                : (token as RawWeightedPoolToken).weight,
+                        };
+                    }),
+                totalShares: data?.totalSupply
+                    ? (formatUnits(data.totalSupply, 18) as HumanAmount)
+                    : pool.totalShares,
+                amp: data?.amp
+                    ? formatUnits(data.amp, 3)
+                    : 'amp' in pool
+                    ? pool.amp
+                    : undefined,
+                swapFee: data?.swapFee
+                    ? (formatUnits(data.swapFee, 18) as HumanAmount)
+                    : pool.swapFee,
+                tokenRates: data?.tokenRates
+                    ? data.tokenRates.map(
+                          (tokenRate) =>
+                              formatUnits(tokenRate, 18) as HumanAmount,
+                      )
+                    : undefined,
+                balances: data?.balances,
+                totalSupply: data?.totalSupply,
+                weights: data?.weights,
+                wrappedTokenRate: data?.wrappedTokenRate,
+                linearTargets: data?.linearTargets,
+                scalingFactors: data?.scalingFactors,
+                rate: data?.poolRate,
+                inRecoveryMode: data?.inRecoveryMode || false,
+                isPaused: data?.isPaused || false,
+                queryFailed: data?.queryFailed,
+            };
+        });
+    }
+
+    private getPoolTokenRate({
+        pool,
+        token,
+        data,
+        index,
+    }: {
+        pool: RawPool;
+        token: RawPoolTokenWithRate;
+        data?: OnChainPoolData;
+        index: number;
+    }): string {
+        if (
+            data?.wrappedTokenRate &&
+            'wrappedIndex' in pool &&
+            pool.wrappedIndex === index
+        ) {
+            return formatUnits(data.wrappedTokenRate, 18);
+        }
+
+        if (data?.scalingFactors) {
+            return formatUnits(data.scalingFactors[index], 18);
+        }
+
+        return token.priceRate;
+    }
+}

--- a/src/data/onChainPoolDataViaMulticall.ts
+++ b/src/data/onChainPoolDataViaMulticall.ts
@@ -1,0 +1,222 @@
+import { PublicClient, formatUnits, parseAbi } from 'viem';
+import { getPoolAddress } from '../utils';
+import { vaultAbi } from '../abi';
+
+const abi = parseAbi([
+    'function getSwapFeePercentage() view returns (uint256)',
+    'function percentFee() view returns (uint256)',
+    'function protocolPercentFee() view returns (uint256)',
+    'function getNormalizedWeights() view returns (uint256[])',
+    'function totalSupply() view returns (uint256)',
+    'function getVirtualSupply() view returns (uint256)',
+    'function getActualSupply() view returns (uint256)',
+    'function getTargets() view returns (uint256 lowerTarget, uint256 upperTarget)',
+    'function getTokenRates() view returns (uint256, uint256)',
+    'function getWrappedTokenRate() view returns (uint256)',
+    'function getAmplificationParameter() view returns (uint256 value, bool isUpdating, uint256 precision)',
+    'function getPausedState() view returns (bool)',
+    'function inRecoveryMode() view returns (bool)',
+    'function getRate() view returns (uint256)',
+    'function getScalingFactors() view returns (uint256[] memory)', // do we need this here?
+]);
+
+const getTotalSupplyFn = (poolType: string) => {
+    if (poolType.includes('Linear') || ['StablePhantom'].includes(poolType)) {
+        return 'getVirtualSupply';
+    } else if (poolType === 'ComposableStable') {
+        return 'getActualSupply';
+    } else {
+        return 'totalSupply';
+    }
+};
+
+const getSwapFeeFn = (poolType: string) => {
+    if (poolType === 'Element') {
+        return 'percentFee';
+    } else if (poolType === 'FX') {
+        return 'protocolPercentFee';
+    } else {
+        return 'getSwapFeePercentage';
+    }
+};
+
+const defaultCalls = {
+    count: 7,
+    build: (id: string, poolType: string) => [
+        {
+            address:
+                '0xBA12222222228d8Ba445958a75a0704d566BF2C8' as `0x${string}`,
+            abi: vaultAbi,
+            functionName: 'getPoolTokens',
+            args: [id],
+        },
+        {
+            address: getPoolAddress(id) as `0x${string}`,
+            abi,
+            functionName: getTotalSupplyFn(poolType),
+        },
+        {
+            address: getPoolAddress(id) as `0x${string}`,
+            abi,
+            functionName: getSwapFeeFn(poolType),
+        },
+        {
+            address: getPoolAddress(id) as `0x${string}`,
+            abi,
+            functionName: 'getPausedState',
+        },
+        {
+            address: getPoolAddress(id) as `0x${string}`,
+            abi,
+            functionName: 'inRecoveryMode',
+        },
+        {
+            address: getPoolAddress(id) as `0x${string}`,
+            abi,
+            functionName: 'getRate',
+        },
+        {
+            address: getPoolAddress(id) as `0x${string}`,
+            abi,
+            functionName: 'getScalingFactors',
+        },
+    ],
+    parse: (results: any, shift: number) => ({
+        balances: results[shift].result[0],
+        totalSupply: results[shift + 1].result,
+        swapFee: results[shift + 2].result,
+        isPaused: results[shift + 3].result,
+        inRecoveryMode: results[shift + 4].result,
+        poolRate: results[shift + 5].result,
+        scalingFactors: results[shift + 6].result,
+        queryFailed: false,
+    }),
+};
+
+const weightedCalls = {
+    count: 1,
+    build: (id: string) => [
+        {
+            address: getPoolAddress(id) as `0x${string}`,
+            abi,
+            functionName: 'getNormalizedWeights',
+        },
+    ],
+    parse: (results: any, shift: number) => ({
+        weights: results[shift].result,
+    }),
+};
+
+const linearCalls = {
+    count: 2,
+    build: (id: string) => [
+        {
+            address: getPoolAddress(id) as `0x${string}`,
+            abi,
+            functionName: 'getTargets',
+        },
+        {
+            address: getPoolAddress(id) as `0x${string}`,
+            abi,
+            functionName: 'getWrappedTokenRate',
+        },
+    ],
+    parse: (results: any, shift: number) => ({
+        linearTargets: results[shift].result,
+        wrappedTokenRate: results[shift + 1].result,
+    }),
+};
+
+const stableCalls = {
+    count: 1,
+    build: (id: string) => [
+        {
+            address: getPoolAddress(id) as `0x${string}`,
+            abi,
+            functionName: 'getAmplificationParameter',
+        },
+    ],
+    parse: (results: any, shift: number) => ({
+        amplificationParameter: formatUnits(
+            results[shift].result[0],
+            String(results[shift].result[2]).length - 1,
+        ),
+    }),
+};
+
+const gyroECalls = {
+    count: 1,
+    build: (id: string) => [
+        {
+            address: getPoolAddress(id) as `0x${string}`,
+            abi,
+            functionName: 'getTokenRates',
+        },
+    ],
+    parse: (results: any, shift: number) => ({
+        tokenRates: results[shift].result,
+    }),
+};
+
+const poolTypeCalls = (poolType: string) => {
+    switch (poolType) {
+        case 'Weighted':
+        case 'LiquidityBootstrapping':
+        case 'Investment':
+            return weightedCalls;
+        case 'Stable':
+        case 'StablePhantom':
+        case 'MetaStable':
+        case 'ComposableStable':
+            return stableCalls;
+        case 'GyroE':
+            return gyroECalls;
+        default:
+            if (poolType.includes('Linear')) {
+                return linearCalls;
+            } else {
+                return {
+                    count: 0,
+                    build: () => [],
+                    parse: () => ({}),
+                };
+            }
+    }
+};
+
+export const fetchAdditionalPoolData = async (
+    pools: {
+        id: string;
+        poolType: string;
+    }[],
+    client: PublicClient,
+) => {
+    if (pools.length === 0) {
+        return [];
+    }
+
+    const contracts = pools.flatMap(({ id, poolType }) => [
+        ...defaultCalls.build(id, poolType),
+        ...poolTypeCalls(poolType).build(id),
+    ]);
+
+    const results = await client.multicall({
+        contracts,
+        batchSize: 2_048,
+    });
+
+    let shift = 0;
+
+    return pools.map(({ id, poolType }) => {
+        const result = {
+            id,
+            ...defaultCalls.parse(results, shift),
+            ...poolTypeCalls(poolType).parse(
+                results,
+                shift + defaultCalls.count,
+            ),
+        };
+        shift += defaultCalls.count + poolTypeCalls(poolType).count;
+        return result;
+    });
+};


### PR DESCRIPTION
Adding multicall source for getting pool's on chain data. It's meant as a drop-in replacement for the current queries contract. Would appreciate pointers where the pools query was failing so we can double check if multicall works as expected.