### PR TITLE
Use vitest globals setup

### DIFF
--- a/test/fxPool.integration.test.ts
+++ b/test/fxPool.integration.test.ts
@@ -1,5 +1,4 @@
 // pnpm test -- test/fxPool.integration.test.ts
-import { beforeAll, beforeEach, describe, expect, test } from 'vitest';
 import dotenv from 'dotenv';
 dotenv.config();
 

--- a/test/gyro2Math.test.ts
+++ b/test/gyro2Math.test.ts
@@ -1,5 +1,4 @@
 // pnpm test -- gyro2Math.test.ts
-import { describe, expect, test } from 'vitest';
 import testPools from './lib/testData/gyro2TestPool.json';
 import { ChainId, RawGyro2Pool, Token, TokenAmount, WAD } from '../src';
 import {

--- a/test/gyro2Pool.test.ts
+++ b/test/gyro2Pool.test.ts
@@ -1,5 +1,4 @@
 // pnpm test -- test/gyro2Pool.test.ts
-import { describe, expect, test } from 'vitest';
 import dotenv from 'dotenv';
 dotenv.config();
 

--- a/test/gyro3Pool.integration.test.ts
+++ b/test/gyro3Pool.integration.test.ts
@@ -1,5 +1,4 @@
 // pnpm test -- test/gyro3Pool.integration.test.ts
-import { beforeEach, describe, expect, test } from 'vitest';
 import dotenv from 'dotenv';
 dotenv.config();
 

--- a/test/gyro3Pool.test.ts
+++ b/test/gyro3Pool.test.ts
@@ -1,5 +1,4 @@
 // pnpm test -- gyro3Pool.test.ts
-import { describe, expect, test } from 'vitest';
 import testPools from './lib/testData/gyro3TestPool.json';
 import { ChainId, RawGyro3Pool, SwapKind, Token, TokenAmount } from '../src';
 import { Gyro3Pool } from '../src/entities/pools/gyro3';

--- a/test/gyroEMath.test.ts
+++ b/test/gyroEMath.test.ts
@@ -1,5 +1,4 @@
 // pnpm test -- gyroEMath.test.ts
-import { describe, expect, test } from 'vitest';
 import testPools from './lib/testData/gyroETestPool.json';
 import { RawGyroEPool } from '../src/data/types';
 import { ChainId } from '../src/utils';

--- a/test/gyroEPool.test.ts
+++ b/test/gyroEPool.test.ts
@@ -1,5 +1,4 @@
 // pnpm test -- test/gyroEPool.test.ts
-import { describe, expect, test } from 'vitest';
 import testPools from './lib/testData/gyroETestPool.json';
 import { ChainId, SwapKind, Token, TokenAmount } from '../src';
 import { RawGyroEPool } from '../src/data/types';

--- a/test/gyroEV2Pool.integration.test.ts
+++ b/test/gyroEV2Pool.integration.test.ts
@@ -1,5 +1,4 @@
 // pnpm test -- test/gyroEV2Pool.integration.test.ts
-import { beforeAll, beforeEach, describe, expect, test } from 'vitest';
 import dotenv from 'dotenv';
 dotenv.config();
 

--- a/test/gyroEV2Pool.test.ts
+++ b/test/gyroEV2Pool.test.ts
@@ -1,5 +1,4 @@
 // pnpm test -- gyroEV2Pool.test.ts
-import { describe, expect, test } from 'vitest';
 import { ChainId, RawGyroEPool, SwapKind, Token, TokenAmount } from '../src';
 import { GyroEPool } from '../src/entities/pools/gyroE';
 import testPools from './lib/testData/gyroETestPool.json';

--- a/test/sor.test.ts
+++ b/test/sor.test.ts
@@ -1,5 +1,4 @@
 // pnpm test -- test/sor.test.ts
-import { beforeEach, describe, expect, test } from 'vitest';
 import dotenv from 'dotenv';
 dotenv.config();
 

--- a/test/subgraph.test.ts
+++ b/test/subgraph.test.ts
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest';
 import { SubgraphPoolProvider } from '../src/data/providers/subgraphPoolProvider';
 import { ChainId } from '../src/utils';
 import { ProviderSwapOptions } from '../src/data/types';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-    "include": ["src"],
+    "include": ["src", "test"],
     "compilerOptions": {
         "target": "ESNext",
         "module": "ESNext",
@@ -18,6 +18,7 @@
         "noImplicitReturns": true,
         "moduleResolution": "node",
         "esModuleInterop": true,
-        "resolveJsonModule": true
+        "resolveJsonModule": true,
+        "types": ["vitest/globals", "vite/client"],
     }
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,5 +4,6 @@ export default defineConfig({
     test: {
         testTimeout: 10_000,
         hookTimeout: 20_000,
+        globals: true,
     },
 });


### PR DESCRIPTION
Adds [globals vitest setup](https://vitest.dev/config/#globals) so that test files do not need to explicitly import `describe, it, beforeEach` etc