### PR TITLE
Constraint validations

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,9 +43,6 @@ devDependencies:
   ts-node:
     specifier: ^10.9.1
     version: 10.9.1(@types/node@18.15.11)(typescript@5.1.3)
-  tsconfig-paths:
-    specifier: ^4.2.0
-    version: 4.2.0
   tsup:
     specifier: ^6.6.0
     version: 6.7.0(ts-node@10.9.1)(typescript@5.1.3)
@@ -2156,12 +2153,6 @@ packages:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
     dev: true
 
-  /json5@2.2.3:
-    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
-    engines: {node: '>=6'}
-    hasBin: true
-    dev: true
-
   /jsonc-parser@3.2.0:
     resolution: {integrity: sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==}
     dev: true
@@ -3256,15 +3247,6 @@ packages:
       typescript: 5.1.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
-    dev: true
-
-  /tsconfig-paths@4.2.0:
-    resolution: {integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==}
-    engines: {node: '>=6'}
-    dependencies:
-      json5: 2.2.3
-      minimist: 1.2.8
-      strip-bom: 3.0.0
     dev: true
 
   /tsup@6.7.0(ts-node@10.9.1)(typescript@5.1.3):

--- a/src/entities/nestedExit/validateInputs.ts
+++ b/src/entities/nestedExit/validateInputs.ts
@@ -1,6 +1,7 @@
 import { NATIVE_ASSETS } from '../../utils';
 import { Token } from '../token';
 import { NestedPoolState } from '../types';
+import { constraintValidation } from '../utils';
 import {
     NestedProportionalExitInput,
     NestedSingleTokenExitInput,
@@ -10,6 +11,7 @@ export const validateInputs = (
     input: NestedProportionalExitInput | NestedSingleTokenExitInput,
     nestedPoolState: NestedPoolState,
 ) => {
+    constraintValidation(nestedPoolState);
     const tokenOut = 'tokenOut' in input ? input.tokenOut : undefined;
     const isProportional = tokenOut === undefined;
     const mainTokens = nestedPoolState.mainTokens.map(

--- a/src/entities/nestedJoin/validateInputs.ts
+++ b/src/entities/nestedJoin/validateInputs.ts
@@ -2,12 +2,14 @@ import { NATIVE_ASSETS } from '../../utils';
 import { Token } from '../token';
 import { TokenAmount } from '../tokenAmount';
 import { NestedPoolState } from '../types';
+import { constraintValidation } from '../utils';
 import { NestedJoinInput } from './types';
 
 export const validateInputs = (
     input: NestedJoinInput,
     nestedPoolState: NestedPoolState,
 ): TokenAmount[] => {
+    constraintValidation(nestedPoolState);
     const mainTokens = nestedPoolState.mainTokens.map(
         (t) => new Token(input.chainId, t.address, t.decimals),
     );

--- a/src/entities/utils/constraintValidation.ts
+++ b/src/entities/utils/constraintValidation.ts
@@ -14,7 +14,9 @@ export function constraintValidation(
     e.g. We can't validate pool state without constructing it which would require more complexity and data.
     So we assume pool state is correct. 
     */
-    const topLevel = nestedPoolState.pools[0].level;
+    // pools may not be in order so find highest level which will be top pool
+    const topLevel = Math.max(...nestedPoolState.pools.map((p) => p.level));
+
     nestedPoolState.mainTokens.forEach((t) => {
         const poolsWithToken = nestedPoolState.pools.filter((p) =>
             p.tokens.some((pt) => pt.address === t.address),

--- a/src/entities/utils/constraintValidation.ts
+++ b/src/entities/utils/constraintValidation.ts
@@ -1,0 +1,35 @@
+import { NestedPoolState } from '../types';
+
+export function constraintValidation(
+    nestedPoolState: NestedPoolState,
+): boolean {
+    /*
+    General rules:
+      * Can only join/exit with the main tokens
+      * Main tokens only supported to a max of 1 level of nesting
+      * Can still pure join with > 1 level 
+      * A main token can't be a token in > 1 pool
+
+    We can only do minimal validation without introducing complexity/data overhead that the API should be handling. 
+    e.g. We can't validate pool state without constructing it which would require more complexity and data.
+    So we assume pool state is correct. 
+    */
+    const topLevel = nestedPoolState.pools[0].level;
+    nestedPoolState.mainTokens.forEach((t) => {
+        const poolsWithToken = nestedPoolState.pools.filter((p) =>
+            p.tokens.some((pt) => pt.address === t.address),
+        );
+
+        if (poolsWithToken.length < 1)
+            throw 'NestedPoolState, main token must exist as a token of a pool';
+
+        if (poolsWithToken.length > 1)
+            throw `NestedPoolState, main token can't be token of more than 1 pool`;
+
+        if (poolsWithToken[0]) {
+            if (topLevel - poolsWithToken[0].level > 1)
+                throw 'NestedPoolState, main token only supported to a max of 1 level of nesting';
+        }
+    });
+    return true;
+}

--- a/src/entities/utils/index.ts
+++ b/src/entities/utils/index.ts
@@ -3,3 +3,4 @@ export * from './getAmounts';
 export * from './getSortedTokens';
 export * from './parseJoinArgs';
 export * from './replaceWrapped';
+export * from './constraintValidation';

--- a/test/constraintValidation.test.ts
+++ b/test/constraintValidation.test.ts
@@ -1,0 +1,246 @@
+// pnpm test -- constraintValidation.test.ts
+import { describe, expect, test } from 'vitest';
+import {
+    NestedPoolState,
+    NestedPool,
+    constraintValidation,
+} from '../src/entities';
+
+describe('constraint validations', () => {
+    describe('happy case', () => {
+        test('should be valid', () => {
+            expect(constraintValidation(happyPoolState)).to.be.true;
+        });
+    });
+    describe('A main token must exist as a token of a pool', () => {
+        test('should throw', () => {
+            // Test the exact error message
+            expect(() => constraintValidation(missingMain)).toThrowError(
+                /^NestedPoolState, main token must exist as a token of a pool$/,
+            );
+        });
+    });
+    describe("A main token can't be token of > 1 pool", () => {
+        test('should throw', () => {
+            // Test the exact error message
+            expect(() =>
+                constraintValidation(multiTokenPoolState),
+            ).toThrowError(
+                /^NestedPoolState, main token can't be token of more than 1 pool$/,
+            );
+        });
+    });
+    describe('A main token only supported to a max of 1 level of nesting', () => {
+        test('should throw', () => {
+            // Test the exact error message
+            expect(() => constraintValidation(deepPoolState)).toThrowError(
+                /^NestedPoolState, main token only supported to a max of 1 level of nesting$/,
+            );
+        });
+    });
+});
+
+/**
+                        TOP
+                3POOL_BPT/auraBal_BPT/WETH
+
+        3POOL_BPT           auraBal_BPT         
+        DAI/USDC/USDT       auraBal/8020_BPT
+
+                                8020_BPT
+                                BAL/WETH
+ */
+// Does not return 8020_BPT pool
+const happyPools: NestedPool[] = [
+    {
+        id: '0x08775ccb6674d6bdceb0797c364c2653ed84f3840002000000000000000004f0',
+        address: '0x08775ccb6674d6bdceb0797c364c2653ed84f384',
+        type: 'Weighted',
+        level: 1,
+        tokens: [
+            {
+                address: '0x79c58f70905f734641735bc61e45c19dd9ad60bc', // 3POOL-BPT
+                decimals: 18,
+                index: 0,
+            },
+            {
+                address: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2', // WETH
+                decimals: 18,
+                index: 1,
+            },
+            {
+                address: '0x3dd0843A028C86e0b760b1A76929d1C5Ef93a2dd', // auraBalBpt
+                decimals: 18,
+                index: 2,
+            },
+        ],
+    },
+    {
+        id: '0x79c58f70905f734641735bc61e45c19dd9ad60bc0000000000000000000004e7',
+        address: '0x79c58f70905f734641735bc61e45c19dd9ad60bc',
+        type: 'ComposableStable',
+        level: 0,
+        tokens: [
+            {
+                address: '0x6b175474e89094c44da98b954eedeac495271d0f', // DAI
+                decimals: 18,
+                index: 0,
+            },
+            {
+                address: '0x79c58f70905f734641735bc61e45c19dd9ad60bc', // 3POOL-BPT
+                decimals: 18,
+                index: 1,
+            },
+            {
+                address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48', // USDC
+                decimals: 6,
+                index: 2,
+            },
+            {
+                address: '0xdac17f958d2ee523a2206206994597c13d831ec7', // USDT
+                decimals: 6,
+                index: 3,
+            },
+        ],
+    },
+    {
+        id: '0x3dd0843a028c86e0b760b1a76929d1c5ef93a2dd000200000000000000000249',
+        address: '0x3dd0843A028C86e0b760b1A76929d1C5Ef93a2dd',
+        type: 'ComposableStable',
+        level: 0,
+        tokens: [
+            {
+                address: '0x5c6Ee304399DBdB9C8Ef030aB642B10820DB8F56', // 8020Bpt
+                decimals: 18,
+                index: 0,
+            },
+            {
+                address: '0x616e8BfA43F920657B3497DBf40D6b1A02D4608d', // auraBal
+                decimals: 18,
+                index: 1,
+            },
+            {
+                address: '0x3dd0843A028C86e0b760b1A76929d1C5Ef93a2dd', // BPT
+                decimals: 18,
+                index: 2,
+            },
+        ],
+    },
+];
+
+// Includes 8020_BPT pool
+const deepPools: NestedPool[] = [
+    { ...happyPools[0], level: 2 },
+    { ...happyPools[1], level: 1 },
+    { ...happyPools[2], level: 1 },
+    {
+        id: '0x5c6ee304399dbdb9c8ef030ab642b10820db8f56000200000000000000000014',
+        address: '0x5c6Ee304399DBdB9C8Ef030aB642B10820DB8F56',
+        type: 'Weighted',
+        level: 0,
+        tokens: [
+            {
+                address: '0xba100000625a3754423978a60c9317c58a424e3D', // BAL
+                decimals: 18,
+                index: 0,
+            },
+            {
+                address: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2', // WETH
+                decimals: 18,
+                index: 1,
+            },
+        ],
+    },
+];
+
+// Returning main tokens as 1 level
+const happyPoolState: NestedPoolState = {
+    pools: [...happyPools],
+    mainTokens: [
+        {
+            address: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2', // WETH
+            decimals: 18,
+        },
+        {
+            address: '0x6b175474e89094c44da98b954eedeac495271d0f', // DAI
+            decimals: 18,
+        },
+        {
+            address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48', // USDC
+            decimals: 6,
+        },
+        {
+            address: '0xdac17f958d2ee523a2206206994597c13d831ec7', // USDT
+            decimals: 6,
+        },
+        {
+            address: '0x5c6Ee304399DBdB9C8Ef030aB642B10820DB8F56', // 8020Bpt
+            decimals: 18,
+        },
+        {
+            address: '0x616e8BfA43F920657B3497DBf40D6b1A02D4608d', // auraBal
+            decimals: 18,
+        },
+    ],
+};
+
+const missingMain: NestedPoolState = {
+    ...happyPoolState,
+    mainTokens: [
+        ...happyPoolState.mainTokens,
+        {
+            address: '0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0', // wstEth
+            decimals: 18,
+        },
+    ],
+};
+
+// WETH is token in two pools
+const multiTokenPoolState: NestedPoolState = {
+    pools: [...deepPools],
+    mainTokens: [
+        {
+            address: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2', // WETH
+            decimals: 18,
+        },
+        {
+            address: '0x6b175474e89094c44da98b954eedeac495271d0f', // DAI
+            decimals: 18,
+        },
+        {
+            address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48', // USDC
+            decimals: 6,
+        },
+        {
+            address: '0xdac17f958d2ee523a2206206994597c13d831ec7', // USDT
+            decimals: 6,
+        },
+        {
+            address: '0xba100000625a3754423978a60c9317c58a424e3D', // BAL
+            decimals: 18,
+        },
+    ],
+};
+
+// BAL is 2 level of nesting
+const deepPoolState: NestedPoolState = {
+    pools: [...deepPools],
+    mainTokens: [
+        {
+            address: '0x6b175474e89094c44da98b954eedeac495271d0f', // DAI
+            decimals: 18,
+        },
+        {
+            address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48', // USDC
+            decimals: 6,
+        },
+        {
+            address: '0xdac17f958d2ee523a2206206994597c13d831ec7', // USDT
+            decimals: 6,
+        },
+        {
+            address: '0xba100000625a3754423978a60c9317c58a424e3D', // BAL
+            decimals: 18,
+        },
+    ],
+};


### PR DESCRIPTION
General rules:
  * Can only join/exit with the main tokens
  * Main tokens only supported to a max of 1 level of nesting
  * Can still pure join with > 1 level 
  * A main token can't be a token in > 1 pool


We can only do minimal validation without introducing complexity/data overhead that the API should be handling. 
e.g. We can't validate pool state without constructing it which would require more complexity and data.
So we assume pool state is correct. 