### PR TITLE
Refactor Input amounts

### DIFF
--- a/examples/exit/weighted.ts
+++ b/examples/exit/weighted.ts
@@ -1,3 +1,4 @@
+// Run with - pnpm example ./examples/exit/weighted.ts
 import dotenv from 'dotenv';
 dotenv.config();
 
@@ -11,7 +12,7 @@ import {
     SingleAssetExitInput,
     Slippage,
     Token,
-    TokenAmount,
+    InputAmount,
 } from '../../src';
 import {
     Client,
@@ -23,6 +24,7 @@ import {
     TestActions,
     WalletActions,
     walletActions,
+    parseEther,
 } from 'viem';
 import {
     forkSetup,
@@ -61,7 +63,11 @@ const exit = async () => {
         [parseUnits('100', 18)],
     );
 
-    const bptIn = TokenAmount.fromHumanAmount(bpt, '1');
+    const bptIn: InputAmount = {
+        rawAmount: parseEther('1'),
+        decimals: 18,
+        address: poolState.address,
+    };
     const tokenOut = '0xba100000625a3754423978a60c9317c58a424e3D'; // BAL
 
     const poolExit = new PoolExit();

--- a/examples/join/weighted.ts
+++ b/examples/join/weighted.ts
@@ -1,3 +1,4 @@
+// Run with - pnpm example ./examples/join/weighted.ts
 import { config } from 'dotenv';
 config();
 
@@ -9,8 +10,6 @@ import {
     PoolJoin,
     PoolStateInput,
     Slippage,
-    Token,
-    TokenAmount,
     UnbalancedJoinInput,
 } from '../../src';
 import {
@@ -64,12 +63,12 @@ const join = async () => {
     );
 
     const poolJoin = new PoolJoin();
-    const poolTokens = poolState.tokens.map(
-        (t) => new Token(chainId, t.address, t.decimals),
-    );
-    const amountsIn = poolTokens.map((t) =>
-        TokenAmount.fromHumanAmount(t, '1'),
-    );
+
+    const amountsIn = poolState.tokens.map((t) => ({
+        rawAmount: parseUnits('1', t.decimals),
+        decimals: t.decimals,
+        address: t.address,
+    }));
 
     // perform join query to get expected bpt out
     const joinInput: UnbalancedJoinInput = {

--- a/src/entities/exit/types.ts
+++ b/src/entities/exit/types.ts
@@ -1,6 +1,6 @@
 import { TokenAmount } from '../tokenAmount';
 import { Slippage } from '../slippage';
-import { Address } from '../../types';
+import { Address, InputAmount } from '../../types';
 import { PoolState } from '../types';
 
 export enum ExitKind {
@@ -18,18 +18,18 @@ export type BaseExitInput = {
 };
 
 export type UnbalancedExitInput = BaseExitInput & {
-    amountsOut: TokenAmount[];
+    amountsOut: InputAmount[];
     kind: ExitKind.UNBALANCED;
 };
 
 export type SingleAssetExitInput = BaseExitInput & {
-    bptIn: TokenAmount;
+    bptIn: InputAmount;
     tokenOut: Address;
     kind: ExitKind.SINGLE_ASSET;
 };
 
 export type ProportionalExitInput = BaseExitInput & {
-    bptIn: TokenAmount;
+    bptIn: InputAmount;
     kind: ExitKind.PROPORTIONAL;
 };
 

--- a/src/entities/exit/weighted/validateInputs.ts
+++ b/src/entities/exit/weighted/validateInputs.ts
@@ -6,7 +6,7 @@ export function validateInputs(input: ExitInput, poolState: PoolStateInput) {
     switch (input.kind) {
         case ExitKind.UNBALANCED:
             areTokensInArray(
-                input.amountsOut.map((a) => a.token.address),
+                input.amountsOut.map((a) => a.address),
                 poolState.tokens.map((t) => t.address),
             );
             break;
@@ -16,7 +16,7 @@ export function validateInputs(input: ExitInput, poolState: PoolStateInput) {
                 poolState.tokens.map((t) => t.address),
             );
         case ExitKind.PROPORTIONAL:
-            areTokensInArray([input.bptIn.token.address], [poolState.address]);
+            areTokensInArray([input.bptIn.address], [poolState.address]);
         default:
             break;
     }

--- a/src/entities/exit/weighted/weightedExit.ts
+++ b/src/entities/exit/weighted/weightedExit.ts
@@ -72,8 +72,9 @@ export class WeightedExit implements BaseExit {
                 return {
                     minAmountsOut: tokens.map(
                         (t) =>
-                            input.amountsOut.find((a) => a.token.isEqual(t))
-                                ?.amount ?? 0n,
+                            input.amountsOut.find((a) =>
+                                t.isSameAddress(a.address),
+                            )?.rawAmount ?? 0n,
                     ),
                     tokenOutIndex: undefined,
                     maxBptAmountIn: MAX_UINT256,
@@ -84,13 +85,13 @@ export class WeightedExit implements BaseExit {
                     tokenOutIndex: tokens.findIndex((t) =>
                         t.isSameAddress(input.tokenOut),
                     ),
-                    maxBptAmountIn: input.bptIn.amount,
+                    maxBptAmountIn: input.bptIn.rawAmount,
                 };
             case ExitKind.PROPORTIONAL:
                 return {
                     minAmountsOut: Array(tokens.length).fill(0n),
                     tokenOutIndex: undefined,
-                    maxBptAmountIn: input.bptIn.amount,
+                    maxBptAmountIn: input.bptIn.rawAmount,
                 };
         }
     }

--- a/src/entities/exit/weighted/weightedExit.ts
+++ b/src/entities/exit/weighted/weightedExit.ts
@@ -20,6 +20,7 @@ import {
 } from '../types';
 import { AmountsExit, PoolState } from '../../types';
 import { doQueryExit } from '../../utils/doQueryExit';
+import { getAmounts } from '../../utils';
 
 export class WeightedExit implements BaseExit {
     public async query(
@@ -70,12 +71,7 @@ export class WeightedExit implements BaseExit {
         switch (input.kind) {
             case ExitKind.UNBALANCED:
                 return {
-                    minAmountsOut: tokens.map(
-                        (t) =>
-                            input.amountsOut.find((a) =>
-                                t.isSameAddress(a.address),
-                            )?.rawAmount ?? 0n,
-                    ),
+                    minAmountsOut: getAmounts(tokens, input.amountsOut),
                     tokenOutIndex: undefined,
                     maxBptAmountIn: MAX_UINT256,
                 };

--- a/src/entities/join/composable-stable/composableStableJoin.ts
+++ b/src/entities/join/composable-stable/composableStableJoin.ts
@@ -131,7 +131,7 @@ export class ComposableStableJoin implements BaseJoin {
                 const maxAmountsIn = Array(poolTokens.length).fill(0n);
                 maxAmountsIn[tokenInIndex] = MAX_UINT256;
                 amountsJoin = {
-                    minimumBpt: input.bptOut.amount,
+                    minimumBpt: input.bptOut.rawAmount,
                     maxAmountsIn,
                     tokenInIndex,
                 };
@@ -139,7 +139,7 @@ export class ComposableStableJoin implements BaseJoin {
             }
             case JoinKind.Proportional: {
                 amountsJoin = {
-                    minimumBpt: input.bptOut.amount,
+                    minimumBpt: input.bptOut.rawAmount,
                     maxAmountsIn: Array(poolTokens.length).fill(MAX_UINT256),
                     tokenInIndex: undefined,
                 };

--- a/src/entities/join/types.ts
+++ b/src/entities/join/types.ts
@@ -1,7 +1,7 @@
 import { TokenAmount } from '../tokenAmount';
 import { Slippage } from '../slippage';
 import { PoolState } from '../types';
-import { Address, Hex } from '../../types';
+import { Address, Hex, InputAmount } from '../../types';
 
 export enum JoinKind {
     Init = 'Init',
@@ -19,23 +19,23 @@ type BaseJoinInput = {
 };
 
 export type InitJoinInput = BaseJoinInput & {
-    amountsIn: TokenAmount[];
+    amountsIn: InputAmount[];
     kind: JoinKind.Init;
 };
 
 export type UnbalancedJoinInput = BaseJoinInput & {
-    amountsIn: TokenAmount[];
+    amountsIn: InputAmount[];
     kind: JoinKind.Unbalanced;
 };
 
 export type SingleAssetJoinInput = BaseJoinInput & {
-    bptOut: TokenAmount;
+    bptOut: InputAmount;
     tokenIn: Address;
     kind: JoinKind.SingleAsset;
 };
 
 export type ProportionalJoinInput = BaseJoinInput & {
-    bptOut: TokenAmount;
+    bptOut: InputAmount;
     kind: JoinKind.Proportional;
 };
 

--- a/src/entities/join/utils/validateInputs.ts
+++ b/src/entities/join/utils/validateInputs.ts
@@ -13,7 +13,7 @@ export function validateInputs(input: JoinInput, poolState: PoolStateInput) {
         case JoinKind.Init:
         case JoinKind.Unbalanced:
             areTokensInArray(
-                input.amountsIn.map((a) => a.token.address),
+                input.amountsIn.map((a) => a.address),
                 poolState.tokens.map((t) => t.address),
             );
             break;
@@ -23,7 +23,7 @@ export function validateInputs(input: JoinInput, poolState: PoolStateInput) {
                 poolState.tokens.map((t) => t.address),
             );
         case JoinKind.Proportional:
-            areTokensInArray([input.bptOut.token.address], [poolState.address]);
+            areTokensInArray([input.bptOut.address], [poolState.address]);
         default:
             break;
     }

--- a/src/entities/join/weighted/weightedJoin.ts
+++ b/src/entities/join/weighted/weightedJoin.ts
@@ -116,14 +116,14 @@ export class WeightedJoin implements BaseJoin {
                 const maxAmountsIn = Array(poolTokens.length).fill(0n);
                 maxAmountsIn[tokenInIndex] = MAX_UINT256;
                 return {
-                    minimumBpt: input.bptOut.amount,
+                    minimumBpt: input.bptOut.rawAmount,
                     maxAmountsIn,
                     tokenInIndex,
                 };
             }
             case JoinKind.Proportional: {
                 return {
-                    minimumBpt: input.bptOut.amount,
+                    minimumBpt: input.bptOut.rawAmount,
                     maxAmountsIn: Array(poolTokens.length).fill(MAX_UINT256),
                     tokenInIndex: undefined,
                 };

--- a/src/entities/utils/getAmounts.ts
+++ b/src/entities/utils/getAmounts.ts
@@ -1,5 +1,5 @@
+import { InputAmount } from '../../types';
 import { Token } from '../token';
-import { TokenAmount } from '../tokenAmount';
 
 /**
  * Get amounts from array of TokenAmounts returning default if not a value for tokens.
@@ -10,10 +10,12 @@ import { TokenAmount } from '../tokenAmount';
  */
 export function getAmounts(
     tokens: Token[],
-    amounts: TokenAmount[],
+    amounts: InputAmount[],
     defaultAmount = 0n,
 ): bigint[] {
     return tokens.map(
-        (t) => amounts.find((a) => a.token.isEqual(t))?.amount ?? defaultAmount,
+        (t) =>
+            amounts.find((a) => t.isSameAddress(a.address))?.rawAmount ??
+            defaultAmount,
     );
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,3 +62,9 @@ export interface BatchSwapStep {
     amount: bigint;
     userData: Hex;
 }
+
+export type InputAmount = {
+    address: Address;
+    decimals: number;
+    rawAmount: bigint;
+};

--- a/test/lib/utils/joinHelper.ts
+++ b/test/lib/utils/joinHelper.ts
@@ -165,11 +165,9 @@ export function assertUnbalancedJoin(
         )
             token = new Token(chainId, zeroAddress, t.decimals);
         else token = new Token(chainId, t.address, t.decimals);
-        const input = joinInput.amountsIn.find(
-            (a) => a.token.address === t.address,
-        );
+        const input = joinInput.amountsIn.find((a) => a.address === t.address);
         if (input === undefined) return TokenAmount.fromRawAmount(token, 0n);
-        else return TokenAmount.fromRawAmount(token, input.amount);
+        else return TokenAmount.fromRawAmount(token, input.rawAmount);
     });
 
     const expectedQueryResult: Omit<JoinQueryResult, 'bptOut' | 'bptIndex'> = {
@@ -229,7 +227,7 @@ export function assertSingleToken(
             // Query should use same bpt out as user sets
             bptOut: TokenAmount.fromRawAmount(
                 bptToken,
-                joinInput.bptOut.amount,
+                joinInput.bptOut.rawAmount,
             ),
             tokenInIndex: tokensWithoutBpt.findIndex(
                 (t) => t.address === joinInput.tokenIn,
@@ -294,7 +292,7 @@ export function assertProportional(
             // Query should use same bpt out as user sets
             bptOut: TokenAmount.fromRawAmount(
                 bptToken,
-                joinInput.bptOut.amount,
+                joinInput.bptOut.rawAmount,
             ),
             // Only expect tokenInIndex for SingleAssetJoin
             tokenInIndex: undefined,

--- a/test/weightedJoin.integration.test.ts
+++ b/test/weightedJoin.integration.test.ts
@@ -9,6 +9,7 @@ import {
     parseUnits,
     publicActions,
     walletActions,
+    parseEther,
 } from 'viem';
 
 import {
@@ -17,8 +18,6 @@ import {
     SingleAssetJoinInput,
     JoinKind,
     Slippage,
-    Token,
-    TokenAmount,
     Address,
     Hex,
     PoolStateInput,
@@ -27,6 +26,7 @@ import {
     getPoolAddress,
     PoolJoin,
     JoinInput,
+    InputAmount,
 } from '../src';
 import { forkSetup } from './lib/utils/helper';
 import {
@@ -45,14 +45,14 @@ const poolId =
 
 describe('weighted join test', () => {
     let txInput: JoinTxInput;
-    let bptToken: Token;
+    let poolStateInput: PoolStateInput;
 
     beforeAll(async () => {
         // setup mock api
         const api = new MockApi();
 
         // get pool state from api
-        const poolStateInput = await api.getPool(poolId);
+        poolStateInput = await api.getPool(poolId);
 
         const client = createTestClient({
             mode: 'anvil',
@@ -70,9 +70,6 @@ describe('weighted join test', () => {
             testAddress: '0x10A19e7eE7d7F8a52822f6817de8ea18204F2e4f', // Balancer DAO Multisig
             joinInput: {} as JoinInput,
         };
-
-        // setup BPT token
-        bptToken = new Token(chainId, poolStateInput.address, 18, 'BPT');
     });
 
     beforeEach(async () => {
@@ -95,14 +92,13 @@ describe('weighted join test', () => {
 
     describe('unbalanced join', () => {
         let input: Omit<UnbalancedJoinInput, 'amountsIn'>;
-        let amountsIn: TokenAmount[];
+        let amountsIn: InputAmount[];
         beforeAll(() => {
-            const poolTokens = txInput.poolStateInput.tokens.map(
-                (t) => new Token(chainId, t.address, t.decimals),
-            );
-            amountsIn = poolTokens.map((t) =>
-                TokenAmount.fromHumanAmount(t, '1'),
-            );
+            amountsIn = txInput.poolStateInput.tokens.map((t) => ({
+                rawAmount: parseUnits('0.001', t.decimals),
+                decimals: t.decimals,
+                address: t.address,
+            }));
             input = {
                 chainId,
                 rpcUrl,
@@ -151,7 +147,11 @@ describe('weighted join test', () => {
     describe('single asset join', () => {
         let joinInput: SingleAssetJoinInput;
         beforeAll(() => {
-            const bptOut = TokenAmount.fromHumanAmount(bptToken, '1');
+            const bptOut: InputAmount = {
+                rawAmount: parseEther('1'),
+                decimals: 18,
+                address: poolStateInput.address,
+            };
             const tokenIn = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2';
             joinInput = {
                 bptOut,
@@ -202,7 +202,11 @@ describe('weighted join test', () => {
     describe('proportional join', () => {
         let joinInput: ProportionalJoinInput;
         beforeAll(() => {
-            const bptOut = TokenAmount.fromHumanAmount(bptToken, '1');
+            const bptOut: InputAmount = {
+                rawAmount: parseEther('1'),
+                decimals: 18,
+                address: poolStateInput.address,
+            };
             joinInput = {
                 bptOut,
                 chainId,


### PR DESCRIPTION
Currently join inputs have TokenAmount as amountsIn type, but this adds too much complexity for the user to properly build the input. This task aims to replace that with a struct with more basic types:
`
InputAmount: {
    address: Address;
    decimals: number;
    rawAmount: bigint;
}
`