### PR TITLE
Manually add BPT in CS API Provider

### DIFF
--- a/src/data/providers/balancer-api/modules/pool-state/index.ts
+++ b/src/data/providers/balancer-api/modules/pool-state/index.ts
@@ -78,14 +78,33 @@ export class Pools {
     constructor(private readonly balancerApiClient: BalancerApiClient) {}
 
     async fetchPoolState(id: string): Promise<PoolStateInput> {
-        const {
-            data: { poolGetPool },
-        } = await this.balancerApiClient.fetch({
+        const { data } = await this.balancerApiClient.fetch({
             query: this.poolStateQuery,
             variables: {
                 id,
             },
         });
+        const poolGetPool: PoolStateInput = data.poolGetPool;
+        /**
+         * TODO:
+         * We are working on assumption that API will return BPT token in token list (as current SG does)
+         * It does not currently do this so we have to add it manually
+         */
+        if (poolGetPool.type === 'PHANTOM_STABLE') {
+            let missingBPTIndex = 0;
+            const sortedIndexes = poolGetPool.tokens.map((t) => t.index).sort();
+            for (let i = 0; i < poolGetPool.tokens.length + 1; i++) {
+                if (i === poolGetPool.tokens.length || sortedIndexes[i] !== i) {
+                    missingBPTIndex = i;
+                    break;
+                }
+            }
+            poolGetPool.tokens.splice(missingBPTIndex, 0, {
+                index: missingBPTIndex,
+                address: poolGetPool.address,
+                decimals: 18,
+            });
+        }
         return poolGetPool;
     }
 }

--- a/src/data/providers/balancer-api/modules/pool-state/index.ts
+++ b/src/data/providers/balancer-api/modules/pool-state/index.ts
@@ -85,25 +85,37 @@ export class Pools {
             },
         });
         const poolGetPool: PoolStateInput = data.poolGetPool;
-        /**
-         * TODO:
-         * We are working on assumption that API will return BPT token in token list (as current SG does)
-         * It does not currently do this so we have to add it manually
-         */
+
         if (poolGetPool.type === 'PHANTOM_STABLE') {
-            let missingBPTIndex = 0;
-            const sortedIndexes = poolGetPool.tokens.map((t) => t.index).sort();
-            for (let i = 0; i < poolGetPool.tokens.length + 1; i++) {
-                if (i === poolGetPool.tokens.length || sortedIndexes[i] !== i) {
-                    missingBPTIndex = i;
-                    break;
+            if (
+                !poolGetPool.tokens.some(
+                    (t) => t.address === poolGetPool.address,
+                )
+            ) {
+                /**
+                 * TODO:
+                 * We are working on assumption that API will return BPT token in token list (as current SG does)
+                 * If it doesn't (as of 09/11/23) we have to add it manually
+                 */
+                let missingBPTIndex = 0;
+                const sortedIndexes = poolGetPool.tokens
+                    .map((t) => t.index)
+                    .sort();
+                for (let i = 0; i < poolGetPool.tokens.length + 1; i++) {
+                    if (
+                        i === poolGetPool.tokens.length ||
+                        sortedIndexes[i] !== i
+                    ) {
+                        missingBPTIndex = i;
+                        break;
+                    }
                 }
+                poolGetPool.tokens.splice(missingBPTIndex, 0, {
+                    index: missingBPTIndex,
+                    address: poolGetPool.address,
+                    decimals: 18,
+                });
             }
-            poolGetPool.tokens.splice(missingBPTIndex, 0, {
-                index: missingBPTIndex,
-                address: poolGetPool.address,
-                decimals: 18,
-            });
         }
         return poolGetPool;
     }

--- a/test/balancerApi.test.ts
+++ b/test/balancerApi.test.ts
@@ -1,0 +1,31 @@
+// pnpm test -- balancerApi.test.ts
+import { describe, expect, test } from 'vitest';
+import { BalancerApi, PoolStateInput, ChainId } from '../src';
+
+describe(
+    'BalancerApi Provider',
+    () => {
+        test('CS Pool - Should add BPT to tokens', async () => {
+            const chainId = ChainId.MAINNET;
+            // wstEth/WETH CS Pool
+            const poolId =
+                '0x93d199263632a4ef4bb438f1feb99e57b4b5f0bd0000000000000000000005c2';
+
+            // API is used to fetch relevant pool data
+            const balancerApi = new BalancerApi(
+                'https://backend-v3-canary.beets-ftm-node.com/graphql',
+                chainId,
+            );
+            const poolStateInput: PoolStateInput =
+                await balancerApi.pools.fetchPoolState(poolId);
+
+            expect(poolStateInput.tokens.length).toEqual(3);
+            expect(poolStateInput.tokens[1].address).toEqual(
+                poolStateInput.address,
+            );
+        });
+    },
+    {
+        timeout: 60000,
+    },
+);


### PR DESCRIPTION
We are working on assumption that API will return BPT token in token list (as current SG does) It does not currently do this so we have to add it manually.