### PR TITLE
Build call output token amounts

### DIFF
--- a/examples/exitPool.ts
+++ b/examples/exitPool.ts
@@ -75,8 +75,11 @@ const exit = async () => {
     });
 
     console.log('\nWith slippage applied:');
-    console.log(`Max BPT In: ${call.maxBptIn.toString()}`); // TODO these should be InputAmounts or TokenAmounts?
-    console.log(`Min amounts out: ${call.minAmountsOut}`); // TODO these should be InputAmounts or TokenAmounts?
+    console.log(`Max BPT In: ${call.maxBptIn.amount}`);
+    console.log('Min amounts out: ');
+    call.minAmountsOut.forEach((a) =>
+        console.log(a.token.address, a.amount.toString()),
+    );
 
     // Make the tx against the local fork and print the result
     await makeForkTx(

--- a/examples/joinPool.ts
+++ b/examples/joinPool.ts
@@ -73,8 +73,11 @@ const join = async () => {
     });
 
     console.log('\nWith slippage applied:');
-    console.log(`Max tokens in: ${call.maxAmountsIn}`); // TODO these should be InputAmounts or TokenAmounts?
-    console.log(`Min BPT Out: ${call.minBptOut.toString()}`); // TODO these should be InputAmounts or TokenAmounts?
+    console.log('Max tokens in:');
+    call.maxAmountsIn.forEach((a) =>
+        console.log(a.token.address, a.amount.toString()),
+    );
+    console.log(`Min BPT Out: ${call.minBptOut.amount.toString()}`);
 
     // Make the tx against the local fork and print the result
     const slots = [1, 3, 0];

--- a/src/entities/exit/composable-stable/composableStableExit.ts
+++ b/src/entities/exit/composable-stable/composableStableExit.ts
@@ -135,8 +135,13 @@ export class ComposableStableExit implements BaseExit {
             call,
             to: BALANCER_VAULT,
             value: 0n,
-            maxBptIn: amounts.maxBptAmountIn,
-            minAmountsOut: amounts.minAmountsOut,
+            maxBptIn: TokenAmount.fromRawAmount(
+                input.bptIn.token,
+                amounts.maxBptAmountIn,
+            ),
+            minAmountsOut: input.amountsOut.map((a, i) =>
+                TokenAmount.fromRawAmount(a.token, amounts.minAmountsOut[i]),
+            ),
         };
     }
 

--- a/src/entities/exit/types.ts
+++ b/src/entities/exit/types.ts
@@ -72,8 +72,8 @@ export type ExitBuildOutput = {
     call: Address;
     to: Address;
     value: bigint;
-    maxBptIn: bigint;
-    minAmountsOut: bigint[];
+    maxBptIn: TokenAmount;
+    minAmountsOut: TokenAmount[];
 };
 
 export interface BaseExit {

--- a/src/entities/exit/weighted/weightedExit.ts
+++ b/src/entities/exit/weighted/weightedExit.ts
@@ -119,8 +119,13 @@ export class WeightedExit implements BaseExit {
             call,
             to: BALANCER_VAULT,
             value: 0n,
-            maxBptIn: amounts.maxBptAmountIn,
-            minAmountsOut: amounts.minAmountsOut,
+            maxBptIn: TokenAmount.fromRawAmount(
+                input.bptIn.token,
+                amounts.maxBptAmountIn,
+            ),
+            minAmountsOut: input.amountsOut.map((a, i) =>
+                TokenAmount.fromRawAmount(a.token, amounts.minAmountsOut[i]),
+            ),
         };
     }
 

--- a/src/entities/join/composable-stable/composableStableJoin.ts
+++ b/src/entities/join/composable-stable/composableStableJoin.ts
@@ -97,8 +97,13 @@ export class ComposableStableJoin implements BaseJoin {
             call,
             to: BALANCER_VAULT,
             value: value === undefined ? 0n : value,
-            minBptOut: amounts.minimumBpt,
-            maxAmountsIn: amounts.maxAmountsIn,
+            minBptOut: TokenAmount.fromRawAmount(
+                input.bptOut.token,
+                amounts.minimumBpt,
+            ),
+            maxAmountsIn: input.amountsIn.map((a, i) =>
+                TokenAmount.fromRawAmount(a.token, amounts.maxAmountsIn[i]),
+            ),
         };
     }
 

--- a/src/entities/join/types.ts
+++ b/src/entities/join/types.ts
@@ -82,8 +82,8 @@ export interface BaseJoin {
         call: Hex;
         to: Address;
         value: bigint;
-        minBptOut: bigint;
-        maxAmountsIn: bigint[];
+        minBptOut: TokenAmount;
+        maxAmountsIn: TokenAmount[];
     };
 }
 
@@ -91,8 +91,8 @@ export type JoinBuildOutput = {
     call: Hex;
     to: Address;
     value: bigint;
-    minBptOut: bigint;
-    maxAmountsIn: bigint[];
+    minBptOut: TokenAmount;
+    maxAmountsIn: TokenAmount[];
 };
 
 export type JoinConfig = {

--- a/src/entities/join/weighted/weightedJoin.ts
+++ b/src/entities/join/weighted/weightedJoin.ts
@@ -89,8 +89,13 @@ export class WeightedJoin implements BaseJoin {
             call,
             to: BALANCER_VAULT,
             value: value === undefined ? 0n : value,
-            minBptOut: amounts.minimumBpt,
-            maxAmountsIn: amounts.maxAmountsIn,
+            minBptOut: TokenAmount.fromRawAmount(
+                input.bptOut.token,
+                amounts.minimumBpt,
+            ),
+            maxAmountsIn: input.amountsIn.map((a, i) =>
+                TokenAmount.fromRawAmount(a.token, amounts.maxAmountsIn[i]),
+            ),
         };
     }
 

--- a/test/lib/utils/joinHelper.ts
+++ b/test/lib/utils/joinHelper.ts
@@ -362,13 +362,18 @@ function assertJoinBuildOutput(
 ) {
     // if exactIn maxAmountsIn should use same amountsIn as input else slippage should be applied
     const maxAmountsIn = isExactIn
-        ? joinQueryResult.amountsIn.map((a) => a.amount)
-        : joinQueryResult.amountsIn.map((a) => slippage.applyTo(a.amount));
+        ? [...joinQueryResult.amountsIn]
+        : joinQueryResult.amountsIn.map((a) =>
+              TokenAmount.fromRawAmount(a.token, slippage.applyTo(a.amount)),
+          );
 
     // if exactIn slippage should be applied to bptOut else should use same bptOut as input
     const minBptOut = isExactIn
-        ? slippage.removeFrom(joinQueryResult.bptOut.amount)
-        : joinQueryResult.bptOut.amount;
+        ? TokenAmount.fromRawAmount(
+              joinQueryResult.bptOut.token,
+              slippage.removeFrom(joinQueryResult.bptOut.amount),
+          )
+        : ({ ...joinQueryResult.bptOut } as TokenAmount);
 
     const expectedBuildOutput: Omit<JoinBuildOutput, 'call'> = {
         maxAmountsIn,


### PR DESCRIPTION
Update Join/ExitBuildOutput to use TokenAmounts instead of bigints. This should make it more useful for consumer.