### PR TITLE
fix: Ignore throwing paths

### DIFF
--- a/.changeset/eight-beans-remember.md
+++ b/.changeset/eight-beans-remember.md
@@ -1,0 +1,5 @@
+---
+"@balancer/sdk": patch
+---
+
+Discard paths with failing limits

--- a/src/pathGraph/pathGraph.ts
+++ b/src/pathGraph/pathGraph.ts
@@ -130,12 +130,18 @@ export class PathGraph {
     ): PathGraphEdgeData[][] {
         const pathsWithLimits = paths
             .map((path) => {
-                const limit = this.getLimitAmountSwapForPath(
-                    path,
-                    SwapKind.GivenIn,
-                );
-                return { path, limit };
+                try {
+                    const limit = this.getLimitAmountSwapForPath(
+                        path,
+                        SwapKind.GivenIn,
+                    );
+                    return { path, limit };
+                } catch (_e) {
+                    console.error('Error getting limit for path', path.map(p => p.pool.id).join(' -> '));
+                    return undefined;
+                }
             })
+            .filter((path): path is { path: PathGraphEdgeData[], limit: bigint } => !!path)
             .sort((a, b) => (a.limit < b.limit ? 1 : -1));
 
         const filtered: PathGraphEdgeData[][] = [];


### PR DESCRIPTION
When comparing multiple paths for a swap, if one pool in any path is throwing, eg: new Error('Swap amount exceeds the pool limit') - it makes the PathGraph.getCandidatePaths to fail for all the other paths. Handling the error allows to return the other paths.