### PR TITLE
chore: expose priceImpact amount from entities index

### DIFF
--- a/.changeset/angry-papayas-live.md
+++ b/.changeset/angry-papayas-live.md
@@ -1,0 +1,5 @@
+---
+"@balancer/sdk": patch
+---
+
+expose priceImpact amount

--- a/src/entities/index.ts
+++ b/src/entities/index.ts
@@ -3,6 +3,7 @@ export * from './encoders';
 export * from './path';
 export * from './pools/';
 export * from './priceImpact/';
+export * from './priceImpactAmount';
 export * from './removeLiquidity';
 export * from './swap';
 export * from './slippage';


### PR DESCRIPTION
We need `PriceImpactAmount` in the consumers to get the return type of `PriceImpact.addLiquidityUnbalanced` but I noticed that it was not exposed. 