### PR TITLE
chore: Explicit lodash.clonedeep import and small DX improvements

### DIFF
--- a/.changeset/strong-pandas-tie.md
+++ b/.changeset/strong-pandas-tie.md
@@ -1,0 +1,5 @@
+---
+"@balancer/sdk": patch
+---
+
+Fix cloneDeep import

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "dependencies": {
         "async-retry": "^1.3.3",
         "decimal.js-light": "^2.5.1",
-        "lodash": "^4.17.21",
+        "lodash.clonedeep": "^4.5.0",
         "pino": "^8.17.2",
         "viem": "^2.1.1"
     },
@@ -39,7 +39,7 @@
         "@biomejs/biome": "^1.5.2",
         "@changesets/cli": "^2.27.1",
         "@types/async-retry": "^1.4.8",
-        "@types/lodash": "^4.14.202",
+        "@types/lodash.clonedeep": "^4.5.9",
         "@types/node": "^18.19.7",
         "@viem/anvil": "^0.0.6",
         "dotenv": "^16.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,9 @@ dependencies:
   decimal.js-light:
     specifier: ^2.5.1
     version: 2.5.1
-  lodash:
-    specifier: ^4.17.21
-    version: 4.17.21
+  lodash.clonedeep:
+    specifier: ^4.5.0
+    version: 4.5.0
   pino:
     specifier: ^8.17.2
     version: 8.17.2
@@ -31,9 +31,9 @@ devDependencies:
   '@types/async-retry':
     specifier: ^1.4.8
     version: 1.4.8
-  '@types/lodash':
-    specifier: ^4.14.202
-    version: 4.14.202
+  '@types/lodash.clonedeep':
+    specifier: ^4.5.9
+    version: 4.5.9
   '@types/node':
     specifier: ^18.19.7
     version: 18.19.7
@@ -1052,6 +1052,12 @@ packages:
 
   /@types/estree@1.0.5:
     resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
+    dev: true
+
+  /@types/lodash.clonedeep@4.5.9:
+    resolution: {integrity: sha512-19429mWC+FyaAhOLzsS8kZUsI+/GmBAQ0HFiCPsKGU+7pBXOQWhyrY6xNNDwUSX8SMZMJvuFVMF9O5dQOlQK9Q==}
+    dependencies:
+      '@types/lodash': 4.14.202
     dev: true
 
   /@types/lodash@4.14.202:
@@ -2545,6 +2551,10 @@ packages:
       p-locate: 5.0.0
     dev: true
 
+  /lodash.clonedeep@4.5.0:
+    resolution: {integrity: sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==}
+    dev: false
+
   /lodash.sortby@4.7.0:
     resolution: {integrity: sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==}
     dev: true
@@ -2552,10 +2562,6 @@ packages:
   /lodash.startcase@4.4.0:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
     dev: true
-
-  /lodash@4.17.21:
-    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
-    dev: false
 
   /log-symbols@4.1.0:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}

--- a/src/entities/addLiquidity/addLiquidityV2/index.ts
+++ b/src/entities/addLiquidity/addLiquidityV2/index.ts
@@ -30,7 +30,7 @@ export class AddLiquidityV2 implements AddLiquidityBase {
 
     public getAddLiquidity(poolType: string): AddLiquidityBase {
         if (!this.addLiquidityTypes[poolType]) {
-            throw new Error('Unsupported pool type');
+            throw new Error(`Unsupported pool type ${poolType}`);
         }
         return this.addLiquidityTypes[poolType];
     }

--- a/src/entities/inputValidator/inputValidator.ts
+++ b/src/entities/inputValidator/inputValidator.ts
@@ -23,7 +23,7 @@ export class InputValidator {
 
     getValidator(poolType: string): InputValidatorBase {
         if (!this.validators[poolType])
-            throw new Error('This Pool type does not have a validator');
+            throw new Error(`Pool type ${poolType} does not have a validator`);
         return this.validators[poolType];
     }
 

--- a/src/entities/removeLiquidity/removeLiquidityV2/index.ts
+++ b/src/entities/removeLiquidity/removeLiquidityV2/index.ts
@@ -31,7 +31,7 @@ export class RemoveLiquidityV2 implements RemoveLiquidityBase {
 
     public getRemoveLiquidity(poolType: string): RemoveLiquidityBase {
         if (!this.removeLiquidityTypes[poolType]) {
-            throw new Error('Unsupported pool type');
+            throw new Error(`Unsupported pool type ${poolType}`);
         }
 
         return this.removeLiquidityTypes[poolType];

--- a/src/entities/swap.ts
+++ b/src/entities/swap.ts
@@ -19,7 +19,8 @@ import {
 } from 'viem';
 import { balancerQueriesAbi } from '../abi';
 import { PriceImpactAmount } from './priceImpactAmount';
-import cloneDeep from 'lodash/cloneDeep';
+import cloneDeep from 'lodash.clonedeep'
+
 
 // A Swap can be a single or multiple paths
 export class Swap {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,3 +2,4 @@ export * from './constants';
 export * from './helpers';
 export * from './math';
 export * from './pool';
+export * from './poolTypeMapper';


### PR DESCRIPTION
- Use explicit `lodash.clonedeep` import to fix error when integrating with v0.7.0 
- It also avoids the whole lodash package in dependencies 
- Minor DX improvements in pool type error handling
- Exposes `poolTypeMapper`