### PR TITLE
fix: add GYRO type for GYRO2 in pool type mapper

### DIFF
--- a/.changeset/many-eyes-do.md
+++ b/.changeset/many-eyes-do.md
@@ -1,0 +1,5 @@
+---
+"@balancer/sdk": patch
+---
+
+add GYRO type for GYRO2 in pool type mapper

--- a/src/utils/poolTypeMapper.ts
+++ b/src/utils/poolTypeMapper.ts
@@ -4,8 +4,9 @@ import { PoolType } from '../types';
 const poolTypeMap = {
     WEIGHTED: PoolType.Weighted,
     COMPOSABLE_STABLE: PoolType.ComposableStable,
-    GYRO3: PoolType.Gyro3,
+    GYRO: PoolType.Gyro2,
     GYRO2: PoolType.Gyro2,
+    GYRO3: PoolType.Gyro3,
     GYROE: PoolType.GyroE,
 };
 


### PR DESCRIPTION
Fixes an issue when mapping pools of type `GYRO2` that have `GYRO` type (without trailing `2`) in the [schema generated from the API](https://github.com/balancer/frontend-v3/blob/c2356b6fa9eb2cb95457697f7332fc2fa81731d9/lib/shared/services/api/generated/graphql.ts#L905).

