### PR TITLE
Refactor Remove Liquidity types

### DIFF
--- a/.changeset/curly-shrimps-jog.md
+++ b/.changeset/curly-shrimps-jog.md
@@ -1,0 +1,5 @@
+---
+"@balancer/sdk": minor
+---
+
+Rename buildCall interface for consistency and clarity

--- a/examples/removeLiquidityNested.ts
+++ b/examples/removeLiquidityNested.ts
@@ -89,18 +89,18 @@ const removeLiquidityNested = async () => {
         client,
     );
 
-    const receiveNativeAsset = false;
+    const wethIsEth = false;
 
     const { call, to, minAmountsOut } = removeLiquidityNested.buildCall({
         ...queryOutput,
         slippage,
         accountAddress,
         relayerApprovalSignature: signature,
-        receiveNativeAsset,
+        wethIsEth,
     });
 
     let tokensOut = queryOutput.amountsOut.map((a) => a.token);
-    if (receiveNativeAsset) {
+    if (wethIsEth) {
         tokensOut = replaceWrapped(tokensOut, chainId);
     }
 

--- a/src/entities/addLiquidity/addLiquidityV2/composableStable/addLiquidityComposableStable.ts
+++ b/src/entities/addLiquidity/addLiquidityV2/composableStable/addLiquidityComposableStable.ts
@@ -20,7 +20,7 @@ import {
     parseAddLiquidityArgs,
 } from '@/entities/utils';
 import { ComposableStableEncoder } from '@/entities/encoders/composableStable';
-import { getValue } from '../../helpers';
+import { getValue } from '../../../utils/getValue';
 import {
     AddLiquidityV2ComposableStableBuildCallInput,
     AddLiquidityV2ComposableStableQueryOutput,
@@ -110,7 +110,7 @@ export class AddLiquidityComposableStable implements AddLiquidityBase {
         return {
             call,
             to: VAULT[input.chainId],
-            value: getValue(input),
+            value: getValue(input.amountsIn, !!input.wethIsEth),
             minBptOut: TokenAmount.fromRawAmount(
                 input.bptOut.token,
                 amounts.minimumBpt,

--- a/src/entities/addLiquidity/addLiquidityV2/composableStable/addLiquidityComposableStable.ts
+++ b/src/entities/addLiquidity/addLiquidityV2/composableStable/addLiquidityComposableStable.ts
@@ -5,7 +5,7 @@ import { VAULT, MAX_UINT256, ZERO_ADDRESS } from '@/utils';
 import { vaultV2Abi } from '@/abi';
 import {
     AddLiquidityBase,
-    AddLiquidityBuildOutput,
+    AddLiquidityBuildCallOutput,
     AddLiquidityInput,
     AddLiquidityKind,
 } from '@/entities/addLiquidity/types';
@@ -22,7 +22,7 @@ import {
 import { ComposableStableEncoder } from '@/entities/encoders/composableStable';
 import { getValue } from '../../helpers';
 import {
-    AddLiquidityV2ComposableStableCall,
+    AddLiquidityV2ComposableStableBuildCallInput,
     AddLiquidityV2ComposableStableQueryOutput,
 } from './types';
 
@@ -83,8 +83,8 @@ export class AddLiquidityComposableStable implements AddLiquidityBase {
     }
 
     public buildCall(
-        input: AddLiquidityV2ComposableStableCall,
-    ): AddLiquidityBuildOutput {
+        input: AddLiquidityV2ComposableStableBuildCallInput,
+    ): AddLiquidityBuildCallOutput {
         const amounts = this.getAmountsCall(input);
 
         const userData = ComposableStableEncoder.encodeAddLiquidityUserData(
@@ -175,7 +175,7 @@ export class AddLiquidityComposableStable implements AddLiquidityBase {
     }
 
     private getAmountsCall(
-        input: AddLiquidityV2ComposableStableCall,
+        input: AddLiquidityV2ComposableStableBuildCallInput,
     ): AddLiquidityAmounts {
         let addLiquidityAmounts: AddLiquidityAmountsBase;
         switch (input.addLiquidityKind) {

--- a/src/entities/addLiquidity/addLiquidityV2/composableStable/types.ts
+++ b/src/entities/addLiquidity/addLiquidityV2/composableStable/types.ts
@@ -1,5 +1,5 @@
 import {
-    AddLiquidityV2BaseCall,
+    AddLiquidityV2BaseBuildCallInput,
     AddLiquidityV2BaseQueryOutput,
 } from '../types';
 
@@ -8,5 +8,6 @@ export type AddLiquidityV2ComposableStableQueryOutput =
         bptIndex: number;
     };
 
-export type AddLiquidityV2ComposableStableCall = AddLiquidityV2BaseCall &
-    AddLiquidityV2ComposableStableQueryOutput;
+export type AddLiquidityV2ComposableStableBuildCallInput =
+    AddLiquidityV2BaseBuildCallInput &
+        AddLiquidityV2ComposableStableQueryOutput;

--- a/src/entities/addLiquidity/addLiquidityV2/index.ts
+++ b/src/entities/addLiquidity/addLiquidityV2/index.ts
@@ -1,6 +1,6 @@
 import {
     AddLiquidityBase,
-    AddLiquidityBuildOutput,
+    AddLiquidityBuildCallOutput,
     AddLiquidityConfig,
     AddLiquidityInput,
     AddLiquidityQueryOutput,
@@ -8,7 +8,7 @@ import {
 } from '../..';
 import { PoolType } from '../../../types';
 import { AddLiquidityComposableStable } from './composableStable/addLiquidityComposableStable';
-import { AddLiquidityV2Call } from './types';
+import { AddLiquidityV2BuildCallInput } from './types';
 import { AddLiquidityWeighted } from './weighted/addLiquidityWeighted';
 
 export class AddLiquidityV2 implements AddLiquidityBase {
@@ -42,7 +42,9 @@ export class AddLiquidityV2 implements AddLiquidityBase {
         return this.getAddLiquidity(poolState.type).query(input, poolState);
     }
 
-    public buildCall(input: AddLiquidityV2Call): AddLiquidityBuildOutput {
+    public buildCall(
+        input: AddLiquidityV2BuildCallInput,
+    ): AddLiquidityBuildCallOutput {
         return this.getAddLiquidity(input.poolType).buildCall(input);
     }
 }

--- a/src/entities/addLiquidity/addLiquidityV2/types.ts
+++ b/src/entities/addLiquidity/addLiquidityV2/types.ts
@@ -1,4 +1,4 @@
-import { Address } from 'viem';
+import { Address } from '@/types';
 import {
     AddLiquidityBaseBuildCallInput,
     AddLiquidityBaseQueryOutput,
@@ -23,6 +23,6 @@ export type AddLiquidityV2BaseQueryOutput = AddLiquidityBaseQueryOutput & {
     vaultVersion: 2;
 };
 
-export type AddLiqudityV2QueryOutput =
+export type AddLiquidityV2QueryOutput =
     | AddLiquidityV2BaseQueryOutput
     | AddLiquidityV2ComposableStableQueryOutput;

--- a/src/entities/addLiquidity/addLiquidityV2/types.ts
+++ b/src/entities/addLiquidity/addLiquidityV2/types.ts
@@ -1,19 +1,23 @@
 import { Address } from 'viem';
-import { AddLiquidityBaseCall, AddLiquidityBaseQueryOutput } from '../types';
 import {
-    AddLiquidityV2ComposableStableCall,
+    AddLiquidityBaseBuildCallInput,
+    AddLiquidityBaseQueryOutput,
+} from '../types';
+import {
+    AddLiquidityV2ComposableStableBuildCallInput,
     AddLiquidityV2ComposableStableQueryOutput,
 } from './composableStable/types';
 
-export type AddLiquidityV2BaseCall = AddLiquidityBaseCall & {
-    fromInternalBalance?: boolean;
-    sender: Address;
-    recipient: Address;
-};
+export type AddLiquidityV2BaseBuildCallInput =
+    AddLiquidityBaseBuildCallInput & {
+        fromInternalBalance?: boolean;
+        sender: Address;
+        recipient: Address;
+    };
 
-export type AddLiquidityV2Call =
-    | AddLiquidityV2BaseCall
-    | AddLiquidityV2ComposableStableCall;
+export type AddLiquidityV2BuildCallInput =
+    | AddLiquidityV2BaseBuildCallInput
+    | AddLiquidityV2ComposableStableBuildCallInput;
 
 export type AddLiquidityV2BaseQueryOutput = AddLiquidityBaseQueryOutput & {
     vaultVersion: 2;

--- a/src/entities/addLiquidity/addLiquidityV2/weighted/addLiquidityWeighted.ts
+++ b/src/entities/addLiquidity/addLiquidityV2/weighted/addLiquidityWeighted.ts
@@ -44,7 +44,6 @@ export class AddLiquidityWeighted implements AddLiquidityBase {
             recipient: ZERO_ADDRESS,
             maxAmountsIn: amounts.maxAmountsIn,
             userData,
-            fromInternalBalance: false, // This isn't required for the query
         });
 
         const queryOutput = await doAddLiquidityQuery(

--- a/src/entities/addLiquidity/addLiquidityV2/weighted/addLiquidityWeighted.ts
+++ b/src/entities/addLiquidity/addLiquidityV2/weighted/addLiquidityWeighted.ts
@@ -17,7 +17,8 @@ import {
     getSortedTokens,
     parseAddLiquidityArgs,
 } from '@/entities/utils';
-import { getAmountsCall, getValue } from '../../helpers';
+import { getAmountsCall } from '../../helpers';
+import { getValue } from '../../../utils/getValue';
 import {
     AddLiquidityV2BaseBuildCallInput,
     AddLiquidityV2BaseQueryOutput,
@@ -98,7 +99,7 @@ export class AddLiquidityWeighted implements AddLiquidityBase {
         return {
             call,
             to: VAULT[input.chainId],
-            value: getValue(input),
+            value: getValue(input.amountsIn, !!input.wethIsEth),
             minBptOut: TokenAmount.fromRawAmount(
                 input.bptOut.token,
                 amounts.minimumBpt,

--- a/src/entities/addLiquidity/addLiquidityV2/weighted/addLiquidityWeighted.ts
+++ b/src/entities/addLiquidity/addLiquidityV2/weighted/addLiquidityWeighted.ts
@@ -6,7 +6,7 @@ import { VAULT, MAX_UINT256, ZERO_ADDRESS } from '@/utils';
 import { vaultV2Abi } from '@/abi';
 import {
     AddLiquidityBase,
-    AddLiquidityBuildOutput,
+    AddLiquidityBuildCallOutput,
     AddLiquidityInput,
     AddLiquidityKind,
 } from '@/entities/addLiquidity/types';
@@ -19,7 +19,7 @@ import {
 } from '@/entities/utils';
 import { getAmountsCall, getValue } from '../../helpers';
 import {
-    AddLiquidityV2BaseCall,
+    AddLiquidityV2BaseBuildCallInput,
     AddLiquidityV2BaseQueryOutput,
 } from '../types';
 
@@ -71,7 +71,9 @@ export class AddLiquidityWeighted implements AddLiquidityBase {
         };
     }
 
-    public buildCall(input: AddLiquidityV2BaseCall): AddLiquidityBuildOutput {
+    public buildCall(
+        input: AddLiquidityV2BaseBuildCallInput,
+    ): AddLiquidityBuildCallOutput {
         const amounts = getAmountsCall(input);
 
         const userData = WeightedEncoder.encodeAddLiquidityUserData(

--- a/src/entities/addLiquidity/addLiquidityV3/index.ts
+++ b/src/entities/addLiquidity/addLiquidityV3/index.ts
@@ -7,7 +7,6 @@ import { getAmounts, getSortedTokens } from '@/entities/utils';
 import { Hex } from '@/types';
 import {
     BALANCER_ROUTER,
-    NATIVE_ASSETS,
     addLiquidityProportionalUnavailableError,
     addLiquiditySingleTokenShouldHaveTokenInIndexError,
 } from '@/utils';
@@ -23,6 +22,7 @@ import {
 } from '../types';
 import { doAddLiquidityUnbalancedQuery } from './doAddLiquidityUnbalancedQuery';
 import { doAddLiquiditySingleTokenQuery } from './doAddLiquiditySingleTokenQuery';
+import { getValue } from '@/entities/utils/getValue';
 
 export class AddLiquidityV3 implements AddLiquidityBase {
     async query(
@@ -131,23 +131,10 @@ export class AddLiquidityV3 implements AddLiquidityBase {
                 break;
         }
 
-        let value = 0n;
-        if (input.wethIsEth) {
-            const wrappedNativeAssetInput = input.amountsIn.find(
-                (a) => a.token.address === NATIVE_ASSETS[input.chainId].wrapped,
-            );
-            if (wrappedNativeAssetInput === undefined) {
-                throw new Error(
-                    'wethIsEth requires wrapped native asset as input',
-                );
-            }
-            value = wrappedNativeAssetInput.amount;
-        }
-
         return {
             call,
             to: BALANCER_ROUTER[input.chainId],
-            value,
+            value: getValue(input.amountsIn, !!input.wethIsEth),
             minBptOut: TokenAmount.fromRawAmount(
                 input.bptOut.token,
                 amounts.minimumBpt,

--- a/src/entities/addLiquidity/addLiquidityV3/index.ts
+++ b/src/entities/addLiquidity/addLiquidityV3/index.ts
@@ -15,9 +15,9 @@ import {
 import { getAmountsCall } from '../helpers';
 import {
     AddLiquidityBase,
-    AddLiquidityBaseCall,
+    AddLiquidityBaseBuildCallInput,
     AddLiquidityBaseQueryOutput,
-    AddLiquidityBuildOutput,
+    AddLiquidityBuildCallOutput,
     AddLiquidityInput,
     AddLiquidityKind,
 } from '../types';
@@ -86,7 +86,9 @@ export class AddLiquidityV3 implements AddLiquidityBase {
         return output;
     }
 
-    buildCall(input: AddLiquidityBaseCall): AddLiquidityBuildOutput {
+    buildCall(
+        input: AddLiquidityBaseBuildCallInput,
+    ): AddLiquidityBuildCallOutput {
         const amounts = getAmountsCall(input);
         let call: Hex;
         switch (input.addLiquidityKind) {

--- a/src/entities/addLiquidity/helpers.ts
+++ b/src/entities/addLiquidity/helpers.ts
@@ -1,4 +1,3 @@
-import { NATIVE_ASSETS } from '@/utils';
 import { AddLiquidityAmounts } from '../types';
 import { AddLiquidityBaseBuildCallInput, AddLiquidityKind } from './types';
 
@@ -25,15 +24,4 @@ export const getAmountsCall = (
             };
         }
     }
-};
-
-export const getValue = (input: AddLiquidityBaseBuildCallInput): bigint => {
-    let value = 0n;
-    if (input.wethIsEth) {
-        value =
-            input.amountsIn.find(
-                (a) => a.token.address === NATIVE_ASSETS[input.chainId].wrapped,
-            )?.amount ?? 0n;
-    }
-    return value;
 };

--- a/src/entities/addLiquidity/helpers.ts
+++ b/src/entities/addLiquidity/helpers.ts
@@ -1,9 +1,9 @@
 import { NATIVE_ASSETS } from '@/utils';
 import { AddLiquidityAmounts } from '../types';
-import { AddLiquidityBaseCall, AddLiquidityKind } from './types';
+import { AddLiquidityBaseBuildCallInput, AddLiquidityKind } from './types';
 
 export const getAmountsCall = (
-    input: AddLiquidityBaseCall,
+    input: AddLiquidityBaseBuildCallInput,
 ): AddLiquidityAmounts => {
     switch (input.addLiquidityKind) {
         case AddLiquidityKind.Unbalanced: {
@@ -27,7 +27,7 @@ export const getAmountsCall = (
     }
 };
 
-export const getValue = (input: AddLiquidityBaseCall): bigint => {
+export const getValue = (input: AddLiquidityBaseBuildCallInput): bigint => {
     let value = 0n;
     if (input.wethIsEth) {
         value =

--- a/src/entities/addLiquidity/index.ts
+++ b/src/entities/addLiquidity/index.ts
@@ -1,9 +1,9 @@
 import {
     AddLiquidityBase,
-    AddLiquidityBuildOutput,
+    AddLiquidityBuildCallOutput,
     AddLiquidityInput,
     AddLiquidityQueryOutput,
-    AddLiquidityCall,
+    AddLiquidityBuildCallInput,
     AddLiquidityConfig,
 } from './types';
 import { PoolState } from '../types';
@@ -32,7 +32,7 @@ export class AddLiquidity implements AddLiquidityBase {
         }
     }
 
-    buildCall(input: AddLiquidityCall): AddLiquidityBuildOutput {
+    buildCall(input: AddLiquidityBuildCallInput): AddLiquidityBuildCallOutput {
         if (input.vaultVersion === 2 && 'sender' in input) {
             const addLiquidity = new AddLiquidityV2(this.config);
             return addLiquidity.buildCall(input);

--- a/src/entities/addLiquidity/types.ts
+++ b/src/entities/addLiquidity/types.ts
@@ -3,7 +3,7 @@ import { Slippage } from '../slippage';
 import { PoolState } from '../types';
 import { Address, Hex, InputAmount } from '../../types';
 import {
-    AddLiquidityV2Call,
+    AddLiquidityV2BuildCallInput,
     AddLiqudityV2QueryOutput,
 } from './addLiquidityV2/types';
 
@@ -54,23 +54,25 @@ export type AddLiquidityQueryOutput =
     | AddLiquidityBaseQueryOutput
     | AddLiqudityV2QueryOutput;
 
-export type AddLiquidityBaseCall = {
+export type AddLiquidityBaseBuildCallInput = {
     slippage: Slippage;
     chainId: number;
     wethIsEth?: boolean;
 } & AddLiquidityBaseQueryOutput;
 
-export type AddLiquidityCall = AddLiquidityBaseCall | AddLiquidityV2Call;
+export type AddLiquidityBuildCallInput =
+    | AddLiquidityBaseBuildCallInput
+    | AddLiquidityV2BuildCallInput;
 
 export interface AddLiquidityBase {
     query(
         input: AddLiquidityInput,
         poolState: PoolState,
     ): Promise<AddLiquidityQueryOutput>;
-    buildCall(input: AddLiquidityCall): AddLiquidityBuildOutput;
+    buildCall(input: AddLiquidityBuildCallInput): AddLiquidityBuildCallOutput;
 }
 
-export type AddLiquidityBuildOutput = {
+export type AddLiquidityBuildCallOutput = {
     call: Hex;
     to: Address;
     value: bigint;

--- a/src/entities/addLiquidity/types.ts
+++ b/src/entities/addLiquidity/types.ts
@@ -4,7 +4,7 @@ import { PoolState } from '../types';
 import { Address, Hex, InputAmount } from '../../types';
 import {
     AddLiquidityV2BuildCallInput,
-    AddLiqudityV2QueryOutput,
+    AddLiquidityV2QueryOutput,
 } from './addLiquidityV2/types';
 
 export enum AddLiquidityKind {
@@ -52,7 +52,7 @@ export type AddLiquidityBaseQueryOutput = {
 
 export type AddLiquidityQueryOutput =
     | AddLiquidityBaseQueryOutput
-    | AddLiqudityV2QueryOutput;
+    | AddLiquidityV2QueryOutput;
 
 export type AddLiquidityBaseBuildCallInput = {
     slippage: Slippage;

--- a/src/entities/addLiquidityNested/encodeCalls.ts
+++ b/src/entities/addLiquidityNested/encodeCalls.ts
@@ -1,11 +1,12 @@
 import { Hex, PoolType } from '../../types';
-import { ZERO_ADDRESS } from '../../utils';
 import { WeightedEncoder } from '../encoders';
 import { ComposableStableEncoder } from '../encoders/composableStable';
 import { AddLiquidityNestedCallAttributes } from './types';
 import { replaceWrapped } from '../utils/replaceWrapped';
 import { batchRelayerLibraryAbi } from '../../abi';
 import { encodeFunctionData } from 'viem';
+import { TokenAmount } from '../tokenAmount';
+import { getValue } from '../utils/getValue';
 
 export const encodeCalls = (
     callsAttributes: AddLiquidityNestedCallAttributes[],
@@ -30,18 +31,14 @@ export const encodeCalls = (
         } = callAttributes;
 
         // replace wrapped token with native asset if needed
-        let tokensIn = [...sortedTokens];
+        const tokensIn = wethIsEth
+            ? replaceWrapped([...sortedTokens], chainId)
+            : [...sortedTokens];
 
-        let value = 0n;
-        if (wethIsEth) {
-            tokensIn = replaceWrapped([...sortedTokens], chainId);
-            const nativeAssetIndex = tokensIn.findIndex((t) =>
-                t.isSameAddress(ZERO_ADDRESS),
-            );
-            if (nativeAssetIndex > -1) {
-                value = maxAmountsIn[nativeAssetIndex].amount;
-            }
-        }
+        const amountsIn = [...sortedTokens].map((t, i) => {
+            return TokenAmount.fromRawAmount(t, maxAmountsIn[i].amount);
+        });
+        const value = getValue(amountsIn, !!wethIsEth);
 
         const _maxAmountsIn = maxAmountsIn.map((a) => a.amount);
         const amountsInWithoutBpt = _maxAmountsIn.filter(

--- a/src/entities/addLiquidityNested/index.ts
+++ b/src/entities/addLiquidityNested/index.ts
@@ -76,7 +76,7 @@ export class AddLiquidityNested {
             minBptOut,
         };
 
-        // update sendNativeAsset flag + sender and recipient placeholders
+        // update wethIsEth flag + sender and recipient placeholders
         input.callsAttributes = input.callsAttributes.map((call) => {
             return {
                 ...call,

--- a/src/entities/initPool/initPoolV2/weighted/initPoolWeighted.ts
+++ b/src/entities/initPool/initPoolV2/weighted/initPoolWeighted.ts
@@ -5,7 +5,7 @@ import {
     InitPoolBuildOutput,
     InitPoolInputV2,
 } from '../../types';
-import { VAULT, ZERO_ADDRESS } from '../../../../utils';
+import { VAULT } from '../../../../utils';
 import { vaultV2Abi } from '../../../../abi';
 import {
     getAmounts,
@@ -14,6 +14,8 @@ import {
 } from '../../../utils';
 import { Token } from '../../../token';
 import { WeightedEncoder } from '../../../encoders';
+import { TokenAmount } from '@/entities/tokenAmount';
+import { getValue } from '@/entities/utils/getValue';
 
 export class InitPoolWeighted implements InitPoolBase {
     buildCall(
@@ -38,14 +40,15 @@ export class InitPoolWeighted implements InitPoolBase {
             args,
         });
 
-        const value = input.amountsIn.find(
-            (a) => a.address === ZERO_ADDRESS,
-        )?.rawAmount;
+        const amountsIn = input.amountsIn.map((a) => {
+            const token = new Token(input.chainId, a.address, a.decimals);
+            return TokenAmount.fromRawAmount(token, a.rawAmount);
+        });
 
         return {
             call,
             to: VAULT[input.chainId] as Address,
-            value: value === undefined ? 0n : value,
+            value: getValue(amountsIn, !!input.wethIsEth),
         };
     }
 

--- a/src/entities/initPool/types.ts
+++ b/src/entities/initPool/types.ts
@@ -1,7 +1,7 @@
 import { Address, Hex } from 'viem';
 import {
     AddLiquidityBaseInput,
-    AddLiquidityBuildOutput,
+    AddLiquidityBuildCallOutput,
 } from '../addLiquidity/types';
 import { InputAmount } from '../../types';
 import { PoolState } from '../types';
@@ -11,7 +11,7 @@ export interface InitPoolBase {
 }
 
 export type InitPoolBuildOutput = Omit<
-    AddLiquidityBuildOutput,
+    AddLiquidityBuildCallOutput,
     'minBptOut' | 'maxAmountsIn'
 >;
 

--- a/src/entities/initPool/types.ts
+++ b/src/entities/initPool/types.ts
@@ -1,8 +1,4 @@
 import { Address, Hex } from 'viem';
-import {
-    AddLiquidityBaseInput,
-    AddLiquidityBuildCallOutput,
-} from '../addLiquidity/types';
 import { InputAmount } from '../../types';
 import { PoolState } from '../types';
 
@@ -10,26 +6,28 @@ export interface InitPoolBase {
     buildCall(input: InitPoolInput, poolState: PoolState): InitPoolBuildOutput;
 }
 
-export type InitPoolBuildOutput = Omit<
-    AddLiquidityBuildCallOutput,
-    'minBptOut' | 'maxAmountsIn'
->;
+export type InitPoolBuildOutput = {
+    call: Hex;
+    to: Address;
+    value: bigint;
+};
 
 export type InitPoolInput = InitPoolInputV2 | InitPoolInputV3;
 
-export type InitPoolInputV2 = Omit<AddLiquidityBaseInput, 'rpcUrl'> & {
-    sender: Address;
-    recipient: Address;
+type InitBaseInput = {
     amountsIn: InputAmount[];
     chainId: number;
+    wethIsEth?: boolean;
+};
+
+export type InitPoolInputV2 = InitBaseInput & {
+    sender: Address;
+    recipient: Address;
     fromInternalBalance?: boolean;
 };
 
-export type InitPoolInputV3 = {
-    amountsIn: InputAmount[];
+export type InitPoolInputV3 = InitBaseInput & {
     minBptAmountOut: bigint;
-    wethIsEth?: boolean;
-    chainId: number;
 };
 
 export type InitPoolConfig = {

--- a/src/entities/removeLiquidity/helper.ts
+++ b/src/entities/removeLiquidity/helper.ts
@@ -6,7 +6,7 @@ import { Token } from '../token';
 import { RemoveLiquidityAmounts } from '../types';
 import { getAmounts } from '../utils';
 import {
-    RemoveLiquidityCall,
+    RemoveLiquidityBuildCallInput,
     RemoveLiquidityInput,
     RemoveLiquidityKind,
 } from './types';
@@ -49,7 +49,7 @@ export const getAmountsQuery = (
 };
 
 export const getAmountsCall = (
-    input: RemoveLiquidityCall,
+    input: RemoveLiquidityBuildCallInput,
 ): RemoveLiquidityAmounts => {
     switch (input.removeLiquidityKind) {
         case RemoveLiquidityKind.Unbalanced:

--- a/src/entities/removeLiquidity/index.ts
+++ b/src/entities/removeLiquidity/index.ts
@@ -1,7 +1,7 @@
 import {
     RemoveLiquidityBase,
-    RemoveLiquidityBuildOutput,
-    RemoveLiquidityCall,
+    RemoveLiquidityBuildCallOutput,
+    RemoveLiquidityBuildCallInput,
     RemoveLiquidityConfig,
     RemoveLiquidityInput,
     RemoveLiquidityQueryOutput,
@@ -33,7 +33,9 @@ export class RemoveLiquidity implements RemoveLiquidityBase {
         }
     }
 
-    public buildCall(input: RemoveLiquidityCall): RemoveLiquidityBuildOutput {
+    public buildCall(
+        input: RemoveLiquidityBuildCallInput,
+    ): RemoveLiquidityBuildCallOutput {
         // TODO: refactor validators to take v3 into account
         const isV2Input = 'sender' in input;
         if (input.vaultVersion === 3 && isV2Input)

--- a/src/entities/removeLiquidity/removeLiquidityV2/composableStable/removeLiquidityComposableStable.ts
+++ b/src/entities/removeLiquidity/removeLiquidityV2/composableStable/removeLiquidityComposableStable.ts
@@ -51,7 +51,6 @@ export class RemoveLiquidityComposableStable implements RemoveLiquidityBase {
             recipient: ZERO_ADDRESS,
             minAmountsOut: amounts.minAmountsOut,
             userData,
-            toInternalBalance: !!input.toInternalBalance,
         });
         const queryOutput = await doRemoveLiquidityQuery(
             input.rpcUrl,
@@ -72,7 +71,6 @@ export class RemoveLiquidityComposableStable implements RemoveLiquidityBase {
             bptIn,
             amountsOut,
             tokenOutIndex: amounts.tokenOutIndex,
-            toInternalBalance: !!input.toInternalBalance,
             bptIndex,
             vaultVersion: poolState.vaultVersion,
             chainId: input.chainId,

--- a/src/entities/removeLiquidity/removeLiquidityV2/composableStable/removeLiquidityComposableStable.ts
+++ b/src/entities/removeLiquidity/removeLiquidityV2/composableStable/removeLiquidityComposableStable.ts
@@ -6,12 +6,12 @@ import { vaultV2Abi } from '../../../../abi';
 import { parseRemoveLiquidityArgs } from '../../../utils/parseRemoveLiquidityArgs';
 import {
     RemoveLiquidityBase,
-    RemoveLiquidityComposableStableBuildCallInput,
     RemoveLiquidityBuildCallOutput,
     RemoveLiquidityInput,
     RemoveLiquidityKind,
     RemoveLiquidityQueryOutput,
 } from '../../types';
+import { RemoveLiquidityV2ComposableStableBuildCallInput } from './types';
 import { RemoveLiquidityAmounts, PoolState } from '../../../types';
 import { doRemoveLiquidityQuery } from '../../../utils/doRemoveLiquidityQuery';
 import { ComposableStableEncoder } from '../../../encoders/composableStable';
@@ -120,7 +120,7 @@ export class RemoveLiquidityComposableStable implements RemoveLiquidityBase {
     }
 
     public buildCall(
-        input: RemoveLiquidityComposableStableBuildCallInput,
+        input: RemoveLiquidityV2ComposableStableBuildCallInput,
     ): RemoveLiquidityBuildCallOutput {
         const amounts = this.getAmountsCall(input);
         const amountsWithoutBpt = {
@@ -167,7 +167,7 @@ export class RemoveLiquidityComposableStable implements RemoveLiquidityBase {
     }
 
     private getAmountsCall(
-        input: RemoveLiquidityComposableStableBuildCallInput,
+        input: RemoveLiquidityV2ComposableStableBuildCallInput,
     ): RemoveLiquidityAmounts {
         switch (input.removeLiquidityKind) {
             case RemoveLiquidityKind.Unbalanced:

--- a/src/entities/removeLiquidity/removeLiquidityV2/composableStable/removeLiquidityComposableStable.ts
+++ b/src/entities/removeLiquidity/removeLiquidityV2/composableStable/removeLiquidityComposableStable.ts
@@ -6,8 +6,8 @@ import { vaultV2Abi } from '../../../../abi';
 import { parseRemoveLiquidityArgs } from '../../../utils/parseRemoveLiquidityArgs';
 import {
     RemoveLiquidityBase,
-    RemoveLiquidityComposableStableCall,
-    RemoveLiquidityBuildOutput,
+    RemoveLiquidityComposableStableBuildCallInput,
+    RemoveLiquidityBuildCallOutput,
     RemoveLiquidityInput,
     RemoveLiquidityKind,
     RemoveLiquidityQueryOutput,
@@ -120,8 +120,8 @@ export class RemoveLiquidityComposableStable implements RemoveLiquidityBase {
     }
 
     public buildCall(
-        input: RemoveLiquidityComposableStableCall,
-    ): RemoveLiquidityBuildOutput {
+        input: RemoveLiquidityComposableStableBuildCallInput,
+    ): RemoveLiquidityBuildCallOutput {
         const amounts = this.getAmountsCall(input);
         const amountsWithoutBpt = {
             ...amounts,
@@ -167,7 +167,7 @@ export class RemoveLiquidityComposableStable implements RemoveLiquidityBase {
     }
 
     private getAmountsCall(
-        input: RemoveLiquidityComposableStableCall,
+        input: RemoveLiquidityComposableStableBuildCallInput,
     ): RemoveLiquidityAmounts {
         switch (input.removeLiquidityKind) {
             case RemoveLiquidityKind.Unbalanced:

--- a/src/entities/removeLiquidity/removeLiquidityV2/composableStable/types.ts
+++ b/src/entities/removeLiquidity/removeLiquidityV2/composableStable/types.ts
@@ -1,0 +1,11 @@
+import { RemoveLiquidityBaseQueryOutput } from '../../types';
+import { RemoveLiquidityV2BaseBuildCallInput } from '../types';
+
+export type RemoveLiquidityV2ComposableStableQueryOutput =
+    RemoveLiquidityBaseQueryOutput & {
+        bptIndex: number;
+    };
+
+export type RemoveLiquidityV2ComposableStableBuildCallInput =
+    RemoveLiquidityV2BaseBuildCallInput &
+        RemoveLiquidityV2ComposableStableQueryOutput;

--- a/src/entities/removeLiquidity/removeLiquidityV2/index.ts
+++ b/src/entities/removeLiquidity/removeLiquidityV2/index.ts
@@ -1,8 +1,8 @@
 import {
     PoolState,
     RemoveLiquidityBase,
-    RemoveLiquidityBuildOutput,
-    RemoveLiquidityCall,
+    RemoveLiquidityBuildCallOutput,
+    RemoveLiquidityBuildCallInput,
     RemoveLiquidityConfig,
     RemoveLiquidityInput,
     RemoveLiquidityQueryOutput,
@@ -44,7 +44,9 @@ export class RemoveLiquidityV2 implements RemoveLiquidityBase {
         return this.getRemoveLiquidity(poolState.type).query(input, poolState);
     }
 
-    public buildCall(input: RemoveLiquidityCall): RemoveLiquidityBuildOutput {
+    public buildCall(
+        input: RemoveLiquidityBuildCallInput,
+    ): RemoveLiquidityBuildCallOutput {
         return this.getRemoveLiquidity(input.poolType).buildCall(input);
     }
 }

--- a/src/entities/removeLiquidity/removeLiquidityV2/types.ts
+++ b/src/entities/removeLiquidity/removeLiquidityV2/types.ts
@@ -12,6 +12,7 @@ export type RemoveLiquidityV2BaseBuildCallInput =
     RemoveLiquidityBaseBuildCallInput & {
         sender: Address;
         recipient: Address;
+        toInternalBalance?: boolean;
     };
 
 export type RemoveLiquidityV2BuildCallInput =

--- a/src/entities/removeLiquidity/removeLiquidityV2/types.ts
+++ b/src/entities/removeLiquidity/removeLiquidityV2/types.ts
@@ -1,0 +1,28 @@
+import { Address } from '@/types';
+import {
+    RemoveLiquidityBaseBuildCallInput,
+    RemoveLiquidityBaseQueryOutput,
+} from '../types';
+import {
+    RemoveLiquidityV2ComposableStableBuildCallInput,
+    RemoveLiquidityV2ComposableStableQueryOutput,
+} from './composableStable/types';
+
+export type RemoveLiquidityV2BaseBuildCallInput =
+    RemoveLiquidityBaseBuildCallInput & {
+        sender: Address;
+        recipient: Address;
+    };
+
+export type RemoveLiquidityV2BuildCallInput =
+    | RemoveLiquidityV2BaseBuildCallInput
+    | RemoveLiquidityV2ComposableStableBuildCallInput;
+
+export type RemoveLiquidityV2BaseQueryOutput =
+    RemoveLiquidityBaseQueryOutput & {
+        vaultVersion: 2;
+    };
+
+export type RemoveLiquidityV2QueryOutput =
+    | RemoveLiquidityV2BaseQueryOutput
+    | RemoveLiquidityV2ComposableStableQueryOutput;

--- a/src/entities/removeLiquidity/removeLiquidityV2/weighted/removeLiquidityWeighted.ts
+++ b/src/entities/removeLiquidity/removeLiquidityV2/weighted/removeLiquidityWeighted.ts
@@ -7,11 +7,11 @@ import { vaultV2Abi } from '../../../../abi';
 import { parseRemoveLiquidityArgs } from '../../../utils/parseRemoveLiquidityArgs';
 import {
     RemoveLiquidityBase,
-    RemoveLiquidityBuildOutput,
+    RemoveLiquidityBuildCallOutput,
     RemoveLiquidityInput,
     RemoveLiquidityKind,
     RemoveLiquidityQueryOutput,
-    RemoveLiquidityWeightedCall,
+    RemoveLiquidityWeightedBuildCallInput,
 } from '../../types';
 import { PoolState } from '../../../types';
 import { doRemoveLiquidityQuery } from '../../../utils/doRemoveLiquidityQuery';
@@ -72,8 +72,8 @@ export class RemoveLiquidityWeighted implements RemoveLiquidityBase {
     }
 
     public buildCall(
-        input: RemoveLiquidityWeightedCall,
-    ): RemoveLiquidityBuildOutput {
+        input: RemoveLiquidityWeightedBuildCallInput,
+    ): RemoveLiquidityBuildCallOutput {
         const amounts = getAmountsCall(input);
 
         const userData = WeightedEncoder.encodeRemoveLiquidityUserData(

--- a/src/entities/removeLiquidity/removeLiquidityV2/weighted/removeLiquidityWeighted.ts
+++ b/src/entities/removeLiquidity/removeLiquidityV2/weighted/removeLiquidityWeighted.ts
@@ -11,12 +11,12 @@ import {
     RemoveLiquidityInput,
     RemoveLiquidityKind,
     RemoveLiquidityQueryOutput,
-    RemoveLiquidityWeightedBuildCallInput,
 } from '../../types';
 import { PoolState } from '../../../types';
 import { doRemoveLiquidityQuery } from '../../../utils/doRemoveLiquidityQuery';
 import { getSortedTokens } from '../../../utils';
 import { getAmountsCall, getAmountsQuery } from '../../helper';
+import { RemoveLiquidityV2BaseBuildCallInput } from '../types';
 
 export class RemoveLiquidityWeighted implements RemoveLiquidityBase {
     public async query(
@@ -72,7 +72,7 @@ export class RemoveLiquidityWeighted implements RemoveLiquidityBase {
     }
 
     public buildCall(
-        input: RemoveLiquidityWeightedBuildCallInput,
+        input: RemoveLiquidityV2BaseBuildCallInput,
     ): RemoveLiquidityBuildCallOutput {
         const amounts = getAmountsCall(input);
 

--- a/src/entities/removeLiquidity/removeLiquidityV2/weighted/removeLiquidityWeighted.ts
+++ b/src/entities/removeLiquidity/removeLiquidityV2/weighted/removeLiquidityWeighted.ts
@@ -42,7 +42,6 @@ export class RemoveLiquidityWeighted implements RemoveLiquidityBase {
             recipient: ZERO_ADDRESS,
             minAmountsOut: amounts.minAmountsOut,
             userData,
-            toInternalBalance: !!input.toInternalBalance,
         });
 
         const queryOutput = await doRemoveLiquidityQuery(
@@ -65,7 +64,6 @@ export class RemoveLiquidityWeighted implements RemoveLiquidityBase {
             bptIn,
             amountsOut,
             tokenOutIndex: amounts.tokenOutIndex,
-            toInternalBalance: !!input.toInternalBalance,
             vaultVersion: poolState.vaultVersion,
             chainId: input.chainId,
         };

--- a/src/entities/removeLiquidity/removeLiquidityV3/encodeRemoveLiquidityProportional.ts
+++ b/src/entities/removeLiquidity/removeLiquidityV3/encodeRemoveLiquidityProportional.ts
@@ -1,9 +1,9 @@
 import { encodeFunctionData } from 'viem';
-import { RemoveLiquidityBaseCall } from '../types';
+import { RemoveLiquidityBaseBuildCallInput } from '../types';
 import { balancerRouterAbi } from '@/abi';
 
 export const encodeRemoveLiquidityProportional = (
-    input: RemoveLiquidityBaseCall,
+    input: RemoveLiquidityBaseBuildCallInput,
     minAmountsOut: bigint[],
 ) => {
     return encodeFunctionData({

--- a/src/entities/removeLiquidity/removeLiquidityV3/encodeRemoveLiquiditySingleTokenExactIn.ts
+++ b/src/entities/removeLiquidity/removeLiquidityV3/encodeRemoveLiquiditySingleTokenExactIn.ts
@@ -1,9 +1,9 @@
 import { encodeFunctionData } from 'viem';
-import { RemoveLiquidityBaseCall } from '../types';
+import { RemoveLiquidityBaseBuildCallInput } from '../types';
 import { balancerRouterAbi } from '@/abi';
 
 export const encodeRemoveLiquiditySingleTokenExactIn = (
-    input: RemoveLiquidityBaseCall,
+    input: RemoveLiquidityBaseBuildCallInput,
     minAmountsOut: bigint[],
 ) => {
     // just a sanity check as this is already checked in InputValidator

--- a/src/entities/removeLiquidity/removeLiquidityV3/encodeRemoveLiquiditySingleTokenExactOut.ts
+++ b/src/entities/removeLiquidity/removeLiquidityV3/encodeRemoveLiquiditySingleTokenExactOut.ts
@@ -1,11 +1,11 @@
 import { removeLiquiditySingleTokenExactInShouldHaveTokenOutIndexError } from '@/utils';
-import { RemoveLiquidityBaseCall } from '../types';
+import { RemoveLiquidityBaseBuildCallInput } from '../types';
 import { encodeFunctionData } from 'viem';
 import { balancerRouterAbi } from '@/abi';
 import { Hex } from '@/types';
 
 export const encodeRemoveLiquiditySingleTokenExactOut = (
-    input: RemoveLiquidityBaseCall,
+    input: RemoveLiquidityBaseBuildCallInput,
     maxBptAmountIn: bigint,
 ): Hex => {
     // just a sanity check as this is already checked in InputValidator

--- a/src/entities/removeLiquidity/removeLiquidityV3/index.ts
+++ b/src/entities/removeLiquidity/removeLiquidityV3/index.ts
@@ -11,9 +11,9 @@ import {
 import { getAmountsCall, getAmountsQuery } from '../helper';
 import {
     RemoveLiquidityBase,
-    RemoveLiquidityBaseCall,
+    RemoveLiquidityBaseBuildCallInput,
     RemoveLiquidityBaseQueryOutput,
-    RemoveLiquidityBuildOutput,
+    RemoveLiquidityBuildCallOutput,
     RemoveLiquidityInput,
     RemoveLiquidityKind,
 } from '../types';
@@ -100,8 +100,8 @@ export class RemoveLiquidityV3 implements RemoveLiquidityBase {
     }
 
     public buildCall(
-        input: RemoveLiquidityBaseCall,
-    ): RemoveLiquidityBuildOutput {
+        input: RemoveLiquidityBaseBuildCallInput,
+    ): RemoveLiquidityBuildCallOutput {
         const amounts = getAmountsCall(input);
 
         let call: Hex;

--- a/src/entities/removeLiquidity/removeLiquidityV3/index.ts
+++ b/src/entities/removeLiquidity/removeLiquidityV3/index.ts
@@ -91,7 +91,6 @@ export class RemoveLiquidityV3 implements RemoveLiquidityBase {
                 TokenAmount.fromRawAmount(t, minAmountsOut[i]),
             ),
             tokenOutIndex: amounts.tokenOutIndex,
-            toInternalBalance: !!input.toInternalBalance,
             vaultVersion: poolState.vaultVersion,
             chainId: input.chainId,
         };

--- a/src/entities/removeLiquidity/types.ts
+++ b/src/entities/removeLiquidity/types.ts
@@ -19,7 +19,6 @@ export enum RemoveLiquidityKind {
 export type RemoveLiquidityBaseInput = {
     chainId: number;
     rpcUrl: string;
-    toInternalBalance?: boolean;
 };
 
 export type RemoveLiquidityUnbalancedInput = RemoveLiquidityBaseInput & {
@@ -65,7 +64,6 @@ export type RemoveLiquidityBaseQueryOutput = {
     bptIn: TokenAmount;
     amountsOut: TokenAmount[];
     tokenOutIndex?: number;
-    toInternalBalance: boolean;
     vaultVersion: 2 | 3;
     chainId: number;
 };

--- a/src/entities/removeLiquidity/types.ts
+++ b/src/entities/removeLiquidity/types.ts
@@ -2,6 +2,10 @@ import { TokenAmount } from '../tokenAmount';
 import { Slippage } from '../slippage';
 import { Address, InputAmount } from '../../types';
 import { PoolState } from '../types';
+import {
+    RemoveLiquidityV2BuildCallInput,
+    RemoveLiquidityV2QueryOutput,
+} from './removeLiquidityV2/types';
 
 export enum RemoveLiquidityKind {
     Unbalanced = 'Unbalanced', // exact out
@@ -66,16 +70,9 @@ export type RemoveLiquidityBaseQueryOutput = {
     chainId: number;
 };
 
-export type RemoveLiquidityComposableStableQueryOutput =
-    RemoveLiquidityBaseQueryOutput & {
-        bptIndex: number;
-    };
-export type RemoveLiquidityWeightedQueryOutput = RemoveLiquidityBaseQueryOutput;
-
 export type RemoveLiquidityQueryOutput =
     | RemoveLiquidityBaseQueryOutput
-    | RemoveLiquidityComposableStableQueryOutput
-    | RemoveLiquidityWeightedQueryOutput;
+    | RemoveLiquidityV2QueryOutput;
 
 export type RemoveLiquidityBaseBuildCallInput = {
     slippage: Slippage;
@@ -83,22 +80,9 @@ export type RemoveLiquidityBaseBuildCallInput = {
     wethIsEth?: boolean;
 } & RemoveLiquidityBaseQueryOutput;
 
-export type RemoveLiquidityBaseBuildCallInputV2 =
-    RemoveLiquidityBaseBuildCallInput & {
-        sender: Address;
-        recipient: Address;
-    };
-
-export type RemoveLiquidityComposableStableBuildCallInput =
-    RemoveLiquidityBaseBuildCallInputV2 &
-        RemoveLiquidityComposableStableQueryOutput;
-export type RemoveLiquidityWeightedBuildCallInput =
-    RemoveLiquidityBaseBuildCallInputV2;
-
 export type RemoveLiquidityBuildCallInput =
     | RemoveLiquidityBaseBuildCallInput
-    | RemoveLiquidityComposableStableBuildCallInput
-    | RemoveLiquidityWeightedBuildCallInput;
+    | RemoveLiquidityV2BuildCallInput;
 
 export type RemoveLiquidityBuildCallOutput = {
     call: Address;

--- a/src/entities/removeLiquidity/types.ts
+++ b/src/entities/removeLiquidity/types.ts
@@ -77,27 +77,30 @@ export type RemoveLiquidityQueryOutput =
     | RemoveLiquidityComposableStableQueryOutput
     | RemoveLiquidityWeightedQueryOutput;
 
-export type RemoveLiquidityBaseCall = {
+export type RemoveLiquidityBaseBuildCallInput = {
     slippage: Slippage;
     chainId: number;
     wethIsEth?: boolean;
 } & RemoveLiquidityBaseQueryOutput;
 
-export type RemoveLiquidityBaseCallV2 = RemoveLiquidityBaseCall & {
-    sender: Address;
-    recipient: Address;
-};
+export type RemoveLiquidityBaseBuildCallInputV2 =
+    RemoveLiquidityBaseBuildCallInput & {
+        sender: Address;
+        recipient: Address;
+    };
 
-export type RemoveLiquidityComposableStableCall = RemoveLiquidityBaseCallV2 &
-    RemoveLiquidityComposableStableQueryOutput;
-export type RemoveLiquidityWeightedCall = RemoveLiquidityBaseCallV2;
+export type RemoveLiquidityComposableStableBuildCallInput =
+    RemoveLiquidityBaseBuildCallInputV2 &
+        RemoveLiquidityComposableStableQueryOutput;
+export type RemoveLiquidityWeightedBuildCallInput =
+    RemoveLiquidityBaseBuildCallInputV2;
 
-export type RemoveLiquidityCall =
-    | RemoveLiquidityBaseCall
-    | RemoveLiquidityComposableStableCall
-    | RemoveLiquidityWeightedCall;
+export type RemoveLiquidityBuildCallInput =
+    | RemoveLiquidityBaseBuildCallInput
+    | RemoveLiquidityComposableStableBuildCallInput
+    | RemoveLiquidityWeightedBuildCallInput;
 
-export type RemoveLiquidityBuildOutput = {
+export type RemoveLiquidityBuildCallOutput = {
     call: Address;
     to: Address;
     value: bigint;
@@ -110,7 +113,9 @@ export interface RemoveLiquidityBase {
         input: RemoveLiquidityInput,
         poolState: PoolState,
     ): Promise<RemoveLiquidityQueryOutput>;
-    buildCall(input: RemoveLiquidityCall): RemoveLiquidityBuildOutput;
+    buildCall(
+        input: RemoveLiquidityBuildCallInput,
+    ): RemoveLiquidityBuildCallOutput;
 }
 
 export type RemoveLiquidityConfig = {

--- a/src/entities/utils/getValue.ts
+++ b/src/entities/utils/getValue.ts
@@ -1,0 +1,16 @@
+import { NATIVE_ASSETS } from '@/utils';
+import { TokenAmount } from '../tokenAmount';
+
+export const getValue = (
+    amountsIn: TokenAmount[],
+    wethIsEth: boolean,
+): bigint => {
+    let value = 0n;
+    if (wethIsEth) {
+        value =
+            amountsIn.find((a) =>
+                a.token.isUnderlyingEqual(NATIVE_ASSETS[a.token.chainId]),
+            )?.amount ?? 0n;
+    }
+    return value;
+};

--- a/src/entities/utils/parseAddLiquidityArgs.ts
+++ b/src/entities/utils/parseAddLiquidityArgs.ts
@@ -21,7 +21,7 @@ export function parseAddLiquidityArgs({
     recipient: Address;
     maxAmountsIn: readonly bigint[];
     userData: Hex;
-    fromInternalBalance: boolean;
+    fromInternalBalance?: boolean;
 }) {
     // replace wrapped token with native asset if needed
     const tokensIn =
@@ -33,7 +33,7 @@ export function parseAddLiquidityArgs({
         assets: tokensIn.map((t) => t.address), // with BPT
         maxAmountsIn, // with BPT
         userData, // wihtout BPT
-        fromInternalBalance,
+        fromInternalBalance: !!fromInternalBalance,
     };
 
     return {

--- a/src/entities/utils/parseRemoveLiquidityArgs.ts
+++ b/src/entities/utils/parseRemoveLiquidityArgs.ts
@@ -22,7 +22,7 @@ export function parseRemoveLiquidityArgs({
     recipient: Address;
     minAmountsOut: bigint[];
     userData: Address;
-    toInternalBalance: boolean;
+    toInternalBalance?: boolean;
 }) {
     // replace wrapped token with native asset if needed
     const tokensOut =
@@ -34,7 +34,7 @@ export function parseRemoveLiquidityArgs({
         assets: tokensOut.map((t) => t.address), // with BPT
         minAmountsOut, // with BPT
         userData, // wihtout BPT
-        toInternalBalance,
+        toInternalBalance: !!toInternalBalance,
     };
 
     return {

--- a/test/lib/utils/addLiquidityHelper.ts
+++ b/test/lib/utils/addLiquidityHelper.ts
@@ -1,7 +1,7 @@
 import {
     AddLiquidity,
-    AddLiquidityBuildOutput,
-    AddLiquidityCall,
+    AddLiquidityBuildCallOutput,
+    AddLiquidityBuildCallInput,
     AddLiquidityInput,
     AddLiquidityProportionalInput,
     AddLiquidityQueryOutput,
@@ -21,12 +21,12 @@ import {
 import { getTokensForBalanceCheck } from './getTokensForBalanceCheck';
 import { TxOutput, sendTransactionGetBalances } from './helper';
 import { AddLiquidityTxInput } from './types';
-import { AddLiquidityV2BaseCall } from '@/entities/addLiquidity/addLiquidityV2/types';
+import { AddLiquidityV2BaseBuildCallInput } from '@/entities/addLiquidity/addLiquidityV2/types';
 import { AddLiquidityV2ComposableStableQueryOutput } from '@/entities/addLiquidity/addLiquidityV2/composableStable/types';
 
 type AddLiquidityOutput = {
     addLiquidityQueryOutput: AddLiquidityQueryOutput;
-    addLiquidityBuildOutput: AddLiquidityBuildOutput;
+    addLiquidityBuildCallOutput: AddLiquidityBuildCallOutput;
     txOutput: TxOutput;
 };
 
@@ -45,7 +45,7 @@ async function sdkAddLiquidity({
     testAddress: Address;
     wethIsEth?: boolean;
 }): Promise<{
-    addLiquidityBuildOutput: AddLiquidityBuildOutput;
+    addLiquidityBuildCallOutput: AddLiquidityBuildCallOutput;
     addLiquidityQueryOutput: AddLiquidityQueryOutput;
 }> {
     const addLiquidityQueryOutput = await addLiquidity.query(
@@ -53,14 +53,14 @@ async function sdkAddLiquidity({
         poolState,
     );
 
-    let addLiquidityBuildInput: AddLiquidityCall = {
+    let addLiquidityBuildInput: AddLiquidityBuildCallInput = {
         ...addLiquidityQueryOutput,
         slippage,
         chainId: addLiquidityInput.chainId,
         wethIsEth: !!wethIsEth,
     };
     if (poolState.vaultVersion === 2) {
-        (addLiquidityBuildInput as AddLiquidityV2BaseCall) = {
+        (addLiquidityBuildInput as AddLiquidityV2BaseBuildCallInput) = {
             ...addLiquidityBuildInput,
             sender: testAddress,
             recipient: testAddress,
@@ -68,12 +68,12 @@ async function sdkAddLiquidity({
         };
     }
 
-    const addLiquidityBuildOutput = addLiquidity.buildCall(
+    const addLiquidityBuildCallOutput = addLiquidity.buildCall(
         addLiquidityBuildInput,
     );
 
     return {
-        addLiquidityBuildOutput,
+        addLiquidityBuildCallOutput,
         addLiquidityQueryOutput,
     };
 }
@@ -130,7 +130,7 @@ export async function doAddLiquidity(txInput: AddLiquidityTxInput) {
         wethIsEth,
     } = txInput;
 
-    const { addLiquidityQueryOutput, addLiquidityBuildOutput } =
+    const { addLiquidityQueryOutput, addLiquidityBuildCallOutput } =
         await sdkAddLiquidity({
             addLiquidity,
             addLiquidityInput,
@@ -147,14 +147,14 @@ export async function doAddLiquidity(txInput: AddLiquidityTxInput) {
         tokens,
         client,
         testAddress,
-        addLiquidityBuildOutput.to,
-        addLiquidityBuildOutput.call,
-        addLiquidityBuildOutput.value,
+        addLiquidityBuildCallOutput.to,
+        addLiquidityBuildCallOutput.call,
+        addLiquidityBuildCallOutput.value,
     );
 
     return {
         addLiquidityQueryOutput,
-        addLiquidityBuildOutput,
+        addLiquidityBuildCallOutput,
         txOutput,
     };
 }
@@ -168,7 +168,7 @@ export function assertAddLiquidityUnbalanced(
     vaultVersion: 2 | 3 = 2,
     wethIsEth?: boolean,
 ) {
-    const { txOutput, addLiquidityQueryOutput, addLiquidityBuildOutput } =
+    const { txOutput, addLiquidityQueryOutput, addLiquidityBuildCallOutput } =
         addLiquidityOutput;
 
     // Get an amount for each pool token defaulting to 0 if not provided as input (this will include BPT token if in tokenList)
@@ -203,10 +203,10 @@ export function assertAddLiquidityUnbalanced(
     // Expect some bpt amount
     expect(addLiquidityQueryOutput.bptOut.amount > 0n).to.be.true;
 
-    assertAddLiquidityBuildOutput(
+    assertAddLiquidityBuildCallOutput(
         addLiquidityInput,
         addLiquidityQueryOutput,
-        addLiquidityBuildOutput,
+        addLiquidityBuildCallOutput,
         true,
         slippage,
         vaultVersion,
@@ -217,7 +217,7 @@ export function assertAddLiquidityUnbalanced(
         poolState,
         addLiquidityInput,
         addLiquidityQueryOutput,
-        addLiquidityBuildOutput,
+        addLiquidityBuildCallOutput,
         txOutput,
         wethIsEth,
     );
@@ -232,7 +232,7 @@ export function assertAddLiquiditySingleToken(
     vaultVersion: 2 | 3 = 2,
     wethIsEth?: boolean,
 ) {
-    const { txOutput, addLiquidityQueryOutput, addLiquidityBuildOutput } =
+    const { txOutput, addLiquidityQueryOutput, addLiquidityBuildCallOutput } =
         addLiquidityOutput;
 
     if (addLiquidityQueryOutput.tokenInIndex === undefined)
@@ -277,10 +277,10 @@ export function assertAddLiquiditySingleToken(
         }
     });
 
-    assertAddLiquidityBuildOutput(
+    assertAddLiquidityBuildCallOutput(
         addLiquidityInput,
         addLiquidityQueryOutput,
-        addLiquidityBuildOutput,
+        addLiquidityBuildCallOutput,
         false,
         slippage,
         vaultVersion,
@@ -291,7 +291,7 @@ export function assertAddLiquiditySingleToken(
         poolState,
         addLiquidityInput,
         addLiquidityQueryOutput,
-        addLiquidityBuildOutput,
+        addLiquidityBuildCallOutput,
         txOutput,
         wethIsEth,
     );
@@ -306,7 +306,7 @@ export function assertAddLiquidityProportional(
     vaultVersion: 2 | 3 = 2,
     wethIsEth?: boolean,
 ) {
-    const { txOutput, addLiquidityQueryOutput, addLiquidityBuildOutput } =
+    const { txOutput, addLiquidityQueryOutput, addLiquidityBuildCallOutput } =
         addLiquidityOutput;
 
     const bptToken = new Token(chainId, poolState.address, 18);
@@ -339,10 +339,10 @@ export function assertAddLiquidityProportional(
         else expect(a.amount > 0n).to.be.true;
     });
 
-    assertAddLiquidityBuildOutput(
+    assertAddLiquidityBuildCallOutput(
         addLiquidityInput,
         addLiquidityQueryOutput,
-        addLiquidityBuildOutput,
+        addLiquidityBuildCallOutput,
         false,
         slippage,
         vaultVersion,
@@ -361,7 +361,7 @@ export function assertAddLiquidityProportional(
         poolState,
         addLiquidityInput,
         addLiquidityQueryOutput,
-        addLiquidityBuildOutput,
+        addLiquidityBuildCallOutput,
         txOutput,
         wethIsEth,
     );
@@ -371,7 +371,7 @@ function assertTokenDeltas(
     poolState: PoolState,
     addLiquidityInput: AddLiquidityInput,
     addLiquidityQueryOutput: AddLiquidityQueryOutput,
-    addLiquidityBuildOutput: AddLiquidityBuildOutput,
+    addLiquidityBuildCallOutput: AddLiquidityBuildCallOutput,
     txOutput: TxOutput,
     wethIsEth?: boolean,
 ) {
@@ -403,16 +403,16 @@ function assertTokenDeltas(
         );
         expectedDeltas[nativeAssetIndex] = 0n;
         expectedDeltas[expectedDeltas.length - 1] =
-            addLiquidityBuildOutput.value;
+            addLiquidityBuildCallOutput.value;
     }
 
     expect(txOutput.balanceDeltas).to.deep.eq(expectedDeltas);
 }
 
-function assertAddLiquidityBuildOutput(
+function assertAddLiquidityBuildCallOutput(
     addLiquidityInput: AddLiquidityInput,
     addLiquidityQueryOutput: AddLiquidityQueryOutput,
-    addLiquidityBuildOutput: AddLiquidityBuildOutput,
+    addLiquidityBuildCallOutput: AddLiquidityBuildCallOutput,
     isExactIn: boolean,
     slippage: Slippage,
     vaultVersion: 2 | 3 = 2,
@@ -449,7 +449,7 @@ function assertAddLiquidityBuildOutput(
             )?.amount ?? 0n;
     }
 
-    const expectedBuildOutput: Omit<AddLiquidityBuildOutput, 'call'> = {
+    const expectedBuildOutput: Omit<AddLiquidityBuildCallOutput, 'call'> = {
         maxAmountsIn,
         minBptOut,
         to,
@@ -457,6 +457,6 @@ function assertAddLiquidityBuildOutput(
     };
 
     // biome-ignore lint/correctness/noUnusedVariables: <explanation>
-    const { call, ...buildCheck } = addLiquidityBuildOutput;
+    const { call, ...buildCheck } = addLiquidityBuildCallOutput;
     expect(buildCheck).to.deep.eq(expectedBuildOutput);
 }

--- a/test/lib/utils/addLiquidityHelper.ts
+++ b/test/lib/utils/addLiquidityHelper.ts
@@ -37,6 +37,7 @@ async function sdkAddLiquidity({
     slippage,
     testAddress,
     wethIsEth,
+    fromInternalBalance,
 }: {
     addLiquidity: AddLiquidity;
     addLiquidityInput: AddLiquidityInput;
@@ -44,6 +45,7 @@ async function sdkAddLiquidity({
     slippage: Slippage;
     testAddress: Address;
     wethIsEth?: boolean;
+    fromInternalBalance?: boolean;
 }): Promise<{
     addLiquidityBuildCallOutput: AddLiquidityBuildCallOutput;
     addLiquidityQueryOutput: AddLiquidityQueryOutput;
@@ -64,7 +66,7 @@ async function sdkAddLiquidity({
             ...addLiquidityBuildInput,
             sender: testAddress,
             recipient: testAddress,
-            fromInternalBalance: false,
+            fromInternalBalance: !!fromInternalBalance,
         };
     }
 

--- a/test/lib/utils/removeLiquidityHelper.ts
+++ b/test/lib/utils/removeLiquidityHelper.ts
@@ -4,10 +4,8 @@ import {
     ChainId,
     NATIVE_ASSETS,
     PoolState,
-    RemoveLiquidityV2BaseBuildCallInput,
     RemoveLiquidityBuildCallInput,
     RemoveLiquidityBuildCallOutput,
-    RemoveLiquidityV2ComposableStableQueryOutput,
     RemoveLiquidityInput,
     RemoveLiquidityProportionalInput,
     RemoveLiquidityQueryOutput,
@@ -24,6 +22,8 @@ import {
 import { getTokensForBalanceCheck } from './getTokensForBalanceCheck';
 import { sendTransactionGetBalances, TxOutput } from './helper';
 import { RemoveLiquidityTxInput } from './types';
+import { RemoveLiquidityV2BaseBuildCallInput } from '@/entities/removeLiquidity/removeLiquidityV2/types';
+import { RemoveLiquidityV2ComposableStableQueryOutput } from '@/entities/removeLiquidity/removeLiquidityV2/composableStable/types';
 
 type RemoveLiquidityOutput = {
     removeLiquidityQueryOutput: RemoveLiquidityQueryOutput;
@@ -38,6 +38,7 @@ export const sdkRemoveLiquidity = async ({
     slippage,
     testAddress,
     wethIsEth,
+    toInternalBalance,
 }: Omit<RemoveLiquidityTxInput, 'client'>): Promise<{
     removeLiquidityBuildCallOutput: RemoveLiquidityBuildCallOutput;
     removeLiquidityQueryOutput: RemoveLiquidityQueryOutput;
@@ -58,6 +59,7 @@ export const sdkRemoveLiquidity = async ({
             ...removeLiquidityBuildInput,
             sender: testAddress,
             recipient: testAddress,
+            toInternalBalance: !!toInternalBalance,
         };
     }
 
@@ -189,7 +191,6 @@ export function assertRemoveLiquidityUnbalanced(
         // Should match inputs
         poolId: poolState.id,
         poolType: poolState.type,
-        toInternalBalance: !!removeLiquidityInput.toInternalBalance,
         removeLiquidityKind: removeLiquidityInput.kind,
         vaultVersion: poolState.vaultVersion,
         chainId,
@@ -260,7 +261,6 @@ export function assertRemoveLiquiditySingleTokenExactOut(
         // Should match inputs
         poolId: poolState.id,
         poolType: poolState.type,
-        toInternalBalance: !!removeLiquidityInput.toInternalBalance,
         removeLiquidityKind: removeLiquidityInput.kind,
         vaultVersion: poolState.vaultVersion,
         chainId,
@@ -330,7 +330,6 @@ export function assertRemoveLiquiditySingleTokenExactIn(
         // Should match inputs
         poolId: poolState.id,
         poolType: poolState.type,
-        toInternalBalance: !!removeLiquidityInput.toInternalBalance,
         removeLiquidityKind: removeLiquidityInput.kind,
         vaultVersion: poolState.vaultVersion,
         chainId,
@@ -405,7 +404,6 @@ export function assertRemoveLiquidityProportional(
         // Should match inputs
         poolId: poolState.id,
         poolType: poolState.type,
-        toInternalBalance: !!removeLiquidityInput.toInternalBalance,
         removeLiquidityKind: removeLiquidityInput.kind,
         vaultVersion: poolState.vaultVersion,
         chainId,
@@ -478,7 +476,6 @@ export function assertRemoveLiquidityRecovery(
         // Should match inputs
         poolId: poolState.id,
         poolType: poolState.type,
-        toInternalBalance: !!removeLiquidityInput.toInternalBalance,
         removeLiquidityKind: removeLiquidityInput.kind,
         vaultVersion: poolState.vaultVersion,
         chainId,

--- a/test/lib/utils/removeLiquidityHelper.ts
+++ b/test/lib/utils/removeLiquidityHelper.ts
@@ -4,10 +4,10 @@ import {
     ChainId,
     NATIVE_ASSETS,
     PoolState,
-    RemoveLiquidityBaseBuildCallInputV2,
+    RemoveLiquidityV2BaseBuildCallInput,
     RemoveLiquidityBuildCallInput,
     RemoveLiquidityBuildCallOutput,
-    RemoveLiquidityComposableStableQueryOutput,
+    RemoveLiquidityV2ComposableStableQueryOutput,
     RemoveLiquidityInput,
     RemoveLiquidityProportionalInput,
     RemoveLiquidityQueryOutput,
@@ -54,7 +54,7 @@ export const sdkRemoveLiquidity = async ({
         wethIsEth: !!wethIsEth,
     };
     if (poolState.vaultVersion === 2) {
-        (removeLiquidityBuildInput as RemoveLiquidityBaseBuildCallInputV2) = {
+        (removeLiquidityBuildInput as RemoveLiquidityV2BaseBuildCallInput) = {
             ...removeLiquidityBuildInput,
             sender: testAddress,
             recipient: testAddress,
@@ -71,27 +71,27 @@ export const sdkRemoveLiquidity = async ({
     };
 };
 
-function isRemoveLiquidityComposableStableQueryOutput(
+function isRemoveLiquidityV2ComposableStableQueryOutput(
     output: RemoveLiquidityQueryOutput,
 ): boolean {
     return (
-        (output as RemoveLiquidityComposableStableQueryOutput).bptIndex !==
+        (output as RemoveLiquidityV2ComposableStableQueryOutput).bptIndex !==
         undefined
     );
 }
 
 function getCheck(output: RemoveLiquidityQueryOutput, isExactIn: boolean) {
-    if (isRemoveLiquidityComposableStableQueryOutput(output)) {
+    if (isRemoveLiquidityV2ComposableStableQueryOutput(output)) {
         if (isExactIn) {
             // Using this destructuring to return only the fields of interest
             // biome-ignore lint/correctness/noUnusedVariables: <explanation>
             const { amountsOut, bptIndex, ...check } =
-                output as RemoveLiquidityComposableStableQueryOutput;
+                output as RemoveLiquidityV2ComposableStableQueryOutput;
             return check;
         }
         // biome-ignore lint/correctness/noUnusedVariables: <explanation>
         const { bptIn, bptIndex, ...check } =
-            output as RemoveLiquidityComposableStableQueryOutput;
+            output as RemoveLiquidityV2ComposableStableQueryOutput;
         return check;
     }
     if (isExactIn) {

--- a/test/lib/utils/types.ts
+++ b/test/lib/utils/types.ts
@@ -23,6 +23,7 @@ export type AddLiquidityTxInput = {
     poolState: PoolState;
     testAddress: Address;
     wethIsEth?: boolean;
+    fromInternalBalance?: boolean;
 };
 
 export type InitPoolTxInput = Omit<
@@ -41,6 +42,7 @@ export type RemoveLiquidityTxInput = {
     poolState: PoolState;
     testAddress: Address;
     wethIsEth?: boolean;
+    toInternalBalance?: boolean;
 };
 
 export type CreatePoolTxInput = {


### PR DESCRIPTION
Following up on previous interface refactors, this PR splits Remove Liquidity types into V2/V3 and restructure them so they are placed closer to their implementation.

Besides that, I took the opportunity to:
- Rename buildCall interface aiming for more consistency and clarity, such as:
    - `AddLiquidityCall` -> `AddLiquidityBuildCallInput`
    - `AddLiquidityBuildOutput` -> `AddLiquidityBuildCallOutput `
- extract `value` calculation to a `getValue` helper
- move `toInternalBalance` from query to buildCall interface (for V2)