### PR TITLE
Refactor queryRemoveLiquidityRecovery into a separate method

### DIFF
--- a/.changeset/silver-tigers-shave.md
+++ b/.changeset/silver-tigers-shave.md
@@ -1,0 +1,5 @@
+---
+"@balancer/sdk": minor
+---
+
+Refactor queryRemoveLiquidityRecovery into a separate method

--- a/examples/removeLiquidityRecovery.ts
+++ b/examples/removeLiquidityRecovery.ts
@@ -1,0 +1,109 @@
+/**
+ * Example showing how to remove liquidity from a pool in recovery mode.
+ * (Runs against a local Anvil fork)
+ *
+ * Run with:
+ * pnpm example ./examples/removeLiquidityRecovery.ts
+ */
+import dotenv from 'dotenv';
+dotenv.config();
+
+import { parseEther } from 'viem';
+
+import {
+    BalancerApi,
+    ChainId,
+    InputAmount,
+    PoolStateWithBalances,
+    RemoveLiquidity,
+    RemoveLiquidityKind,
+    RemoveLiquidityRecoveryInput,
+    Slippage,
+} from '../src';
+import { ANVIL_NETWORKS, startFork } from '../test/anvil/anvil-global-setup';
+import { makeForkTx } from './utils/makeForkTx';
+
+const removeLiquidity = async () => {
+    // User defined:
+    const chainId = ChainId.MAINNET;
+    const userAccount = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045';
+    const poolId =
+        '0x156c02f3f7fef64a3a9d80ccf7085f23cce91d76000000000000000000000570'; // vETH/WETH
+    const slippage = Slippage.fromPercentage('1'); // 1%
+
+    // Start a local anvil fork that will be used to query/tx against
+    const { rpcUrl } = await startFork(ANVIL_NETWORKS[ChainId[chainId]]);
+
+    // API is used to fetch relevant pool data
+    const balancerApi = new BalancerApi(
+        'https://backend-v3-canary.beets-ftm-node.com/graphql',
+        chainId,
+    );
+    const poolStateWithBalances: PoolStateWithBalances =
+        await balancerApi.pools.fetchPoolStateWithBalances(poolId);
+
+    // Construct the RemoveLiquidityInput, in this case a RemoveLiquiditySingleTokenExactIn
+    const bptIn: InputAmount = {
+        rawAmount: parseEther('1'),
+        decimals: 18,
+        address: poolStateWithBalances.address,
+    };
+    const removeLiquidityRecoveryInput: RemoveLiquidityRecoveryInput = {
+        chainId,
+        rpcUrl,
+        bptIn,
+        kind: RemoveLiquidityKind.Recovery,
+    };
+
+    // No need to calculate Price Impact as it's always zero for remove liquidity recovery
+
+    // Simulate removing liquidity to get the tokens out
+    const removeLiquidity = new RemoveLiquidity();
+    const queryOutput = await removeLiquidity.queryRemoveLiquidityRecovery(
+        removeLiquidityRecoveryInput,
+        poolStateWithBalances,
+    );
+
+    console.log('\nRemove Liquidity Query Output:');
+    console.log(`BPT In: ${queryOutput.bptIn.amount.toString()}`);
+    console.table({
+        tokensOut: queryOutput.amountsOut.map((a) => a.token.address),
+        amountsOut: queryOutput.amountsOut.map((a) => a.amount),
+    });
+
+    // Apply slippage to the tokens out received from the query and construct the call
+    const call = removeLiquidity.buildCall({
+        ...queryOutput,
+        slippage,
+        sender: userAccount,
+        recipient: userAccount,
+        chainId,
+    });
+
+    console.log('\nWith slippage applied:');
+    console.log(`Max BPT In: ${call.maxBptIn.amount}`);
+    console.table({
+        tokensOut: call.minAmountsOut.map((a) => a.token.address),
+        minAmountsOut: call.minAmountsOut.map((a) => a.amount),
+    });
+
+    // Make the tx against the local fork and print the result
+    await makeForkTx(
+        call,
+        {
+            rpcUrl,
+            chainId,
+            impersonateAccount: userAccount,
+            forkTokens: [
+                {
+                    address: bptIn.address,
+                    slot: 0,
+                    rawBalance: bptIn.rawAmount,
+                },
+            ],
+        },
+        poolStateWithBalances,
+    );
+};
+
+export default removeLiquidity;

--- a/examples/removeLiquidityRecovery.ts
+++ b/examples/removeLiquidityRecovery.ts
@@ -14,7 +14,7 @@ import {
     BalancerApi,
     ChainId,
     InputAmount,
-    PoolStateWithBalances,
+    PoolState,
     RemoveLiquidity,
     RemoveLiquidityKind,
     RemoveLiquidityRecoveryInput,
@@ -39,14 +39,13 @@ const removeLiquidity = async () => {
         'https://backend-v3-canary.beets-ftm-node.com/graphql',
         chainId,
     );
-    const poolStateWithBalances: PoolStateWithBalances =
-        await balancerApi.pools.fetchPoolStateWithBalances(poolId);
+    const poolState: PoolState = await balancerApi.pools.fetchPoolState(poolId);
 
     // Construct the RemoveLiquidityInput, in this case a RemoveLiquiditySingleTokenExactIn
     const bptIn: InputAmount = {
         rawAmount: parseEther('1'),
         decimals: 18,
-        address: poolStateWithBalances.address,
+        address: poolState.address,
     };
     const removeLiquidityRecoveryInput: RemoveLiquidityRecoveryInput = {
         chainId,
@@ -61,7 +60,7 @@ const removeLiquidity = async () => {
     const removeLiquidity = new RemoveLiquidity();
     const queryOutput = await removeLiquidity.queryRemoveLiquidityRecovery(
         removeLiquidityRecoveryInput,
-        poolStateWithBalances,
+        poolState,
     );
 
     console.log('\nRemove Liquidity Query Output:');
@@ -102,7 +101,7 @@ const removeLiquidity = async () => {
                 },
             ],
         },
-        poolStateWithBalances,
+        poolState,
     );
 };
 

--- a/examples/utils/calculateProportionalAmounts.ts
+++ b/examples/utils/calculateProportionalAmounts.ts
@@ -14,7 +14,7 @@ export default async function calculateProportionalAmountsExample() {
     const pool =
         await poolDataProvider.pools.fetchPoolStateWithBalances(poolId);
     const inputAmount: InputAmount = {
-        rawAmount: BigInt(149277708680793000),
+        rawAmount: 149277708680793000n,
         address: '0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0', // wstETH
         decimals: 18,
     };

--- a/examples/utils/calculateProportionalAmounts.ts
+++ b/examples/utils/calculateProportionalAmounts.ts
@@ -1,9 +1,17 @@
+/**
+ * Example showing how to remove liquidity from a pool in recovery mode.
+ * (Runs against a local Anvil fork)
+ *
+ * Run with:
+ * pnpm example ./examples/utils/calculateProportionalAmounts.ts
+ */
+
 import { BalancerApi } from '@/data';
 import { calculateProportionalAmounts } from '@/entities/utils/calculateProportionalAmounts';
 import { InputAmount } from '@/types';
 import { ChainId } from '@/utils';
 
-export default async function calculateProportionalAmountsExample() {
+const calculateProportionalAmountsExample = async () => {
     const chainId = ChainId.MAINNET;
     const poolDataProvider = new BalancerApi(
         'https://api-v3.balancer.fi/',
@@ -18,15 +26,19 @@ export default async function calculateProportionalAmountsExample() {
         address: '0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0', // wstETH
         decimals: 18,
     };
-    const { amountsIn, bptOut } = calculateProportionalAmounts(
+    const { tokenAmounts, bptAmount } = calculateProportionalAmounts(
         pool,
         inputAmount,
     );
     console.log(
-        `Token Addresses:     ${amountsIn.map(({ address }) => address)}`,
+        `Token Addresses:     ${tokenAmounts.map(({ address }) => address)}`,
     );
     console.log(
-        `Proportional Amounts:${amountsIn.map(({ rawAmount }) => rawAmount)}`,
+        `Proportional Amounts:${tokenAmounts.map(
+            ({ rawAmount }) => rawAmount,
+        )}`,
     );
-    console.log(`BPT Out:             ${bptOut.rawAmount}`);
-}
+    console.log(`BPT Out:             ${bptAmount.rawAmount}`);
+};
+
+export default calculateProportionalAmountsExample;

--- a/src/data/providers/balancer-api/modules/pool-state/index.ts
+++ b/src/data/providers/balancer-api/modules/pool-state/index.ts
@@ -104,8 +104,6 @@ export class Pools {
               decimals
               index
               balance
-              name
-              symbol
             }
           }
         }
@@ -116,8 +114,6 @@ export class Pools {
               decimals
               index
               balance
-              name
-              symbol
             }
           }
         }
@@ -128,8 +124,6 @@ export class Pools {
               decimals
               index
               balance
-              name
-              symbol
             }
           }
         }
@@ -140,8 +134,6 @@ export class Pools {
               decimals
               index
               balance
-              name
-              symbol
             }
           }
         }
@@ -152,8 +144,6 @@ export class Pools {
               decimals
               index
               balance
-              name
-              symbol
             }
           }
         }
@@ -164,8 +154,6 @@ export class Pools {
               decimals
               index
               balance
-              name
-              symbol
             }
           }
         }
@@ -176,8 +164,6 @@ export class Pools {
               decimals
               index
               balance
-              name
-              symbol
             }
           }
         }
@@ -188,8 +174,6 @@ export class Pools {
               decimals
               index
               balance
-              name
-              symbol
             }
           }
         }

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -8,23 +8,6 @@ export interface MinimalToken {
     index: number;
 }
 
-export interface RawPoolToken extends MinimalToken {
-    symbol: string;
-    name: string;
+export interface PoolTokenWithBalance extends MinimalToken {
     balance: HumanAmount;
-}
-
-export interface RawWeightedPoolToken extends RawPoolToken {
-    weight: HumanAmount;
-}
-
-export interface RawPoolTokenWithRate extends RawPoolToken {
-    priceRate: HumanAmount;
-}
-
-export interface RawFxPoolToken extends RawPoolToken {
-    token: {
-        latestFXPrice: HumanAmount;
-        fxOracleDecimals?: number;
-    };
 }

--- a/src/entities/inputValidator/composableStable/inputValidatorComposableStable.ts
+++ b/src/entities/inputValidator/composableStable/inputValidatorComposableStable.ts
@@ -2,14 +2,18 @@ import { areTokensInArray } from '@/entities/utils/areTokensInArray';
 import { AddLiquidityInput } from '../../addLiquidity/types';
 import { CreatePoolV2ComposableStableInput } from '../../createPool/types';
 import { InitPoolInput } from '../../initPool/types';
-import { RemoveLiquidityInput } from '../../removeLiquidity/types';
-import { PoolState } from '../../types';
+import {
+    RemoveLiquidityInput,
+    RemoveLiquidityRecoveryInput,
+} from '../../removeLiquidity/types';
+import { PoolState, PoolStateWithBalances } from '../../types';
 import { InputValidatorBase } from '../types';
 import {
     validateCreatePoolTokens,
     validatePoolHasBpt,
     validateTokensAddLiquidity,
     validateTokensRemoveLiquidity,
+    validateTokensRemoveLiquidityRecovery,
 } from '../utils/validateTokens';
 
 export class InputValidatorComposableStable implements InputValidatorBase {
@@ -34,6 +38,14 @@ export class InputValidatorComposableStable implements InputValidatorBase {
     ): void {
         validatePoolHasBpt(poolState);
         validateTokensRemoveLiquidity(input, poolState);
+    }
+
+    validateRemoveLiquidityRecovery(
+        input: RemoveLiquidityRecoveryInput,
+        poolStateWithBalances: PoolStateWithBalances,
+    ): void {
+        validatePoolHasBpt(poolStateWithBalances);
+        validateTokensRemoveLiquidityRecovery(input, poolStateWithBalances);
     }
 
     validateCreatePool(input: CreatePoolV2ComposableStableInput): void {

--- a/src/entities/inputValidator/gyro/inputValidatorGyro.ts
+++ b/src/entities/inputValidator/gyro/inputValidatorGyro.ts
@@ -4,12 +4,14 @@ import { CreatePoolInput } from '../../createPool/types';
 import {
     RemoveLiquidityInput,
     RemoveLiquidityKind,
+    RemoveLiquidityRecoveryInput,
 } from '../../removeLiquidity/types';
-import { PoolState } from '../../types';
+import { PoolState, PoolStateWithBalances } from '../../types';
 import { InputValidatorBase } from '../types';
 import {
     validateTokensAddLiquidity,
     validateTokensRemoveLiquidity,
+    validateTokensRemoveLiquidityRecovery,
 } from '../utils/validateTokens';
 
 export class InputValidatorGyro implements InputValidatorBase {
@@ -46,6 +48,13 @@ export class InputValidatorGyro implements InputValidatorBase {
             );
         }
         validateTokensRemoveLiquidity(removeLiquidityInput, poolState);
+    }
+
+    validateRemoveLiquidityRecovery(
+        input: RemoveLiquidityRecoveryInput,
+        poolStateWithBalances: PoolStateWithBalances,
+    ): void {
+        validateTokensRemoveLiquidityRecovery(input, poolStateWithBalances);
     }
 
     validateCreatePool(input: CreatePoolInput): void {

--- a/src/entities/inputValidator/inputValidator.ts
+++ b/src/entities/inputValidator/inputValidator.ts
@@ -2,7 +2,11 @@ import { PoolType } from '../../types';
 import { AddLiquidityInput } from '../addLiquidity/types';
 import { CreatePoolInput } from '../createPool/types';
 import { InitPoolInput } from '../initPool/types';
-import { PoolState } from '../types';
+import {
+    RemoveLiquidityInput,
+    RemoveLiquidityRecoveryInput,
+} from '../removeLiquidity/types';
+import { PoolState, PoolStateWithBalances } from '../types';
 import { InputValidatorComposableStable } from './composableStable/inputValidatorComposableStable';
 import { InputValidatorGyro } from './gyro/inputValidatorGyro';
 import { InputValidatorStable } from './stable/inputValidatorStable';
@@ -47,10 +51,25 @@ export class InputValidator {
         );
     }
 
-    validateRemoveLiquidity(removeLiquidityInput: any, poolState: any): void {
+    validateRemoveLiquidity(
+        removeLiquidityInput: RemoveLiquidityInput,
+        poolState: PoolState,
+    ): void {
         this.getValidator(poolState.type).validateRemoveLiquidity(
             removeLiquidityInput,
             poolState,
+        );
+    }
+
+    validateRemoveLiquidityRecovery(
+        removeLiquidityRecoveryInput: RemoveLiquidityRecoveryInput,
+        poolStateWithBalances: PoolStateWithBalances,
+    ): void {
+        this.getValidator(
+            poolStateWithBalances.type,
+        ).validateRemoveLiquidityRecovery(
+            removeLiquidityRecoveryInput,
+            poolStateWithBalances,
         );
     }
 

--- a/src/entities/inputValidator/inputValidator.ts
+++ b/src/entities/inputValidator/inputValidator.ts
@@ -6,7 +6,7 @@ import {
     RemoveLiquidityInput,
     RemoveLiquidityRecoveryInput,
 } from '../removeLiquidity/types';
-import { PoolState, PoolStateWithBalances } from '../types';
+import { PoolState } from '../types';
 import { InputValidatorComposableStable } from './composableStable/inputValidatorComposableStable';
 import { InputValidatorGyro } from './gyro/inputValidatorGyro';
 import { InputValidatorStable } from './stable/inputValidatorStable';
@@ -63,13 +63,11 @@ export class InputValidator {
 
     validateRemoveLiquidityRecovery(
         removeLiquidityRecoveryInput: RemoveLiquidityRecoveryInput,
-        poolStateWithBalances: PoolStateWithBalances,
+        poolState: PoolState,
     ): void {
-        this.getValidator(
-            poolStateWithBalances.type,
-        ).validateRemoveLiquidityRecovery(
+        this.getValidator(poolState.type).validateRemoveLiquidityRecovery(
             removeLiquidityRecoveryInput,
-            poolStateWithBalances,
+            poolState,
         );
     }
 

--- a/src/entities/inputValidator/stable/inputValidatorStable.ts
+++ b/src/entities/inputValidator/stable/inputValidatorStable.ts
@@ -3,8 +3,11 @@ import {
     AddLiquidityKind,
 } from '@/entities/addLiquidity/types';
 import { InitPoolInput, InitPoolInputV3 } from '@/entities/initPool/types';
-import { RemoveLiquidityInput } from '@/entities/removeLiquidity/types';
-import { PoolState } from '@/entities/types';
+import {
+    RemoveLiquidityInput,
+    RemoveLiquidityRecoveryInput,
+} from '@/entities/removeLiquidity/types';
+import { PoolState, PoolStateWithBalances } from '@/entities/types';
 import { areTokensInArray } from '@/entities/utils/areTokensInArray';
 import {
     addLiquidityProportionalNotSupportedOnPoolTypeError,
@@ -16,6 +19,7 @@ import { InputValidatorBase } from '../types';
 import {
     validateTokensAddLiquidity,
     validateTokensRemoveLiquidity,
+    validateTokensRemoveLiquidityRecovery,
 } from '../utils/validateTokens';
 import { CreatePoolInput } from '@/entities/createPool';
 
@@ -51,6 +55,13 @@ export class InputValidatorStable implements InputValidatorBase {
         poolState: PoolState,
     ): void {
         validateTokensRemoveLiquidity(input, poolState);
+    }
+
+    validateRemoveLiquidityRecovery(
+        input: RemoveLiquidityRecoveryInput,
+        poolStateWithBalances: PoolStateWithBalances,
+    ): void {
+        validateTokensRemoveLiquidityRecovery(input, poolStateWithBalances);
     }
 
     private validateWethIsEth(initPoolInput: InitPoolInputV3) {

--- a/src/entities/inputValidator/types.ts
+++ b/src/entities/inputValidator/types.ts
@@ -5,7 +5,7 @@ import {
     RemoveLiquidityInput,
     RemoveLiquidityRecoveryInput,
 } from '../removeLiquidity/types';
-import { PoolState, PoolStateWithBalances } from '../types';
+import { PoolState } from '../types';
 
 export interface InputValidatorBase {
     validateAddLiquidity(
@@ -20,7 +20,7 @@ export interface InputValidatorBase {
 
     validateRemoveLiquidityRecovery(
         input: RemoveLiquidityRecoveryInput,
-        poolStateWithBalances: PoolStateWithBalances,
+        poolState: PoolState,
     ): void;
 
     validateCreatePool(input: CreatePoolInput): void;

--- a/src/entities/inputValidator/types.ts
+++ b/src/entities/inputValidator/types.ts
@@ -1,8 +1,11 @@
 import { AddLiquidityInput } from '../addLiquidity/types';
 import { CreatePoolInput } from '../createPool/types';
 import { InitPoolInput } from '../initPool/types';
-import { RemoveLiquidityInput } from '../removeLiquidity/types';
-import { PoolState } from '../types';
+import {
+    RemoveLiquidityInput,
+    RemoveLiquidityRecoveryInput,
+} from '../removeLiquidity/types';
+import { PoolState, PoolStateWithBalances } from '../types';
 
 export interface InputValidatorBase {
     validateAddLiquidity(
@@ -13,6 +16,11 @@ export interface InputValidatorBase {
     validateRemoveLiquidity(
         input: RemoveLiquidityInput,
         poolState: PoolState,
+    ): void;
+
+    validateRemoveLiquidityRecovery(
+        input: RemoveLiquidityRecoveryInput,
+        poolStateWithBalances: PoolStateWithBalances,
     ): void;
 
     validateCreatePool(input: CreatePoolInput): void;

--- a/src/entities/inputValidator/utils/validateTokens.ts
+++ b/src/entities/inputValidator/utils/validateTokens.ts
@@ -2,8 +2,9 @@ import { AddLiquidityInput, AddLiquidityKind } from '../../addLiquidity/types';
 import {
     RemoveLiquidityInput,
     RemoveLiquidityKind,
+    RemoveLiquidityRecoveryInput,
 } from '../../removeLiquidity/types';
-import { PoolState } from '../../types';
+import { PoolState, PoolStateWithBalances } from '../../types';
 import { areTokensInArray } from '../../utils/areTokensInArray';
 
 export const validateTokensAddLiquidity = (
@@ -64,6 +65,16 @@ export const validateTokensRemoveLiquidity = (
             );
             break;
     }
+};
+
+export const validateTokensRemoveLiquidityRecovery = (
+    removeLiquidityRecoveryInput: RemoveLiquidityRecoveryInput,
+    poolStateWithBalances: PoolStateWithBalances,
+) => {
+    areTokensInArray(
+        [removeLiquidityRecoveryInput.bptIn.address],
+        [poolStateWithBalances.address],
+    );
 };
 
 export const validatePoolHasBpt = (poolState: PoolState) => {

--- a/src/entities/inputValidator/weighted/inputValidatorWeighted.ts
+++ b/src/entities/inputValidator/weighted/inputValidatorWeighted.ts
@@ -1,15 +1,19 @@
-import { RemoveLiquidityInput } from '@/entities/removeLiquidity/types';
+import {
+    RemoveLiquidityInput,
+    RemoveLiquidityRecoveryInput,
+} from '@/entities/removeLiquidity/types';
 import {
     CreatePoolV2WeightedInput,
     CreatePoolV3WeightedInput,
 } from '../../createPool/types';
 import { InitPoolInput, InitPoolInputV3 } from '../../initPool/types';
-import { PoolState } from '../../types';
+import { PoolState, PoolStateWithBalances } from '../../types';
 import { InputValidatorBase } from '../types';
 import {
     validateCreatePoolTokens,
     validateTokensAddLiquidity,
     validateTokensRemoveLiquidity,
+    validateTokensRemoveLiquidityRecovery,
 } from '../utils/validateTokens';
 import { TokenType } from '@/types';
 import { zeroAddress } from 'viem';
@@ -71,6 +75,13 @@ export class InputValidatorWeighted implements InputValidatorBase {
         poolState: PoolState,
     ): void {
         validateTokensRemoveLiquidity(input, poolState);
+    }
+
+    validateRemoveLiquidityRecovery(
+        input: RemoveLiquidityRecoveryInput,
+        poolStateWithBalances: PoolStateWithBalances,
+    ): void {
+        validateTokensRemoveLiquidityRecovery(input, poolStateWithBalances);
     }
 
     private validateWethIsEth(initPoolInput: InitPoolInputV3) {

--- a/src/entities/removeLiquidity/helper.ts
+++ b/src/entities/removeLiquidity/helper.ts
@@ -40,7 +40,6 @@ export const getAmountsQuery = (
                 maxBptAmountIn: input.bptIn.rawAmount,
             };
         case RemoveLiquidityKind.Proportional:
-        case RemoveLiquidityKind.Recovery:
             return {
                 minAmountsOut: Array(tokens.length).fill(1n), // minAmountsOut set to 1 wei when querying
                 tokenOutIndex: undefined,

--- a/src/entities/removeLiquidity/index.ts
+++ b/src/entities/removeLiquidity/index.ts
@@ -5,11 +5,15 @@ import {
     RemoveLiquidityConfig,
     RemoveLiquidityInput,
     RemoveLiquidityQueryOutput,
+    RemoveLiquidityRecoveryInput,
 } from './types';
-import { PoolState } from '../types';
+import { PoolState, PoolStateWithBalances } from '../types';
 import { InputValidator } from '../inputValidator/inputValidator';
 import { RemoveLiquidityV2 } from './removeLiquidityV2';
 import { RemoveLiquidityV3 } from './removeLiquidityV3';
+import { calculateProportionalAmounts } from '../utils';
+import { TokenAmount } from '../tokenAmount';
+import { Token } from '../token';
 
 export class RemoveLiquidity implements RemoveLiquidityBase {
     private readonly inputValidator: InputValidator = new InputValidator();
@@ -53,5 +57,40 @@ export class RemoveLiquidity implements RemoveLiquidityBase {
                 return removeLiquidity.buildCall(input);
             }
         }
+    }
+
+    /**
+     * It's not possible to query Remove Liquidity Recovery in the same way as
+     * other remove liquidity kinds, but since it's not affected by fees or anything
+     * other than pool balances, we can calculate amountsOut as proportional amounts.
+     */
+    public queryRemoveLiquidityRecovery(
+        input: RemoveLiquidityRecoveryInput,
+        poolStateWithBalances: PoolStateWithBalances,
+    ): RemoveLiquidityQueryOutput {
+        const { tokenAmounts, bptAmount } = calculateProportionalAmounts(
+            poolStateWithBalances,
+            input.bptIn,
+        );
+        const bptIn = TokenAmount.fromRawAmount(
+            new Token(input.chainId, bptAmount.address, bptAmount.decimals),
+            bptAmount.rawAmount,
+        );
+        const amountsOut = tokenAmounts.map((amountIn) =>
+            TokenAmount.fromRawAmount(
+                new Token(input.chainId, amountIn.address, amountIn.decimals),
+                amountIn.rawAmount,
+            ),
+        );
+        return {
+            poolType: poolStateWithBalances.type,
+            removeLiquidityKind: input.kind,
+            poolId: poolStateWithBalances.id,
+            bptIn,
+            amountsOut,
+            tokenOutIndex: undefined,
+            vaultVersion: poolStateWithBalances.vaultVersion,
+            chainId: input.chainId,
+        };
     }
 }

--- a/src/entities/removeLiquidity/index.ts
+++ b/src/entities/removeLiquidity/index.ts
@@ -7,7 +7,7 @@ import {
     RemoveLiquidityQueryOutput,
     RemoveLiquidityRecoveryInput,
 } from './types';
-import { PoolState, PoolStateWithBalances } from '../types';
+import { PoolState } from '../types';
 import { InputValidator } from '../inputValidator/inputValidator';
 import { RemoveLiquidityV2 } from './removeLiquidityV2';
 import { RemoveLiquidityV3 } from './removeLiquidityV3';
@@ -40,27 +40,24 @@ export class RemoveLiquidity implements RemoveLiquidityBase {
      * Since it's not affected by fees or anything other than pool balances,
      * it's possible to calculate amountsOut as proportional amounts.
      */
-    public queryRemoveLiquidityRecovery(
+    public async queryRemoveLiquidityRecovery(
         input: RemoveLiquidityRecoveryInput,
-        poolStateWithBalances: PoolStateWithBalances,
-    ): RemoveLiquidityQueryOutput {
-        this.inputValidator.validateRemoveLiquidityRecovery(
-            input,
-            poolStateWithBalances,
-        );
-        switch (poolStateWithBalances.vaultVersion) {
+        poolState: PoolState,
+    ): Promise<RemoveLiquidityQueryOutput> {
+        this.inputValidator.validateRemoveLiquidityRecovery(input, poolState);
+        switch (poolState.vaultVersion) {
             case 2: {
                 const removeLiquidity = new RemoveLiquidityV2(this.config);
                 return removeLiquidity.queryRemoveLiquidityRecovery(
                     input,
-                    poolStateWithBalances,
+                    poolState,
                 );
             }
             case 3: {
                 const removeLiquidity = new RemoveLiquidityV3();
                 return removeLiquidity.queryRemoveLiquidityRecovery(
                     input,
-                    poolStateWithBalances,
+                    poolState,
                 );
             }
         }

--- a/src/entities/removeLiquidity/removeLiquidityV2/composableStable/removeLiquidityComposableStable.ts
+++ b/src/entities/removeLiquidity/removeLiquidityV2/composableStable/removeLiquidityComposableStable.ts
@@ -36,13 +36,10 @@ export class RemoveLiquidityComposableStable implements RemoveLiquidityBase {
             ],
         };
         const userData = ComposableStableEncoder.encodeRemoveLiquidityUserData(
-            input.kind === RemoveLiquidityKind.Recovery
-                ? RemoveLiquidityKind.Proportional
-                : input.kind,
+            input.kind,
             amountsWithoutBpt,
         );
 
-        // tokensOut will have zero address if removing liquidity to native asset
         const { args, tokensOut } = parseRemoveLiquidityArgs({
             chainId: input.chainId,
             poolId: poolState.id,

--- a/src/entities/removeLiquidity/removeLiquidityV2/index.ts
+++ b/src/entities/removeLiquidity/removeLiquidityV2/index.ts
@@ -7,7 +7,6 @@ import {
     RemoveLiquidityInput,
     RemoveLiquidityQueryOutput,
     RemoveLiquidityRecoveryInput,
-    PoolStateWithBalances,
 } from '@/entities';
 import { RemoveLiquidityWeighted } from './weighted/removeLiquidityWeighted';
 import { RemoveLiquidityComposableStable } from './composableStable/removeLiquidityComposableStable';
@@ -49,13 +48,13 @@ export class RemoveLiquidityV2 implements RemoveLiquidityBase {
         return this.getRemoveLiquidity(poolState.type).query(input, poolState);
     }
 
-    public queryRemoveLiquidityRecovery(
+    public async queryRemoveLiquidityRecovery(
         input: RemoveLiquidityRecoveryInput,
-        poolStateWithBalances: PoolStateWithBalances,
-    ): RemoveLiquidityQueryOutput {
+        poolState: PoolState,
+    ): Promise<RemoveLiquidityQueryOutput> {
         return this.getRemoveLiquidity(
-            poolStateWithBalances.type,
-        ).queryRemoveLiquidityRecovery(input, poolStateWithBalances);
+            poolState.type,
+        ).queryRemoveLiquidityRecovery(input, poolState);
     }
 
     public buildCall(

--- a/src/entities/removeLiquidity/removeLiquidityV2/index.ts
+++ b/src/entities/removeLiquidity/removeLiquidityV2/index.ts
@@ -6,6 +6,8 @@ import {
     RemoveLiquidityConfig,
     RemoveLiquidityInput,
     RemoveLiquidityQueryOutput,
+    RemoveLiquidityRecoveryInput,
+    PoolStateWithBalances,
 } from '@/entities';
 import { RemoveLiquidityWeighted } from './weighted/removeLiquidityWeighted';
 import { RemoveLiquidityComposableStable } from './composableStable/removeLiquidityComposableStable';
@@ -45,6 +47,15 @@ export class RemoveLiquidityV2 implements RemoveLiquidityBase {
         poolState: PoolState,
     ): Promise<RemoveLiquidityQueryOutput> {
         return this.getRemoveLiquidity(poolState.type).query(input, poolState);
+    }
+
+    public queryRemoveLiquidityRecovery(
+        input: RemoveLiquidityRecoveryInput,
+        poolStateWithBalances: PoolStateWithBalances,
+    ): RemoveLiquidityQueryOutput {
+        return this.getRemoveLiquidity(
+            poolStateWithBalances.type,
+        ).queryRemoveLiquidityRecovery(input, poolStateWithBalances);
     }
 
     public buildCall(

--- a/src/entities/removeLiquidity/removeLiquidityV2/stable/removeLiquidityStable.ts
+++ b/src/entities/removeLiquidity/removeLiquidityV2/stable/removeLiquidityStable.ts
@@ -9,7 +9,6 @@ import {
     RemoveLiquidityBase,
     RemoveLiquidityBuildCallOutput,
     RemoveLiquidityInput,
-    RemoveLiquidityKind,
     RemoveLiquidityQueryOutput,
 } from '../../types';
 import { PoolState } from '../../../types';
@@ -27,13 +26,10 @@ export class RemoveLiquidityStable implements RemoveLiquidityBase {
         const amounts = getAmountsQuery(sortedTokens, input);
 
         const userData = StableEncoder.encodeRemoveLiquidityUserData(
-            input.kind === RemoveLiquidityKind.Recovery
-                ? RemoveLiquidityKind.Proportional
-                : input.kind,
+            input.kind,
             amounts,
         );
 
-        // tokensOut will have zero address if removing liquidity to native asset
         const { args, tokensOut } = parseRemoveLiquidityArgs({
             chainId: input.chainId,
             poolId: poolState.id,

--- a/src/entities/removeLiquidity/removeLiquidityV2/stable/removeLiquidityStable.ts
+++ b/src/entities/removeLiquidity/removeLiquidityV2/stable/removeLiquidityStable.ts
@@ -1,8 +1,14 @@
-import { encodeFunctionData } from 'viem';
+import {
+    createPublicClient,
+    encodeFunctionData,
+    formatEther,
+    formatUnits,
+    http,
+} from 'viem';
 import { Token } from '../../../token';
 import { TokenAmount } from '../../../tokenAmount';
 import { StableEncoder } from '../../../encoders/stable';
-import { VAULT, ZERO_ADDRESS } from '../../../../utils/constants';
+import { CHAINS, VAULT, ZERO_ADDRESS } from '../../../../utils/constants';
 import { vaultV2Abi } from '../../../../abi';
 import { parseRemoveLiquidityArgs } from '../../../utils/parseRemoveLiquidityArgs';
 import {
@@ -17,6 +23,8 @@ import { doRemoveLiquidityQuery } from '../../../utils/doRemoveLiquidityQuery';
 import { calculateProportionalAmounts, getSortedTokens } from '../../../utils';
 import { getAmountsCall, getAmountsQuery } from '../../helper';
 import { RemoveLiquidityV2BaseBuildCallInput } from '../types';
+import { getPoolTokensV2, getTotalSupply } from '@/utils/tokens';
+import { HumanAmount } from '@/data';
 
 export class RemoveLiquidityStable implements RemoveLiquidityBase {
     public async query(
@@ -66,10 +74,33 @@ export class RemoveLiquidityStable implements RemoveLiquidityBase {
         };
     }
 
-    public queryRemoveLiquidityRecovery(
+    public async queryRemoveLiquidityRecovery(
         input: RemoveLiquidityRecoveryInput,
-        poolStateWithBalances: PoolStateWithBalances,
-    ): RemoveLiquidityQueryOutput {
+        poolState: PoolState,
+    ): Promise<RemoveLiquidityQueryOutput> {
+        const client = createPublicClient({
+            transport: http(input.rpcUrl),
+            chain: CHAINS[input.chainId],
+        });
+
+        const sortedTokens = getSortedTokens(poolState.tokens, input.chainId);
+        const [_, tokenBalances] = await getPoolTokensV2(poolState.id, client);
+        const totalShares = await getTotalSupply(poolState.address, client);
+
+        const poolStateWithBalances: PoolStateWithBalances = {
+            ...poolState,
+            tokens: sortedTokens.map((token, i) => ({
+                address: token.address,
+                decimals: token.decimals,
+                index: i,
+                balance: formatUnits(
+                    tokenBalances[i],
+                    token.decimals,
+                ) as HumanAmount,
+            })),
+            totalShares: formatEther(totalShares) as HumanAmount,
+        };
+
         const { tokenAmounts, bptAmount } = calculateProportionalAmounts(
             poolStateWithBalances,
             input.bptIn,
@@ -87,13 +118,13 @@ export class RemoveLiquidityStable implements RemoveLiquidityBase {
             ),
         );
         return {
-            poolType: poolStateWithBalances.type,
+            poolType: poolState.type,
             removeLiquidityKind: input.kind,
-            poolId: poolStateWithBalances.id,
+            poolId: poolState.id,
             bptIn,
             amountsOut,
             tokenOutIndex: undefined,
-            vaultVersion: poolStateWithBalances.vaultVersion,
+            vaultVersion: poolState.vaultVersion,
             chainId: input.chainId,
         };
     }

--- a/src/entities/removeLiquidity/removeLiquidityV2/weighted/removeLiquidityWeighted.ts
+++ b/src/entities/removeLiquidity/removeLiquidityV2/weighted/removeLiquidityWeighted.ts
@@ -10,10 +10,11 @@ import {
     RemoveLiquidityBuildCallOutput,
     RemoveLiquidityInput,
     RemoveLiquidityQueryOutput,
+    RemoveLiquidityRecoveryInput,
 } from '../../types';
-import { PoolState } from '../../../types';
+import { PoolState, PoolStateWithBalances } from '../../../types';
 import { doRemoveLiquidityQuery } from '../../../utils/doRemoveLiquidityQuery';
-import { getSortedTokens } from '../../../utils';
+import { calculateProportionalAmounts, getSortedTokens } from '../../../utils';
 import { getAmountsCall, getAmountsQuery } from '../../helper';
 import { RemoveLiquidityV2BaseBuildCallInput } from '../types';
 
@@ -61,6 +62,38 @@ export class RemoveLiquidityWeighted implements RemoveLiquidityBase {
             amountsOut,
             tokenOutIndex: amounts.tokenOutIndex,
             vaultVersion: poolState.vaultVersion,
+            chainId: input.chainId,
+        };
+    }
+
+    public queryRemoveLiquidityRecovery(
+        input: RemoveLiquidityRecoveryInput,
+        poolStateWithBalances: PoolStateWithBalances,
+    ): RemoveLiquidityQueryOutput {
+        const { tokenAmounts, bptAmount } = calculateProportionalAmounts(
+            poolStateWithBalances,
+            input.bptIn,
+        );
+        const bptToken = new Token(
+            input.chainId,
+            bptAmount.address,
+            bptAmount.decimals,
+        );
+        const bptIn = TokenAmount.fromRawAmount(bptToken, bptAmount.rawAmount);
+        const amountsOut = tokenAmounts.map((amountIn) =>
+            TokenAmount.fromRawAmount(
+                new Token(input.chainId, amountIn.address, amountIn.decimals),
+                amountIn.rawAmount,
+            ),
+        );
+        return {
+            poolType: poolStateWithBalances.type,
+            removeLiquidityKind: input.kind,
+            poolId: poolStateWithBalances.id,
+            bptIn,
+            amountsOut,
+            tokenOutIndex: undefined,
+            vaultVersion: poolStateWithBalances.vaultVersion,
             chainId: input.chainId,
         };
     }

--- a/src/entities/removeLiquidity/removeLiquidityV2/weighted/removeLiquidityWeighted.ts
+++ b/src/entities/removeLiquidity/removeLiquidityV2/weighted/removeLiquidityWeighted.ts
@@ -9,7 +9,6 @@ import {
     RemoveLiquidityBase,
     RemoveLiquidityBuildCallOutput,
     RemoveLiquidityInput,
-    RemoveLiquidityKind,
     RemoveLiquidityQueryOutput,
 } from '../../types';
 import { PoolState } from '../../../types';
@@ -27,13 +26,10 @@ export class RemoveLiquidityWeighted implements RemoveLiquidityBase {
         const amounts = getAmountsQuery(sortedTokens, input);
 
         const userData = WeightedEncoder.encodeRemoveLiquidityUserData(
-            input.kind === RemoveLiquidityKind.Recovery
-                ? RemoveLiquidityKind.Proportional
-                : input.kind,
+            input.kind,
             amounts,
         );
 
-        // tokensOut will have zero address if removing liquidity to native asset
         const { args, tokensOut } = parseRemoveLiquidityArgs({
             chainId: input.chainId,
             poolId: poolState.id,

--- a/src/entities/removeLiquidity/removeLiquidityV3/index.ts
+++ b/src/entities/removeLiquidity/removeLiquidityV3/index.ts
@@ -74,10 +74,6 @@ export class RemoveLiquidityV3 implements RemoveLiquidityBase {
                     );
                 }
                 break;
-            case RemoveLiquidityKind.Recovery:
-                throw new Error(
-                    'Pending smart contract implementation and Router ABI update',
-                );
         }
 
         const bptToken = new Token(input.chainId, poolState.address, 18);

--- a/src/entities/removeLiquidity/types.ts
+++ b/src/entities/removeLiquidity/types.ts
@@ -53,8 +53,7 @@ export type RemoveLiquidityInput =
     | RemoveLiquidityUnbalancedInput
     | RemoveLiquiditySingleTokenExactOutInput
     | RemoveLiquiditySingleTokenExactInInput
-    | RemoveLiquidityProportionalInput
-    | RemoveLiquidityRecoveryInput;
+    | RemoveLiquidityProportionalInput;
 
 // Returned from a remove liquidity query
 export type RemoveLiquidityBaseQueryOutput = {

--- a/src/entities/removeLiquidity/types.ts
+++ b/src/entities/removeLiquidity/types.ts
@@ -1,7 +1,7 @@
 import { TokenAmount } from '../tokenAmount';
 import { Slippage } from '../slippage';
 import { Address, InputAmount } from '../../types';
-import { PoolState } from '../types';
+import { PoolState, PoolStateWithBalances } from '../types';
 import {
     RemoveLiquidityV2BuildCallInput,
     RemoveLiquidityV2QueryOutput,
@@ -93,6 +93,10 @@ export interface RemoveLiquidityBase {
         input: RemoveLiquidityInput,
         poolState: PoolState,
     ): Promise<RemoveLiquidityQueryOutput>;
+    queryRemoveLiquidityRecovery(
+        input: RemoveLiquidityRecoveryInput,
+        poolStateWithBalances: PoolStateWithBalances,
+    ): RemoveLiquidityQueryOutput;
     buildCall(
         input: RemoveLiquidityBuildCallInput,
     ): RemoveLiquidityBuildCallOutput;

--- a/src/entities/removeLiquidity/types.ts
+++ b/src/entities/removeLiquidity/types.ts
@@ -1,7 +1,7 @@
 import { TokenAmount } from '../tokenAmount';
 import { Slippage } from '../slippage';
 import { Address, InputAmount } from '../../types';
-import { PoolState, PoolStateWithBalances } from '../types';
+import { PoolState } from '../types';
 import {
     RemoveLiquidityV2BuildCallInput,
     RemoveLiquidityV2QueryOutput,
@@ -95,8 +95,8 @@ export interface RemoveLiquidityBase {
     ): Promise<RemoveLiquidityQueryOutput>;
     queryRemoveLiquidityRecovery(
         input: RemoveLiquidityRecoveryInput,
-        poolStateWithBalances: PoolStateWithBalances,
-    ): RemoveLiquidityQueryOutput;
+        poolState: PoolState,
+    ): Promise<RemoveLiquidityQueryOutput>;
     buildCall(
         input: RemoveLiquidityBuildCallInput,
     ): RemoveLiquidityBuildCallOutput;

--- a/src/entities/types.ts
+++ b/src/entities/types.ts
@@ -1,4 +1,4 @@
-import { HumanAmount, MinimalToken, RawPoolToken } from '../data';
+import { HumanAmount, MinimalToken, PoolTokenWithBalance } from '../data';
 import { Address, Hex, PoolType } from '../types';
 
 // Returned from API and used as input
@@ -14,7 +14,7 @@ export type PoolStateWithBalances = {
     id: Hex;
     address: Address;
     type: string;
-    tokens: RawPoolToken[];
+    tokens: PoolTokenWithBalance[];
     totalShares: HumanAmount;
     vaultVersion: 2 | 3;
 };

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -45,3 +45,9 @@ export function removeIndex<T>(array: T[], index: number): T[] {
         ? array
         : [...array.slice(0, index), ...array.slice(index + 1)];
 }
+
+export function insertIndex<T>(array: T[], index: number, value: T): T[] {
+    return index === -1
+        ? array
+        : [...array.slice(0, index), value, ...array.slice(index)];
+}

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -81,3 +81,81 @@ export async function getPoolTokensV3(
         );
     }
 }
+
+export async function getTotalSupply(
+    poolAddress: Address,
+    client: PublicClient,
+): Promise<bigint> {
+    const abi = [
+        {
+            inputs: [],
+            name: 'totalSupply',
+            outputs: [
+                {
+                    internalType: 'uint256',
+                    name: '',
+                    type: 'uint256',
+                },
+            ],
+            stateMutability: 'view',
+            type: 'function',
+        },
+    ];
+
+    try {
+        const poolContract = getContract({
+            abi,
+            address: poolAddress,
+            client,
+        });
+
+        const totalSupply: bigint =
+            (await poolContract.read.totalSupply()) as bigint;
+
+        return totalSupply;
+    } catch (e) {
+        console.warn(e);
+        throw new Error(
+            `Error: Unable to get total supply for pool ${poolAddress}`,
+        );
+    }
+}
+
+export async function getActualSupply(
+    poolAddress: Address,
+    client: PublicClient,
+): Promise<bigint> {
+    const abi = [
+        {
+            inputs: [],
+            name: 'getActualSupply',
+            outputs: [
+                {
+                    internalType: 'uint256',
+                    name: '',
+                    type: 'uint256',
+                },
+            ],
+            stateMutability: 'view',
+            type: 'function',
+        },
+    ];
+
+    try {
+        const poolContract = getContract({
+            abi,
+            address: poolAddress,
+            client,
+        });
+
+        const actualSupply: bigint =
+            (await poolContract.read.getActualSupply()) as bigint;
+
+        return actualSupply;
+    } catch (e) {
+        console.warn(e);
+        throw new Error(
+            `Error: Unable to get actual supply for pool ${poolAddress}`,
+        );
+    }
+}

--- a/test/lib/utils/index.ts
+++ b/test/lib/utils/index.ts
@@ -9,5 +9,6 @@ export * from './initPoolHelper';
 export * from './promises';
 export * from './relayerHelper';
 export * from './removeLiquidityHelper';
+export * from './removeLiquidityRecoveryHelper';
 export * from './swapHelpers';
 export * from './types';

--- a/test/lib/utils/removeLiquidityRecoveryHelper.ts
+++ b/test/lib/utils/removeLiquidityRecoveryHelper.ts
@@ -1,0 +1,192 @@
+import {
+    NATIVE_ASSETS,
+    PoolState,
+    RemoveLiquidityBuildCallInput,
+    RemoveLiquidityBuildCallOutput,
+    RemoveLiquidityQueryOutput,
+    RemoveLiquidityRecoveryInput,
+    Slippage,
+    Token,
+    TokenAmount,
+} from 'src';
+import { getTokensForBalanceCheck } from './getTokensForBalanceCheck';
+import { sendTransactionGetBalances } from './helper';
+import { RemoveLiquidityRecoveryTxInput } from './types';
+import { RemoveLiquidityV2BaseBuildCallInput } from '@/entities/removeLiquidity/removeLiquidityV2/types';
+import {
+    RemoveLiquidityOutput,
+    assertRemoveLiquidityBuildCallOutput,
+    assertTokenDeltas,
+    getCheck,
+} from './removeLiquidityHelper';
+
+export const sdkRemoveLiquidityRecovery = async ({
+    removeLiquidity,
+    removeLiquidityRecoveryInput,
+    poolStateWithBalances,
+    slippage,
+    testAddress,
+    wethIsEth,
+    toInternalBalance,
+}: Omit<RemoveLiquidityRecoveryTxInput, 'client'>): Promise<{
+    removeLiquidityBuildCallOutput: RemoveLiquidityBuildCallOutput;
+    removeLiquidityQueryOutput: RemoveLiquidityQueryOutput;
+}> => {
+    const removeLiquidityQueryOutput =
+        removeLiquidity.queryRemoveLiquidityRecovery(
+            removeLiquidityRecoveryInput,
+            poolStateWithBalances,
+        );
+
+    let removeLiquidityBuildInput: RemoveLiquidityBuildCallInput = {
+        ...removeLiquidityQueryOutput,
+        slippage,
+        wethIsEth: !!wethIsEth,
+    };
+    if (poolStateWithBalances.vaultVersion === 2) {
+        (removeLiquidityBuildInput as RemoveLiquidityV2BaseBuildCallInput) = {
+            ...removeLiquidityBuildInput,
+            sender: testAddress,
+            recipient: testAddress,
+            toInternalBalance: !!toInternalBalance,
+        };
+    }
+
+    const removeLiquidityBuildCallOutput = removeLiquidity.buildCall(
+        removeLiquidityBuildInput,
+    );
+
+    return {
+        removeLiquidityBuildCallOutput,
+        removeLiquidityQueryOutput,
+    };
+};
+
+/**
+ * Create and submit remove liquidity transaction.
+ * @param txInput
+ *     @param client: Client & PublicActions & WalletActions - The RPC client
+ *     @param removeLiquidity: RemoveLiquidity - The remove liquidity class, used to query outputs and build transaction call
+ *     @param removeLiquidityInput: RemoveLiquidityInput - The parameters of the transaction, example: bptIn, amountsOut, etc.
+ *     @param slippage: Slippage - The slippage tolerance for the transaction
+ *     @param poolState: PoolState - The state of the pool
+ *     @param testAddress: Address - The address to send the transaction from
+ *  */
+export async function doRemoveLiquidityRecovery(
+    txInput: RemoveLiquidityRecoveryTxInput,
+) {
+    const {
+        removeLiquidity,
+        poolStateWithBalances,
+        removeLiquidityRecoveryInput,
+        testAddress,
+        client,
+        slippage,
+        wethIsEth,
+    } = txInput;
+
+    const { removeLiquidityQueryOutput, removeLiquidityBuildCallOutput } =
+        await sdkRemoveLiquidityRecovery({
+            removeLiquidity,
+            removeLiquidityRecoveryInput,
+            poolStateWithBalances,
+            slippage,
+            testAddress,
+            wethIsEth,
+        });
+
+    // get tokens for balance change - pool tokens, BPT, native
+    const tokens = getTokensForBalanceCheck(poolStateWithBalances);
+
+    // send transaction and calculate balance changes
+    const txOutput = await sendTransactionGetBalances(
+        tokens,
+        client,
+        testAddress,
+        removeLiquidityBuildCallOutput.to,
+        removeLiquidityBuildCallOutput.call,
+        removeLiquidityBuildCallOutput.value,
+    );
+
+    return {
+        removeLiquidityQueryOutput,
+        removeLiquidityBuildCallOutput,
+        txOutput,
+    };
+}
+
+export function assertRemoveLiquidityRecovery(
+    poolState: PoolState,
+    removeLiquidityRecoveryInput: RemoveLiquidityRecoveryInput,
+    removeLiquidityOutput: RemoveLiquidityOutput,
+    slippage: Slippage,
+    vaultVersion: 2 | 3 = 2,
+    wethIsEth?: boolean,
+) {
+    const {
+        txOutput,
+        removeLiquidityQueryOutput,
+        removeLiquidityBuildCallOutput,
+    } = removeLiquidityOutput;
+
+    const bptToken = new Token(
+        removeLiquidityRecoveryInput.chainId,
+        poolState.address,
+        18,
+    );
+
+    const expectedQueryOutput: Omit<
+        RemoveLiquidityQueryOutput,
+        'amountsOut' | 'bptIndex'
+    > = {
+        // Query should use same bpt out as user sets
+        bptIn: TokenAmount.fromRawAmount(
+            bptToken,
+            removeLiquidityRecoveryInput.bptIn.rawAmount,
+        ),
+        // Only expect tokenInIndex for AddLiquiditySingleToken
+        tokenOutIndex: undefined,
+        // Should match inputs
+        poolId: poolState.id,
+        poolType: poolState.type,
+        removeLiquidityKind: removeLiquidityRecoveryInput.kind,
+        vaultVersion: poolState.vaultVersion,
+        chainId: removeLiquidityRecoveryInput.chainId,
+    };
+
+    const queryCheck = getCheck(removeLiquidityQueryOutput, true);
+
+    expect(queryCheck).to.deep.eq(expectedQueryOutput);
+
+    // Expect all assets in to have an amount > 0 apart from BPT if it exists
+    removeLiquidityQueryOutput.amountsOut.forEach((a) => {
+        if (a.token.address === poolState.address) expect(a.amount).toEqual(0n);
+        else expect(a.amount > 0n).to.be.true;
+    });
+
+    if (wethIsEth) {
+        expect(
+            removeLiquidityQueryOutput.amountsOut.some((a) =>
+                a.token.isSameAddress(
+                    NATIVE_ASSETS[removeLiquidityQueryOutput.chainId].wrapped,
+                ),
+            ),
+        ).to.be.true;
+    }
+
+    assertRemoveLiquidityBuildCallOutput(
+        removeLiquidityQueryOutput,
+        removeLiquidityBuildCallOutput,
+        true,
+        slippage,
+        vaultVersion,
+    );
+
+    assertTokenDeltas(
+        poolState,
+        removeLiquidityRecoveryInput,
+        removeLiquidityQueryOutput,
+        txOutput,
+        wethIsEth,
+    );
+}

--- a/test/lib/utils/removeLiquidityRecoveryHelper.ts
+++ b/test/lib/utils/removeLiquidityRecoveryHelper.ts
@@ -23,7 +23,7 @@ import {
 export const sdkRemoveLiquidityRecovery = async ({
     removeLiquidity,
     removeLiquidityRecoveryInput,
-    poolStateWithBalances,
+    poolState,
     slippage,
     testAddress,
     wethIsEth,
@@ -33,9 +33,9 @@ export const sdkRemoveLiquidityRecovery = async ({
     removeLiquidityQueryOutput: RemoveLiquidityQueryOutput;
 }> => {
     const removeLiquidityQueryOutput =
-        removeLiquidity.queryRemoveLiquidityRecovery(
+        await removeLiquidity.queryRemoveLiquidityRecovery(
             removeLiquidityRecoveryInput,
-            poolStateWithBalances,
+            poolState,
         );
 
     let removeLiquidityBuildInput: RemoveLiquidityBuildCallInput = {
@@ -43,7 +43,7 @@ export const sdkRemoveLiquidityRecovery = async ({
         slippage,
         wethIsEth: !!wethIsEth,
     };
-    if (poolStateWithBalances.vaultVersion === 2) {
+    if (poolState.vaultVersion === 2) {
         (removeLiquidityBuildInput as RemoveLiquidityV2BaseBuildCallInput) = {
             ...removeLiquidityBuildInput,
             sender: testAddress,
@@ -77,7 +77,7 @@ export async function doRemoveLiquidityRecovery(
 ) {
     const {
         removeLiquidity,
-        poolStateWithBalances,
+        poolState,
         removeLiquidityRecoveryInput,
         testAddress,
         client,
@@ -89,14 +89,14 @@ export async function doRemoveLiquidityRecovery(
         await sdkRemoveLiquidityRecovery({
             removeLiquidity,
             removeLiquidityRecoveryInput,
-            poolStateWithBalances,
+            poolState,
             slippage,
             testAddress,
             wethIsEth,
         });
 
     // get tokens for balance change - pool tokens, BPT, native
-    const tokens = getTokensForBalanceCheck(poolStateWithBalances);
+    const tokens = getTokensForBalanceCheck(poolState);
 
     // send transaction and calculate balance changes
     const txOutput = await sendTransactionGetBalances(

--- a/test/lib/utils/types.ts
+++ b/test/lib/utils/types.ts
@@ -9,6 +9,8 @@ import {
     Slippage,
     ChainId,
     NestedPoolState,
+    RemoveLiquidityRecoveryInput,
+    PoolStateWithBalances,
 } from '@/.';
 import { CreatePool } from '@/entities/createPool';
 import { CreatePoolInput } from '@/entities/createPool/types';
@@ -34,15 +36,23 @@ export type InitPoolTxInput = Omit<
     initPool: InitPool;
 };
 
-export type RemoveLiquidityTxInput = {
+export type RemoveLiquidityTxInputBase = {
     client: Client & PublicActions & TestActions & WalletActions;
     removeLiquidity: RemoveLiquidity;
-    removeLiquidityInput: RemoveLiquidityInput;
     slippage: Slippage;
-    poolState: PoolState;
     testAddress: Address;
     wethIsEth?: boolean;
     toInternalBalance?: boolean;
+};
+
+export type RemoveLiquidityTxInput = RemoveLiquidityTxInputBase & {
+    removeLiquidityInput: RemoveLiquidityInput;
+    poolState: PoolState;
+};
+
+export type RemoveLiquidityRecoveryTxInput = RemoveLiquidityTxInputBase & {
+    removeLiquidityRecoveryInput: RemoveLiquidityRecoveryInput;
+    poolStateWithBalances: PoolStateWithBalances;
 };
 
 export type CreatePoolTxInput = {

--- a/test/lib/utils/types.ts
+++ b/test/lib/utils/types.ts
@@ -10,7 +10,6 @@ import {
     ChainId,
     NestedPoolState,
     RemoveLiquidityRecoveryInput,
-    PoolStateWithBalances,
 } from '@/.';
 import { CreatePool } from '@/entities/createPool';
 import { CreatePoolInput } from '@/entities/createPool/types';
@@ -39,6 +38,7 @@ export type InitPoolTxInput = Omit<
 export type RemoveLiquidityTxInputBase = {
     client: Client & PublicActions & TestActions & WalletActions;
     removeLiquidity: RemoveLiquidity;
+    poolState: PoolState;
     slippage: Slippage;
     testAddress: Address;
     wethIsEth?: boolean;
@@ -47,12 +47,10 @@ export type RemoveLiquidityTxInputBase = {
 
 export type RemoveLiquidityTxInput = RemoveLiquidityTxInputBase & {
     removeLiquidityInput: RemoveLiquidityInput;
-    poolState: PoolState;
 };
 
 export type RemoveLiquidityRecoveryTxInput = RemoveLiquidityTxInputBase & {
     removeLiquidityRecoveryInput: RemoveLiquidityRecoveryInput;
-    poolStateWithBalances: PoolStateWithBalances;
 };
 
 export type CreatePoolTxInput = {

--- a/test/v2/removeLiquidity/composableStable.recovery.integration.test.ts
+++ b/test/v2/removeLiquidity/composableStable.recovery.integration.test.ts
@@ -12,9 +12,8 @@ import {
 import {
     CHAINS,
     ChainId,
-    HumanAmount,
     InputAmount,
-    PoolStateWithBalances,
+    PoolState,
     RemoveLiquidity,
     RemoveLiquidityKind,
     RemoveLiquidityRecoveryInput,
@@ -38,13 +37,13 @@ const testPool = POOLS[chainId].vETH_WETH;
 
 describe('composable stable remove liquidity test', () => {
     let txInput: RemoveLiquidityRecoveryTxInput;
-    let poolStateWithBalances: PoolStateWithBalances;
+    let poolState: PoolState;
     beforeAll(async () => {
         // setup mock api
         const api = new MockApi();
 
         // get pool state from api
-        poolStateWithBalances = await api.getPoolWithBalances();
+        poolState = await api.getPool();
 
         const client = createTestClient({
             mode: 'anvil',
@@ -60,7 +59,7 @@ describe('composable stable remove liquidity test', () => {
             client,
             removeLiquidity: new RemoveLiquidity(),
             slippage: Slippage.fromPercentage('1'), // 1%
-            poolStateWithBalances,
+            poolState,
             testAddress,
             removeLiquidityRecoveryInput: {} as RemoveLiquidityRecoveryInput,
         };
@@ -82,7 +81,7 @@ describe('composable stable remove liquidity test', () => {
             const bptIn: InputAmount = {
                 rawAmount: parseEther('0.1'),
                 decimals: 18,
-                address: poolStateWithBalances.address,
+                address: poolState.address,
             };
             input = {
                 bptIn,
@@ -98,11 +97,11 @@ describe('composable stable remove liquidity test', () => {
             });
 
             assertRemoveLiquidityRecovery(
-                txInput.poolStateWithBalances,
+                txInput.poolState,
                 input,
                 removeLiquidityOutput,
                 txInput.slippage,
-                poolStateWithBalances.vaultVersion,
+                poolState.vaultVersion,
             );
         });
         test('with native', async () => {
@@ -114,11 +113,11 @@ describe('composable stable remove liquidity test', () => {
             });
 
             assertRemoveLiquidityRecovery(
-                txInput.poolStateWithBalances,
+                txInput.poolState,
                 input,
                 removeLiquidityOutput,
                 txInput.slippage,
-                poolStateWithBalances.vaultVersion,
+                poolState.vaultVersion,
                 wethIsEth,
             );
         });
@@ -126,31 +125,22 @@ describe('composable stable remove liquidity test', () => {
 });
 
 class MockApi {
-    public async getPoolWithBalances(): Promise<PoolStateWithBalances> {
+    public async getPool(): Promise<PoolState> {
         const tokens = [
             {
                 address: testPool.address,
                 decimals: testPool.decimals,
                 index: 0,
-                name: 'vETH_wETH',
-                symbol: 'vETH_wETH',
-                balance: '2596148429267413.794052669613761796' as HumanAmount,
             },
             {
                 address: TOKENS_MAINNET.vETH.address,
                 decimals: TOKENS_MAINNET.vETH.decimals,
                 index: 1,
-                name: 'vETH',
-                symbol: 'vETH',
-                balance: '1.045187143371175654' as HumanAmount,
             },
             {
                 address: TOKENS_MAINNET.WETH.address,
                 decimals: TOKENS_MAINNET.WETH.decimals,
                 index: 2,
-                name: 'WETH',
-                symbol: 'WETH',
-                balance: '0.813652579142753934' as HumanAmount,
             },
         ];
 
@@ -159,7 +149,6 @@ class MockApi {
             address: testPool.address,
             type: testPool.type,
             tokens,
-            totalShares: '1.879969119336134102' as HumanAmount,
             vaultVersion: 2,
         };
     }

--- a/test/v2/removeLiquidity/weighted.recovery.integration.test.ts
+++ b/test/v2/removeLiquidity/weighted.recovery.integration.test.ts
@@ -26,13 +26,13 @@ import {
 
 import {
     assertRemoveLiquidityRecovery,
+    doRemoveLiquidityRecovery,
     forkSetup,
     POOLS,
     RemoveLiquidityRecoveryTxInput,
     TOKENS,
 } from 'test/lib/utils';
 import { ANVIL_NETWORKS, startFork } from 'test/anvil/anvil-global-setup';
-import { doRemoveLiquidityRecovery } from 'test/lib/utils/removeLiquidityRecoveryHelper';
 
 const chainId = ChainId.POLYGON;
 const { rpcUrl } = await startFork(ANVIL_NETWORKS[ChainId[chainId]]);

--- a/test/v2/utils/calculateProportionalAmounts.integration.test.ts
+++ b/test/v2/utils/calculateProportionalAmounts.integration.test.ts
@@ -1,3 +1,5 @@
+// pnpm test -- calculateProportionalAmounts.integration.test.ts
+
 import {
     AddLiquidity,
     Slippage,
@@ -35,7 +37,7 @@ const poolId =
 describe('add liquidity composable stable test', () => {
     let txInput: AddLiquidityTxInput;
     let poolState: PoolStateWithBalances;
-    let functionOutput: { amountsIn: InputAmount[]; bptOut: InputAmount };
+    let functionOutput: { tokenAmounts: InputAmount[]; bptAmount: InputAmount };
     beforeAll(async () => {
         // setup mock api
         const api = new MockApi();
@@ -93,7 +95,7 @@ describe('add liquidity composable stable test', () => {
         test('token inputs', async () => {
             const addLiquidityInput = {
                 ...input,
-                amountsIn: functionOutput.amountsIn,
+                amountsIn: functionOutput.tokenAmounts,
             };
             const addLiquidityOutput = await doAddLiquidity({
                 ...txInput,
@@ -101,7 +103,7 @@ describe('add liquidity composable stable test', () => {
             });
             let delta =
                 addLiquidityOutput.addLiquidityQueryOutput.bptOut.amount -
-                functionOutput.bptOut.rawAmount;
+                functionOutput.bptAmount.rawAmount;
             if (delta < 0) {
                 delta = -delta;
             }
@@ -112,7 +114,7 @@ describe('add liquidity composable stable test', () => {
         let input: AddLiquidityProportionalInput;
         beforeAll(() => {
             input = {
-                bptOut: functionOutput.bptOut,
+                bptOut: functionOutput.bptAmount,
                 chainId,
                 rpcUrl,
                 kind: AddLiquidityKind.Proportional,
@@ -128,7 +130,7 @@ describe('add liquidity composable stable test', () => {
                 .slice(1)
                 .forEach(({ amount }, index) => {
                     const signedDelta =
-                        amount - functionOutput.amountsIn[index].rawAmount;
+                        amount - functionOutput.tokenAmounts[index].rawAmount;
                     const delta = signedDelta < 0 ? -signedDelta : signedDelta;
                     expect(delta < 10n).to.be.true; // 10n of tolerance
                 });

--- a/test/v3/initPool.integration.test.ts
+++ b/test/v3/initPool.integration.test.ts
@@ -1,3 +1,5 @@
+// pnpm test -- test/v3/initPool.integration.test.ts
+
 import {
     PoolState,
     CreatePool,
@@ -43,7 +45,7 @@ describe('Initialize Pool V3 - Weighted Pool', async () => {
         const client = createTestClient({
             mode: 'anvil',
             chain: CHAINS[chainId],
-            transport: http(rpcUrl),
+            transport: http(rpcUrl, { timeout: 60_000 }),
         })
             .extend(publicActions)
             .extend(walletActions);
@@ -119,7 +121,7 @@ describe('Initialize Pool V3 - Weighted Pool', async () => {
             undefined,
             3,
         );
-    });
+    }, 60000);
     test('Initialize Pool V3 - Weighted Pool', async () => {
         const addLiquidityOutput = await doInitPool({
             ...initPoolTxInput,
@@ -128,5 +130,5 @@ describe('Initialize Pool V3 - Weighted Pool', async () => {
         });
 
         assertInitPool(initPoolInput, addLiquidityOutput);
-    });
+    }, 60000);
 });

--- a/test/v3/initPool.integration.test.ts
+++ b/test/v3/initPool.integration.test.ts
@@ -45,7 +45,7 @@ describe('Initialize Pool V3 - Weighted Pool', async () => {
         const client = createTestClient({
             mode: 'anvil',
             chain: CHAINS[chainId],
-            transport: http(rpcUrl, { timeout: 60_000 }),
+            transport: http(rpcUrl, { timeout: 120_000 }), // FIXME: shouldn't take that long - investigate/fix in a following PR
         })
             .extend(publicActions)
             .extend(walletActions);
@@ -121,7 +121,7 @@ describe('Initialize Pool V3 - Weighted Pool', async () => {
             undefined,
             3,
         );
-    }, 60000);
+    }, 120_000);
     test('Initialize Pool V3 - Weighted Pool', async () => {
         const addLiquidityOutput = await doInitPool({
             ...initPoolTxInput,
@@ -130,5 +130,5 @@ describe('Initialize Pool V3 - Weighted Pool', async () => {
         });
 
         assertInitPool(initPoolInput, addLiquidityOutput);
-    }, 60000);
+    }, 120_000);
 });


### PR DESCRIPTION
Closes #279 

Main:
- Move queryRemoveLiquidityRecovery into a separate method

Also:
- Refactor calculateProportionalAmounts to be a bit more generic:
    - Accept bptAmount as input
    - Rename variables so it's not relative to addLiquidity only (e.g. amountsIn/bptOut -> tokenAmounts/bptAmount)