### PR TITLE
Fix nested phantom bpt

### DIFF
--- a/.changeset/hot-timers-tell.md
+++ b/.changeset/hot-timers-tell.md
@@ -1,0 +1,5 @@
+---
+"@balancer/sdk": patch
+---
+
+Filter phantomBpt in mapPoolToNestedPoolState.

--- a/src/data/providers/balancer-api/index.ts
+++ b/src/data/providers/balancer-api/index.ts
@@ -5,7 +5,10 @@ import { NestedPools } from './modules/nested-pool-state';
 import { SorSwapPaths } from './modules/sorSwapPaths';
 
 export { SorInput as GetQuoteInput } from './modules/sorSwapPaths';
-export { mapPoolToNestedPoolState } from './modules/nested-pool-state';
+export {
+    mapPoolToNestedPoolState,
+    PoolGetPool,
+} from './modules/nested-pool-state';
 
 export class BalancerApi {
     balancerApiClient: BalancerApiClient;

--- a/src/data/providers/balancer-api/modules/nested-pool-state/index.ts
+++ b/src/data/providers/balancer-api/modules/nested-pool-state/index.ts
@@ -5,7 +5,7 @@ import { Address, Hex } from '../../../../../types';
 import { mapPoolType } from '@/utils/poolTypeMapper';
 import { isSameAddress } from '@/utils';
 
-type PoolGetPool = {
+export type PoolGetPool = {
     id: Hex;
     address: Address;
     type: string;

--- a/src/data/providers/balancer-api/modules/nested-pool-state/index.ts
+++ b/src/data/providers/balancer-api/modules/nested-pool-state/index.ts
@@ -3,6 +3,7 @@ import { NestedPool, NestedPoolState } from '../../../../../entities';
 import { MinimalToken } from '../../../../types';
 import { Address, Hex } from '../../../../../types';
 import { mapPoolType } from '@/utils/poolTypeMapper';
+import { isSameAddress } from '@/utils';
 
 type PoolGetPool = {
     id: Hex;
@@ -105,7 +106,12 @@ export function mapPoolToNestedPoolState(pool: PoolGetPool): NestedPoolState {
 
     pool.poolTokens.forEach((token) => {
         // Token represents nested pools only if they have a nestedPool property
-        if (!token.nestedPool) return;
+        // Filter out phantomBpt
+        if (
+            !token.nestedPool ||
+            isSameAddress(pool.address, token.nestedPool.address)
+        )
+            return;
 
         // map API result to NestedPool
         pools.push({

--- a/src/entities/utils/validateNestedPoolState.ts
+++ b/src/entities/utils/validateNestedPoolState.ts
@@ -23,14 +23,20 @@ export function validateNestedPoolState(
         );
 
         if (poolsWithToken.length < 1)
-            throw 'NestedPoolState, main token must exist as a token of a pool';
+            throw new Error(
+                'NestedPoolState, main token must exist as a token of a pool',
+            );
 
         if (poolsWithToken.length > 1)
-            throw `NestedPoolState, main token can't be token of more than 1 pool`;
+            throw new Error(
+                `NestedPoolState, main token can't be token of more than 1 pool`,
+            );
 
         if (poolsWithToken[0]) {
             if (topLevel - poolsWithToken[0].level > 1)
-                throw 'NestedPoolState, main token only supported to a max of 1 level of nesting';
+                throw new Error(
+                    'NestedPoolState, main token only supported to a max of 1 level of nesting',
+                );
         }
     });
     return true;


### PR DESCRIPTION
API returns the BPT address as part of the nestedPool tokens data when pool has phantomBpt. (This is unexpected?)
When mapping it meant it appeared in `pools` twice. The change filters out any phantomBpt. 
Note - this only fixes things for consumers using sdk data providers, it may cause issues if API is being consumed/mapped separately.
```
{
  "data": {
    "poolGetPool": {
      "poolTokens": [
        {
          "index": 0,
          "address": "0x49cbd67651fbabce12d1df18499896ec87bef46f",
          "decimals": 18,
          "nestedPool": {
            "id": "0x49cbd67651fbabce12d1df18499896ec87bef46f00000000000000000000064a",
            "address": "0x49cbd67651fbabce12d1df18499896ec87bef46f",
            "type": "COMPOSABLE_STABLE",
            "tokens": [
              {
                "index": 0,
                "address": "0x49cbd67651fbabce12d1df18499896ec87bef46f", ----------PhantomBpt token
                "decimals": 18
              },
              {
                "index": 1,
                "address": "0x79c58f70905f734641735bc61e45c19dd9ad60bc",
                "decimals": 18
              },
              {
                "index": 2,
                "address": "0x83f20f44975d03b1b09e64809b757c47f942beea",
                "decimals": 18
              }
            ]
          }
        },
        ....cut rest out
      ]
    }
  }
}
```