### PR TITLE
fix: add liquidity example

### DIFF
--- a/examples/addLiquidity/addLiquidity.ts
+++ b/examples/addLiquidity/addLiquidity.ts
@@ -26,17 +26,17 @@ async function runAgainstFork() {
     const userAccount = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045';
     // 80BAL-20WETH
     const pool = {
-        id: '0xB2456A6f51530053bC41b0EE700fe6A2C37282e8',
-        address: '0xB2456A6f51530053bC41b0EE700fe6A2C37282e8' as Address,
+        id: '0x03Bf996C7BD45B3386cb41875761d45e27EaB284',
+        address: '0x03Bf996C7BD45B3386cb41875761d45e27EaB284' as Address,
     };
     const amountsIn = [
         {
-            rawAmount: parseEther('0.01'),
+            rawAmount: parseEther('0.001'),
             decimals: 18,
             address: '0x7b79995e5f793a07bc00c21412e50ecae098e7f9' as Address,
         },
         {
-            rawAmount: parseEther('0.01'),
+            rawAmount: parseEther('0.001'),
             decimals: 18,
             address: '0xb19382073c7a0addbb56ac6af1808fa49e377b75' as Address,
         },
@@ -77,7 +77,10 @@ const addLiquidity = async ({
     slippage,
 }) => {
     // API is used to fetch relevant pool data
-    const balancerApi = new BalancerApi('https://api-v3.balancer.fi/', chainId);
+    const balancerApi = new BalancerApi(
+        'https://test-api-v3.balancer.fi/',
+        chainId,
+    );
     const poolState = await balancerApi.pools.fetchPoolState(poolId);
 
     // Construct the AddLiquidityInput, in this case an AddLiquidityUnbalanced

--- a/src/data/providers/balancer-api/modules/pool-state/index.ts
+++ b/src/data/providers/balancer-api/modules/pool-state/index.ts
@@ -2,10 +2,12 @@ import { BalancerApiClient } from '../../client';
 import { PoolState, PoolStateWithBalances } from '../../../../../entities';
 import { mapPoolType } from '../../../../../utils/poolTypeMapper';
 
+import { API_CHAIN_NAMES } from '../../../../../utils/constants';
+
 export class Pools {
     readonly poolStateQuery = `
-    query GetPool($id: String!) {
-      poolGetPool(id:$id) {
+    query poolGetPool($id: String!, $chain: GqlChain!) {
+      poolGetPool(id: $id, chain:$chain) {
         id
         address
         type
@@ -19,8 +21,8 @@ export class Pools {
     }`;
 
     readonly poolStateWithRawTokensQuery = `
-    query GetPool($id: String!) {
-      poolGetPool(id:$id) {
+    query GetPool($id: String!, $chain: GqlChain!) {
+      poolGetPool(id:$id, chain:$chain) {
         id
         address
         type
@@ -44,6 +46,8 @@ export class Pools {
             query: this.poolStateQuery,
             variables: {
                 id: id.toLowerCase(),
+                // the API requires chain names to be sent as uppercase strings
+                chain: API_CHAIN_NAMES[this.balancerApiClient.chainId],
             },
         });
         const poolGetPool: PoolState = {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -72,6 +72,22 @@ export enum ChainId {
     SEPOLIA = 11155111,
 }
 
+// The Balancer API requires the chain to be passed as a specific string
+export const API_CHAIN_NAMES: Record<number, string> = {
+    [ChainId.MAINNET]: 'MAINNET',
+    [ChainId.OPTIMISM]: 'OPTIMISM',
+    [ChainId.GNOSIS_CHAIN]: 'GNOSIS',
+    [ChainId.POLYGON]: 'POLYGON',
+    [ChainId.FANTOM]: 'FANTOM',
+    [ChainId.FRAXTAL]: 'FRAXTAL',
+    [ChainId.ZKSYNC]: 'ZKEVM',
+    [ChainId.BASE]: 'BASE',
+    [ChainId.MODE]: 'MODE',
+    [ChainId.ARBITRUM_ONE]: 'ARBITRUM',
+    [ChainId.AVALANCHE]: 'AVALANCHE',
+    [ChainId.SEPOLIA]: 'SEPOLIA',
+};
+
 export const CHAINS: Record<number, Chain> = {
     [ChainId.MAINNET]: mainnet,
     [ChainId.GOERLI]: goerli,


### PR DESCRIPTION
This pr fixes the add-liquidity-example. The following changes were made:
- replace the api endpoint. Some V3 pools are not part of the production api endpoint. At a further point in time we need to change it back to the production endpoint
- Reduce add liquidity amount as otherwise the priceImpact calculation (swap queries) will revert with the pool used, due to `revert MaxAmountInRatio`
- Add the chain parameter to the api query
- Added chain name strings the api requires to constants. I initially tried accessing the `Chain.name` from https://github.com/wevm/viem/blob/main/src/types/chain.ts#L49. However, even with uppercasing them they do not perfectly match with what the api expects. 