### PR TITLE
Fix remove liquidity nested query (peek) logic

### DIFF
--- a/.changeset/purple-points-perform.md
+++ b/.changeset/purple-points-perform.md
@@ -1,0 +1,5 @@
+---
+"@balancer/sdk": patch
+---
+
+Fix remove liquidity nested query (peek) logic

--- a/src/entities/removeLiquidityNested/doRemoveLiquidityNestedQuery.ts
+++ b/src/entities/removeLiquidityNested/doRemoveLiquidityNestedQuery.ts
@@ -12,7 +12,7 @@ export const doRemoveLiquidityNestedQuery = async (
     chainId: ChainId,
     rpcUrl: string,
     encodedMulticall: Hex,
-    tokensOutLength: number,
+    tokensOutIndexes: number[],
 ): Promise<bigint[]> => {
     const client = createPublicClient({
         transport: http(rpcUrl),
@@ -30,11 +30,12 @@ export const doRemoveLiquidityNestedQuery = async (
         data: data as Hex,
     });
 
-    const resultsToPeek = result.slice(result.length - tokensOutLength);
+    const peekedValues: bigint[] = [];
 
-    const peekedValues = resultsToPeek.map(
-        (r) => decodeAbiParameters([{ type: 'uint256' }], r)[0],
-    );
+    result.forEach((r, i) => {
+        if (tokensOutIndexes.includes(i))
+            peekedValues.push(decodeAbiParameters([{ type: 'uint256' }], r)[0]);
+    });
 
     return peekedValues;
 };

--- a/src/entities/removeLiquidityNested/getPeekCalls.ts
+++ b/src/entities/removeLiquidityNested/getPeekCalls.ts
@@ -26,9 +26,13 @@ export const getPeekCalls = (
 
                 if (!isTokenBeingUsedAsInput) {
                     tokensOut.push(tokenOut);
+                    const readOnlyChainedReference = Relayer.toChainedReference(
+                        Relayer.fromChainedReference(outputReference.key),
+                        false,
+                    );
                     peekCalls.push(
                         Relayer.encodePeekChainedReferenceValue(
-                            outputReference.key,
+                            readOnlyChainedReference,
                         ),
                     );
                 }
@@ -40,10 +44,12 @@ export const getPeekCalls = (
         const tokenOut =
             lastCall.sortedTokens[lastCall.tokenOutIndex as number];
         tokensOut.push(tokenOut);
+        const readOnlyChainedReference = Relayer.toChainedReference(
+            Relayer.fromChainedReference(lastCall.outputReferences[0].key),
+            false,
+        );
         peekCalls.push(
-            Relayer.encodePeekChainedReferenceValue(
-                lastCall.outputReferences[0].key,
-            ),
+            Relayer.encodePeekChainedReferenceValue(readOnlyChainedReference),
         );
     }
 


### PR DESCRIPTION
Closes #377 

Peek calls were being added at the end of the multicall array.
This is a problem because results are temporary and may be consumed/cleared by the time the peek happens.
In order to fix this, peek calls were moved to right after their respective call.