### PR TITLE
Fix outputReference index being incorrectly consumed

### DIFF
--- a/.changeset/rare-goats-exercise.md
+++ b/.changeset/rare-goats-exercise.md
@@ -1,0 +1,5 @@
+---
+"@balancer/sdk": patch
+---
+
+Fix outputReference index being incorrectly consumed

--- a/src/entities/removeLiquidityNested/getQueryCallsAttributes.ts
+++ b/src/entities/removeLiquidityNested/getQueryCallsAttributes.ts
@@ -234,8 +234,11 @@ const getBptAmountIn = (
         previousCall = calls[calls.length - 1];
         outputReferenceIndex = 0;
     }
+    const previousCallOutputReference = previousCall.outputReferences.find(
+        (opRef) => opRef.index === BigInt(outputReferenceIndex),
+    ) as { key: bigint; index: bigint };
     return {
-        amount: previousCall.outputReferences[outputReferenceIndex].key,
+        amount: previousCallOutputReference.key,
         isRef: true,
     };
 };


### PR DESCRIPTION
OutputReference index was being incorrectly passed down to the next call input.