### PR TITLE
Fix calculate proportional amounts rounding direction for Cow Amm

### DIFF
--- a/.changeset/tall-jokes-leave.md
+++ b/.changeset/tall-jokes-leave.md
@@ -1,0 +1,5 @@
+---
+"@balancer/sdk": patch
+---
+
+Fix calculate proportional amounts rounding direction for Cow Amm

--- a/test/lib/utils/addresses.ts
+++ b/test/lib/utils/addresses.ts
@@ -172,10 +172,16 @@ export const TOKENS: Record<number, Record<string, TestToken>> = {
         WETH: {
             address: '0x6a023ccd1ff6f2045c3309768ead9e68f978f6e1',
             decimals: 18,
+            slot: 3,
         },
         wstETH: {
             address: '0x6c76971f98945ae98dd7d4dfca8711ebea946ea6',
             decimals: 18,
+        },
+        GNO: {
+            address: '0x9c58bacc331c9aa871afd802db6379a98e80cedb',
+            decimals: 18,
+            slot: 3,
         },
     },
 };


### PR DESCRIPTION
Here’s a bit of context on what this PR fixes:

CowAmm pools use custom maths operations called `bdiv` and `bmul` to calculate proportional amounts internally. The problem is that they are not the exact opposite of each other. In other words, when using them: `a / b = c` but `c * b != a`
This is a problem because we get a referenceAmount (i.e. max user balance) to calculate bptOut and, from there, querying with bptOut as input won't return the same referenceAmount in.
Since these behave similar to `divUp` and `mulUp`, we end up with a slightly bigger amountIn than the user balance.I created a variation of those maths called `bdivDown` and `bmulDown` so we get a slightly smaller bptOut instead, from there we can then use bdiv and bmul to get an exact match on the query amounts.
This will leave some dust behind, but at least won't cause the transaction to revert, even with 0% slippage.