### PR TITLE
Accept ETH as input on buildCallWithPermit

### DIFF
--- a/.changeset/green-pets-wait.md
+++ b/.changeset/green-pets-wait.md
@@ -1,0 +1,5 @@
+---
+"@balancer/sdk": patch
+---
+
+Accept ETH as input on buildCallWithPermit

--- a/src/entities/addLiquidity/addLiquidityCowAmm/index.ts
+++ b/src/entities/addLiquidity/addLiquidityCowAmm/index.ts
@@ -7,6 +7,7 @@ import {
     calculateProportionalAmountsCowAmm,
     getPoolStateWithBalancesCowAmm,
 } from '@/entities/utils';
+import { buildCallWithPermit2ProtocolVersionError } from '@/utils';
 
 import { getAmountsCall } from '../helpers';
 import {
@@ -92,5 +93,9 @@ export class AddLiquidityCowAmm implements AddLiquidityBase {
                 TokenAmount.fromRawAmount(a.token, amounts.maxAmountsIn[i]),
             ),
         };
+    }
+
+    public buildCallWithPermit2(): AddLiquidityBuildCallOutput {
+        throw buildCallWithPermit2ProtocolVersionError;
     }
 }

--- a/src/entities/addLiquidity/addLiquidityV2/composableStable/addLiquidityComposableStable.ts
+++ b/src/entities/addLiquidity/addLiquidityV2/composableStable/addLiquidityComposableStable.ts
@@ -1,7 +1,11 @@
 import { encodeFunctionData } from 'viem';
 import { Token } from '@/entities/token';
 import { TokenAmount } from '@/entities/tokenAmount';
-import { VAULT, ZERO_ADDRESS } from '@/utils';
+import {
+    buildCallWithPermit2ProtocolVersionError,
+    VAULT,
+    ZERO_ADDRESS,
+} from '@/utils';
 import { vaultV2Abi } from '@/abi';
 import {
     AddLiquidityBase,
@@ -112,5 +116,9 @@ export class AddLiquidityComposableStable implements AddLiquidityBase {
                 TokenAmount.fromRawAmount(a.token, amounts.maxAmountsIn[i]),
             ),
         };
+    }
+
+    public buildCallWithPermit2(): AddLiquidityBuildCallOutput {
+        throw buildCallWithPermit2ProtocolVersionError;
     }
 }

--- a/src/entities/addLiquidity/addLiquidityV2/index.ts
+++ b/src/entities/addLiquidity/addLiquidityV2/index.ts
@@ -1,3 +1,4 @@
+import { buildCallWithPermit2ProtocolVersionError } from '@/utils';
 import {
     AddLiquidityBase,
     AddLiquidityBuildCallOutput,
@@ -49,5 +50,9 @@ export class AddLiquidityV2 implements AddLiquidityBase {
         input: AddLiquidityV2BuildCallInput,
     ): AddLiquidityBuildCallOutput {
         return this.getAddLiquidity(input.poolType).buildCall(input);
+    }
+
+    public buildCallWithPermit2(): AddLiquidityBuildCallOutput {
+        throw buildCallWithPermit2ProtocolVersionError;
     }
 }

--- a/src/entities/addLiquidity/addLiquidityV2/stable/addLiquidityStable.ts
+++ b/src/entities/addLiquidity/addLiquidityV2/stable/addLiquidityStable.ts
@@ -2,7 +2,11 @@ import { encodeFunctionData } from 'viem';
 import { Token } from '@/entities/token';
 import { TokenAmount } from '@/entities/tokenAmount';
 import { StableEncoder } from '@/entities/encoders/stable';
-import { VAULT, ZERO_ADDRESS } from '@/utils';
+import {
+    buildCallWithPermit2ProtocolVersionError,
+    VAULT,
+    ZERO_ADDRESS,
+} from '@/utils';
 import { vaultV2Abi } from '@/abi';
 import {
     AddLiquidityBase,
@@ -105,5 +109,9 @@ export class AddLiquidityStable implements AddLiquidityBase {
                 TokenAmount.fromRawAmount(a.token, amounts.maxAmountsIn[i]),
             ),
         };
+    }
+
+    public buildCallWithPermit2(): AddLiquidityBuildCallOutput {
+        throw buildCallWithPermit2ProtocolVersionError;
     }
 }

--- a/src/entities/addLiquidity/addLiquidityV2/weighted/addLiquidityWeighted.ts
+++ b/src/entities/addLiquidity/addLiquidityV2/weighted/addLiquidityWeighted.ts
@@ -2,7 +2,11 @@ import { encodeFunctionData } from 'viem';
 import { Token } from '@/entities/token';
 import { TokenAmount } from '@/entities/tokenAmount';
 import { WeightedEncoder } from '@/entities/encoders/weighted';
-import { VAULT, ZERO_ADDRESS } from '@/utils';
+import {
+    buildCallWithPermit2ProtocolVersionError,
+    VAULT,
+    ZERO_ADDRESS,
+} from '@/utils';
 import { vaultV2Abi } from '@/abi';
 import {
     AddLiquidityBase,
@@ -107,5 +111,9 @@ export class AddLiquidityWeighted implements AddLiquidityBase {
                 TokenAmount.fromRawAmount(a.token, amounts.maxAmountsIn[i]),
             ),
         };
+    }
+
+    public buildCallWithPermit2(): AddLiquidityBuildCallOutput {
+        throw buildCallWithPermit2ProtocolVersionError;
     }
 }

--- a/src/entities/addLiquidity/addLiquidityV3/index.ts
+++ b/src/entities/addLiquidity/addLiquidityV3/index.ts
@@ -23,7 +23,7 @@ import { doAddLiquidityUnbalancedQuery } from './doAddLiquidityUnbalancedQuery';
 import { doAddLiquiditySingleTokenQuery } from './doAddLiquiditySingleTokenQuery';
 import { doAddLiquidityProportionalQuery } from './doAddLiquidityProportionalQuery';
 import { getValue } from '@/entities/utils/getValue';
-import { Permit2 } from '@/entities/permit2';
+import { Permit2 } from '@/entities/permit2Helper';
 
 export class AddLiquidityV3 implements AddLiquidityBase {
     async query(

--- a/src/entities/inputValidator/inputValidator.ts
+++ b/src/entities/inputValidator/inputValidator.ts
@@ -13,11 +13,7 @@ import { InputValidatorGyro } from './gyro/inputValidatorGyro';
 import { InputValidatorStable } from './stable/inputValidatorStable';
 import { InputValidatorBase } from './inputValidatorBase';
 import { InputValidatorWeighted } from './weighted/inputValidatorWeighted';
-import {
-    ChainId,
-    buildCallWithPermit2ETHError,
-    buildCallWithPermit2ProtocolVersionError,
-} from '@/utils';
+import { ChainId, buildCallWithPermit2ProtocolVersionError } from '@/utils';
 
 export class InputValidator {
     validators: Record<string, InputValidatorBase> = {};
@@ -98,14 +94,9 @@ export class InputValidator {
 
     static validateBuildCallWithPermit2(input: {
         protocolVersion: number;
-        wethIsEth?: boolean;
     }): void {
         if (input.protocolVersion !== 3) {
             throw buildCallWithPermit2ProtocolVersionError;
-        }
-
-        if (input.wethIsEth) {
-            throw buildCallWithPermit2ETHError;
         }
     }
 }

--- a/src/entities/removeLiquidity/removeLiquidityV3/index.ts
+++ b/src/entities/removeLiquidity/removeLiquidityV3/index.ts
@@ -39,7 +39,7 @@ import {
 import { getPoolTokensV2, getTotalSupply } from '@/utils/tokens';
 import { HumanAmount } from '@/data';
 import { balancerRouterAbi } from '@/abi';
-import { Permit } from '@/entities/permit';
+import { Permit } from '@/entities/permitHelper';
 
 export class RemoveLiquidityV3 implements RemoveLiquidityBase {
     public async query(

--- a/src/entities/swap/index.ts
+++ b/src/entities/swap/index.ts
@@ -93,7 +93,6 @@ export class Swap {
     ): SwapBuildOutputExactIn | SwapBuildOutputExactOut {
         InputValidator.validateBuildCallWithPermit2({
             protocolVersion: this.protocolVersion,
-            wethIsEth: input.wethIsEth,
         });
 
         return this.swap.buildCallWithPermit2(input, permit2);

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -36,10 +36,6 @@ export const removeLiquidityProportionalOnlyError = (
         `Remove Liquidity ${kind} not supported for pool ${poolType}. Use Remove Liquidity Proportional`,
     );
 
-export const buildCallWithPermit2ETHError = Error(
-    'buildCallWithPermit2 does not support ETH as input - please use buildCall instead',
-);
-
 export const buildCallWithPermit2ProtocolVersionError = Error(
     'buildCall with Permit2 signatures is only available for v3',
 );

--- a/test/entities/swaps/v3/swapV3.integration.test.ts
+++ b/test/entities/swaps/v3/swapV3.integration.test.ts
@@ -25,7 +25,6 @@ import {
     BALANCER_ROUTER,
     BALANCER_BATCH_ROUTER,
     PERMIT2,
-    buildCallWithPermit2ETHError,
 } from '@/index';
 import { Path } from '@/entities/swap/paths/types';
 
@@ -293,7 +292,7 @@ describe('SwapV3', () => {
                     );
                 });
             });
-            describe.skip('path with exit', () => {
+            describe('path with exit', () => {
                 test('GivenIn', async () => {
                     const swap = new Swap({
                         chainId,
@@ -311,11 +310,11 @@ describe('SwapV3', () => {
                         USDC.decimals,
                     );
                     expect(expected.swapKind).to.eq(SwapKind.GivenIn);
-                    expect(expected.pathAmounts).to.deep.eq([151734n, 779073n]);
+                    expect(expected.pathAmounts).to.deep.eq([378320n, 637976n]);
                     expect(expected.expectedAmountOut.token).to.deep.eq(
                         usdcToken,
                     );
-                    expect(expected.expectedAmountOut.amount).to.eq(930807n);
+                    expect(expected.expectedAmountOut.amount).to.eq(1016296n);
                 });
                 test('GivenOut', async () => {
                     const swap = new Swap({
@@ -335,14 +334,14 @@ describe('SwapV3', () => {
                     );
                     expect(expected.swapKind).to.eq(SwapKind.GivenOut);
                     expect(expected.pathAmounts).to.deep.eq([
-                        1827358022063780n,
-                        841746490376824n,
+                        593566581018333n,
+                        998115374792638n,
                     ]);
                     expect(expected.expectedAmountIn.token).to.deep.eq(
                         wethToken,
                     );
                     expect(expected.expectedAmountIn.amount).to.eq(
-                        2669104512440604n,
+                        1591681955810971n,
                     );
                 });
             });
@@ -568,7 +567,7 @@ describe('SwapV3', () => {
                         });
                     });
                 });
-                describe.skip('paths with exit/join', () => {
+                describe('paths with exit/join', () => {
                     describe('wethIsEth: false', () => {
                         test('GivenIn', async () => {
                             const swap = new Swap({
@@ -721,23 +720,37 @@ describe('SwapV3', () => {
                     });
                 });
                 describe('wethIsEth: true', () => {
-                    test('should throw', async () => {
+                    test('GivenIn', async () => {
                         const swap = new Swap({
                             chainId,
                             paths: [pathBalWeth],
                             swapKind: SwapKind.GivenIn,
                         });
-                        await expect(() =>
-                            assertSwapExactIn({
-                                contractToCall: BALANCER_ROUTER[chainId],
-                                client,
-                                rpcUrl,
-                                chainId,
-                                swap,
-                                wethIsEth: true,
-                                usePermit2Signatures,
-                            }),
-                        ).rejects.toThrowError(buildCallWithPermit2ETHError);
+                        await assertSwapExactIn({
+                            contractToCall: BALANCER_ROUTER[chainId],
+                            client,
+                            rpcUrl,
+                            chainId,
+                            swap,
+                            wethIsEth: true,
+                            usePermit2Signatures,
+                        });
+                    });
+                    test('GivenOut', async () => {
+                        const swap = new Swap({
+                            chainId,
+                            paths: [pathBalWeth],
+                            swapKind: SwapKind.GivenOut,
+                        });
+                        await assertSwapExactOut({
+                            contractToCall: BALANCER_ROUTER[chainId],
+                            client,
+                            rpcUrl,
+                            chainId,
+                            swap,
+                            wethIsEth: true,
+                            usePermit2Signatures,
+                        });
                     });
                 });
             });
@@ -747,7 +760,6 @@ describe('SwapV3', () => {
             describe('swap should be executed correctly', () => {
                 describe('path with swaps only', () => {
                     describe('wethIsEth: false', () => {
-                        const wethIsEth = false;
                         test('GivenIn', async () => {
                             await assertSwapExactIn({
                                 contractToCall: BALANCER_BATCH_ROUTER[chainId],
@@ -759,7 +771,7 @@ describe('SwapV3', () => {
                                     paths: [pathMultiSwap],
                                     swapKind: SwapKind.GivenIn,
                                 }),
-                                wethIsEth,
+                                wethIsEth: false,
                                 usePermit2Signatures,
                             });
                         });
@@ -774,36 +786,45 @@ describe('SwapV3', () => {
                                     paths: [pathMultiSwap],
                                     swapKind: SwapKind.GivenOut,
                                 }),
-                                wethIsEth,
+                                wethIsEth: false,
                                 usePermit2Signatures,
                             });
                         });
                     });
                     describe('wethIsEth: true', () => {
-                        const wethIsEth = true;
-                        test('should throw', async () => {
-                            await expect(() =>
-                                assertSwapExactIn({
-                                    contractToCall:
-                                        BALANCER_BATCH_ROUTER[chainId],
-                                    client,
-                                    rpcUrl,
+                        test('GivenIn', async () => {
+                            await assertSwapExactIn({
+                                contractToCall: BALANCER_BATCH_ROUTER[chainId],
+                                client,
+                                rpcUrl,
+                                chainId,
+                                swap: new Swap({
                                     chainId,
-                                    swap: new Swap({
-                                        chainId,
-                                        paths: [pathMultiSwap],
-                                        swapKind: SwapKind.GivenIn,
-                                    }),
-                                    wethIsEth,
-                                    usePermit2Signatures,
+                                    paths: [pathMultiSwap],
+                                    swapKind: SwapKind.GivenIn,
                                 }),
-                            ).rejects.toThrowError(
-                                buildCallWithPermit2ETHError,
-                            );
+                                wethIsEth: true,
+                                usePermit2Signatures,
+                            });
+                        });
+                        test('GivenOut', async () => {
+                            await assertSwapExactOut({
+                                contractToCall: BALANCER_BATCH_ROUTER[chainId],
+                                client,
+                                rpcUrl,
+                                chainId,
+                                swap: new Swap({
+                                    chainId,
+                                    paths: [pathMultiSwap],
+                                    swapKind: SwapKind.GivenOut,
+                                }),
+                                wethIsEth: true,
+                                usePermit2Signatures,
+                            });
                         });
                     });
                 });
-                describe.skip('paths with exit/join', () => {
+                describe('paths with exit/join', () => {
                     describe('wethIsEth: false', () => {
                         test('GivenIn', async () => {
                             const swap = new Swap({
@@ -839,26 +860,37 @@ describe('SwapV3', () => {
                         });
                     });
                     describe('wethIsEth: true', () => {
-                        test('should throw', async () => {
+                        test('GivenIn', async () => {
                             const swap = new Swap({
                                 chainId,
                                 paths: [pathMultiSwap, pathWithExit],
                                 swapKind: SwapKind.GivenIn,
                             });
-                            await expect(() =>
-                                assertSwapExactIn({
-                                    contractToCall:
-                                        BALANCER_BATCH_ROUTER[chainId],
-                                    client,
-                                    rpcUrl,
-                                    chainId,
-                                    swap,
-                                    wethIsEth: true,
-                                    usePermit2Signatures,
-                                }),
-                            ).rejects.toThrowError(
-                                buildCallWithPermit2ETHError,
-                            );
+                            await assertSwapExactIn({
+                                contractToCall: BALANCER_BATCH_ROUTER[chainId],
+                                client,
+                                rpcUrl,
+                                chainId,
+                                swap,
+                                wethIsEth: true,
+                                usePermit2Signatures,
+                            });
+                        });
+                        test('GivenOut', async () => {
+                            const swap = new Swap({
+                                chainId,
+                                paths: [pathMultiSwap, pathWithExit],
+                                swapKind: SwapKind.GivenOut,
+                            });
+                            await assertSwapExactOut({
+                                contractToCall: BALANCER_BATCH_ROUTER[chainId],
+                                client,
+                                rpcUrl,
+                                chainId,
+                                swap,
+                                wethIsEth: true,
+                                usePermit2Signatures,
+                            });
                         });
                     });
                 });

--- a/test/v3/addLiquidity.integration.test.ts
+++ b/test/v3/addLiquidity.integration.test.ts
@@ -31,7 +31,6 @@ import {
     InputAmount,
     PoolType,
     PERMIT2,
-    buildCallWithPermit2ETHError,
 } from '../../src';
 import {
     AddLiquidityTxInput,
@@ -321,13 +320,19 @@ describe('add liquidity test', () => {
 
             test('with native', async () => {
                 const wethIsEth = true;
-                await expect(() =>
-                    doAddLiquidity({
-                        ...txInput,
-                        addLiquidityInput,
-                        wethIsEth,
-                    }),
-                ).rejects.toThrowError(buildCallWithPermit2ETHError);
+                const addLiquidityOutput = await doAddLiquidity({
+                    ...txInput,
+                    addLiquidityInput,
+                    wethIsEth,
+                });
+                assertAddLiquidityUnbalanced(
+                    txInput.poolState,
+                    addLiquidityInput,
+                    addLiquidityOutput,
+                    txInput.slippage,
+                    protocolVersion,
+                    wethIsEth,
+                );
             });
         });
 
@@ -364,17 +369,24 @@ describe('add liquidity test', () => {
 
             test('with native', async () => {
                 const wethIsEth = true;
-                await expect(() =>
-                    doAddLiquidity({
-                        ...txInput,
-                        addLiquidityInput,
-                        wethIsEth,
-                    }),
-                ).rejects.toThrowError(buildCallWithPermit2ETHError);
+                const addLiquidityOutput = await doAddLiquidity({
+                    ...txInput,
+                    addLiquidityInput,
+                    wethIsEth,
+                });
+
+                assertAddLiquiditySingleToken(
+                    txInput.poolState,
+                    addLiquidityInput,
+                    addLiquidityOutput,
+                    txInput.slippage,
+                    protocolVersion,
+                    wethIsEth,
+                );
             });
         });
         describe('add liquidity proportional', () => {
-            let input: AddLiquidityProportionalInput;
+            let addLiquidityInput: AddLiquidityProportionalInput;
             beforeAll(() => {
                 const bptOut: InputAmount = {
                     rawAmount: parseUnits('1', 18),
@@ -382,7 +394,7 @@ describe('add liquidity test', () => {
                     address: poolState.address,
                 };
 
-                input = {
+                addLiquidityInput = {
                     bptOut: bptOut,
                     kind: AddLiquidityKind.Proportional,
                     chainId: chainId,
@@ -390,15 +402,9 @@ describe('add liquidity test', () => {
                 };
             });
             test('with token', async () => {
-                const addLiquidityInput = {
-                    ...input,
-                };
-
-                // call the addLiquidity function
-                // assert the output
                 const addLiquidityOutput = await doAddLiquidity({
                     ...txInput,
-                    addLiquidityInput: input,
+                    addLiquidityInput,
                 });
 
                 assertAddLiquidityProportional(
@@ -411,13 +417,20 @@ describe('add liquidity test', () => {
             });
             test('with native', async () => {
                 const wethIsEth = true;
-                await expect(() =>
-                    doAddLiquidity({
-                        ...txInput,
-                        addLiquidityInput: input,
-                        wethIsEth,
-                    }),
-                ).rejects.toThrowError(buildCallWithPermit2ETHError);
+                const addLiquidityOutput = await doAddLiquidity({
+                    ...txInput,
+                    addLiquidityInput,
+                    wethIsEth,
+                });
+
+                assertAddLiquidityProportional(
+                    txInput.poolState,
+                    addLiquidityInput,
+                    addLiquidityOutput,
+                    txInput.slippage,
+                    protocolVersion,
+                    wethIsEth,
+                );
             });
         });
     });


### PR DESCRIPTION
Closes #383
Functionality was added to SC implementation and required updating Input Validator and Integration tests.

Closes #351
Took the opportunity and re-enabled swap tests

Extra:
Fix lint issues regarding missing buildCallWithPermit implementations