### PR TITLE
chore: add optimism rpc url to envs

### DIFF
--- a/.changeset/gentle-months-share.md
+++ b/.changeset/gentle-months-share.md
@@ -1,0 +1,5 @@
+---
+"@balancer/sdk": patch
+---
+
+Add OPTIMISM_RPC_URL to test envs

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -46,6 +46,7 @@ jobs:
           ETHEREUM_RPC_URL: ${{ secrets.ETHEREUM_RPC_URL }}
           POLYGON_RPC_URL: ${{ secrets.POLYGON_RPC_URL }}
           FANTOM_RPC_URL: ${{ secrets.FANTOM_RPC_URL }}
+          OPTIMISM_RPC_URL: ${{ secrets.OPTIMISM_RPC_URL }}
           SEPOLIA_RPC_URL: ${{ secrets.SEPOLIA_RPC_URL }}
   build:
     name: Build

--- a/test/anvil/anvil-global-setup.ts
+++ b/test/anvil/anvil-global-setup.ts
@@ -111,7 +111,7 @@ function getAnvilOptions(
     blockNumber?: bigint,
 ): CreateAnvilOptions {
     let forkUrl: string;
-    if (process.env[network.rpcEnv] !== undefined) {
+    if (process.env[network.rpcEnv] !== 'undefined') {
         forkUrl = process.env[network.rpcEnv] as string;
     } else {
         if (!network.fallBackRpc)

--- a/test/anvil/anvil-global-setup.ts
+++ b/test/anvil/anvil-global-setup.ts
@@ -70,7 +70,7 @@ export const ANVIL_NETWORKS: Record<NetworksWithFork, NetworkSetup> = {
     },
     OPTIMISM: {
         rpcEnv: 'OPTIMISM_RPC_URL',
-        fallBackRpc: 'https://optimism.gateway.tenderly.co',
+        fallBackRpc: 'https://optimism.llamarpc.com',
         port: ANVIL_PORTS.OPTIMISM,
         forkBlockNumber: 117374265n,
     },

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -15,6 +15,9 @@ export default defineConfig(({ mode }) => {
                 env.ARBITRUM_RPC_URL,
             ),
             'process.env.FANTOM_RPC_URL': JSON.stringify(env.FANTOM_RPC_URL),
+            'process.env.OPTIMISM_RPC_URL': JSON.stringify(
+                env.OPTIMISM_RPC_URL,
+            ),
             'process.env.SKIP_GLOBAL_SETUP': JSON.stringify(
                 env.SKIP_GLOBAL_SETUP,
             ),


### PR DESCRIPTION
Fixes integration tests by: 

1. Replacing optimism fallback rpc url from `https://optimism.gateway.tenderly.co` (was failing) to `https://optimism.llamarpc.com` (more stable according to `https://chainlist.org/chain/10`) 

2. Defining `OPTIMISM_RPC_URL` in CI and vitest setup. 

The last step would be defining the `OPTIMISM_RPC_URL` env in the repo secrets. 