### PR TITLE
fix: Add zero address sender to viem multicall calls to avoid issues with Nethermind/Geth nodes

### DIFF
--- a/.changeset/nasty-phones-care.md
+++ b/.changeset/nasty-phones-care.md
@@ -1,0 +1,5 @@
+---
+"@balancer/sdk": minor
+---
+
+Add zero address sender to multicall calls to avoid issues with Nethermind/Geth nodes

--- a/src/entities/addLiquidityNested/doAddLiquidityNestedQuery.ts
+++ b/src/entities/addLiquidityNested/doAddLiquidityNestedQuery.ts
@@ -5,13 +5,7 @@ import {
     http,
 } from 'viem';
 import { Hex } from '../../types';
-import {
-    BALANCER_RELAYER,
-    CHAINS,
-    ChainId,
-    EMPTY_SENDER,
-    ZERO_ADDRESS,
-} from '../../utils';
+import { BALANCER_RELAYER, CHAINS, ChainId, EMPTY_SENDER } from '../../utils';
 import {
     balancerRelayerAbi,
     permit2Abi,

--- a/src/entities/addLiquidityNested/doAddLiquidityNestedQuery.ts
+++ b/src/entities/addLiquidityNested/doAddLiquidityNestedQuery.ts
@@ -5,7 +5,13 @@ import {
     http,
 } from 'viem';
 import { Hex } from '../../types';
-import { BALANCER_RELAYER, CHAINS, ChainId } from '../../utils';
+import {
+    BALANCER_RELAYER,
+    CHAINS,
+    ChainId,
+    EMPTY_SENDER,
+    ZERO_ADDRESS,
+} from '../../utils';
 import {
     balancerRelayerAbi,
     permit2Abi,
@@ -24,6 +30,7 @@ export const doAddLiquidityNestedQuery = async (
     });
 
     const { data } = await client.call({
+        ...EMPTY_SENDER,
         to: BALANCER_RELAYER[chainId],
         data: encodedMulticall,
     });

--- a/src/entities/removeLiquidityNested/doRemoveLiquidityNestedQuery.ts
+++ b/src/entities/removeLiquidityNested/doRemoveLiquidityNestedQuery.ts
@@ -5,7 +5,7 @@ import {
     http,
 } from 'viem';
 import { Hex } from '../../types';
-import { BALANCER_RELAYER, CHAINS, ChainId } from '../../utils';
+import { BALANCER_RELAYER, CHAINS, ChainId, EMPTY_SENDER } from '../../utils';
 import { balancerRelayerAbi } from '../../abi';
 
 export const doRemoveLiquidityNestedQuery = async (
@@ -20,6 +20,7 @@ export const doRemoveLiquidityNestedQuery = async (
     });
 
     const { data } = await client.call({
+        ...EMPTY_SENDER,
         to: BALANCER_RELAYER[chainId],
         data: encodedMulticall,
     });

--- a/src/entities/swap/swaps/v2/auraBalSwaps/joinSwap.ts
+++ b/src/entities/swap/swaps/v2/auraBalSwaps/joinSwap.ts
@@ -7,7 +7,7 @@ import {
     Hex,
 } from 'viem';
 import { TokenAmount } from '../../../../tokenAmount';
-import { BALANCER_RELAYER, ChainId, EMPTY_SENDER, ZERO_ADDRESS } from '@/utils';
+import { BALANCER_RELAYER, ChainId, EMPTY_SENDER } from '@/utils';
 import { balancerRelayerAbi } from '@/abi';
 import { Relayer } from '@/entities/relayer';
 import { auraBalToken, balWethAddress, auraBAL } from './constants';

--- a/src/entities/swap/swaps/v2/auraBalSwaps/joinSwap.ts
+++ b/src/entities/swap/swaps/v2/auraBalSwaps/joinSwap.ts
@@ -7,7 +7,7 @@ import {
     Hex,
 } from 'viem';
 import { TokenAmount } from '../../../../tokenAmount';
-import { BALANCER_RELAYER, ChainId } from '@/utils';
+import { BALANCER_RELAYER, ChainId, EMPTY_SENDER, ZERO_ADDRESS } from '@/utils';
 import { balancerRelayerAbi } from '@/abi';
 import { Relayer } from '@/entities/relayer';
 import { auraBalToken, balWethAddress, auraBAL } from './constants';
@@ -55,6 +55,7 @@ export async function queryJoinSwap(
     });
 
     const { data } = await client.call({
+        ...EMPTY_SENDER,
         to: BALANCER_RELAYER[ChainId.MAINNET],
         data: encodedMulticall,
     });

--- a/src/entities/swap/swaps/v2/auraBalSwaps/swapExit.ts
+++ b/src/entities/swap/swaps/v2/auraBalSwaps/swapExit.ts
@@ -7,7 +7,7 @@ import {
     Hex,
 } from 'viem';
 import { TokenAmount } from '../../../../tokenAmount';
-import { BALANCER_RELAYER, ChainId } from '@/utils';
+import { BALANCER_RELAYER, ChainId, EMPTY_SENDER } from '@/utils';
 import { balancerRelayerAbi } from '@/abi';
 import { Relayer } from '@/entities/relayer';
 import { auraBalToken, balWethAddress, auraBAL } from './constants';
@@ -56,6 +56,7 @@ export async function querySwapExit(
     });
 
     const { data } = await client.call({
+        ...EMPTY_SENDER,
         to: BALANCER_RELAYER[ChainId.MAINNET],
         data: encodedMulticall,
     });

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -21,6 +21,12 @@ import {
 
 export const ZERO_ADDRESS: Address =
     '0x0000000000000000000000000000000000000000';
+/*
+    Using empty account (undefined by default) in some multicall requests causes failures in some nodes
+    More info: https://github.com/wevm/viem/issues/2792
+*/
+export const EMPTY_SENDER = { account: ZERO_ADDRESS };
+
 const NATIVE_ADDRESS: Address = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
 
 export const MAX_UINT112 = 5192296858534827628530496329220095n;


### PR DESCRIPTION
We found an issue with different RPC providers and the only solution is using `ZERO_ADDRESS` as the default account in certain multicall viem calls. 

More context: 
https://github.com/wevm/viem/issues/2792