### PR TITLE
Testing add unbalanced examples

### DIFF
--- a/examples/addLiquidity/addLiquidityCustom.ts
+++ b/examples/addLiquidity/addLiquidityCustom.ts
@@ -23,22 +23,21 @@ async function runAgainstFork() {
     const { rpcUrl } = await startFork(ANVIL_NETWORKS.SEPOLIA);
     const chainId = ChainId.SEPOLIA;
     const userAccount = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045';
-    // Pool from a custom factory that is not currently supported in Balancer API
+    // Weighted pool from deploy 9
     const pool = {
-        // TODO: update with pool from testnet deployment 4
-        id: '0xd851b2b78c41c40a4fa134f6fc4282b71f0f1491',
-        address: '0xd851b2b78c41c40a4fa134f6fc4282b71f0f1491' as Address,
+        id: '0xd71958aeD5E2e835A648Ff832a181F7BdaBbaF13',
+        address: '0xd71958aeD5E2e835A648Ff832a181F7BdaBbaF13' as Address,
     };
     const amountsIn = [
         {
-            rawAmount: parseEther('0.01'),
+            rawAmount: parseEther('0.02'),
             decimals: 18,
-            address: '0x990c8eab51d9ecb365bf9b3de09d121af007db68' as Address,
+            address: '0x7b79995e5f793A07Bc00c21412e50Ecae098E7f9' as Address, // wETH
         },
         {
-            rawAmount: parseEther('0.01'),
+            rawAmount: parseEther('0.04'),
             decimals: 18,
-            address: '0xcd20075dc190c411287132e891ec42f009babc73' as Address,
+            address: '0xb19382073c7A0aDdbb56Ac6AF1808Fa49e377B75' as Address, // BAL
         },
     ];
     const slippage = Slippage.fromPercentage('1'); // 1%
@@ -80,7 +79,7 @@ const addLiquidity = async ({
     const onchainProvider = new OnChainProvider(rpcUrl, chainId);
     const poolState = await onchainProvider.pools.fetchPoolState(
         poolId,
-        'CustomPool',
+        'Weighted',
     );
 
     // Construct the AddLiquidityInput, in this case an AddLiquidityUnbalanced

--- a/examples/addLiquidity/addLiquidityUnbalanced.ts
+++ b/examples/addLiquidity/addLiquidityUnbalanced.ts
@@ -27,17 +27,17 @@ async function runAgainstFork() {
     const userAccount = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045';
     // 80BAL-20WETH
     const pool = {
-        id: '0x03Bf996C7BD45B3386cb41875761d45e27EaB284',
-        address: '0x03Bf996C7BD45B3386cb41875761d45e27EaB284' as Address,
+        id: '0xd71958aeD5E2e835A648Ff832a181F7BdaBbaF13',
+        address: '0xd71958aeD5E2e835A648Ff832a181F7BdaBbaF13' as Address,
     };
     const amountsIn = [
         {
-            rawAmount: parseEther('0.0001'),
+            rawAmount: parseEther('0.00033'),
             decimals: 18,
-            address: '0x7b79995e5f793a07bc00c21412e50ecae098e7f9' as Address,
+            address: '0x7b79995e5f793A07Bc00c21412e50Ecae098E7f9' as Address,
         },
         {
-            rawAmount: parseEther('0.0001'),
+            rawAmount: parseEther('0.00069'),
             decimals: 18,
             address: '0xb19382073c7a0addbb56ac6af1808fa49e377b75' as Address,
         },


### PR DESCRIPTION
Updated the `addLiquidityCustom`  and `addLiquidityUnbalanced` examples to use same pool alberto is targeting. 

Examples run fine here on the SDK repo

`pnpm example ./examples/addLiquidity/addLiquidityUnbalanced.ts`
`pnpm example ./examples/addLiquidity/addLiquidityCustom.ts`

here's alberto's error logs for reference

```
{
    "cause": {
        "metaMessages": [
            "Error: PoolNotInitialized(address pool)",
            "                         (0xd71958aeD5E2e835A648Ff832a181F7BdaBbaF13)"
        ],
        "shortMessage": "The contract function \"queryAddLiquidityUnbalanced\" reverted.",
        "version": "2.21.22",
        "name": "ContractFunctionRevertedError",
        "data": {
            "abiItem": {
                "inputs": [
                    {
                        "internalType": "address",
                        "name": "pool",
                        "type": "address"
                    }
                ],
                "name": "PoolNotInitialized",
                "type": "error"
            },
            "args": [
                "0xd71958aeD5E2e835A648Ff832a181F7BdaBbaF13"
            ],
            "errorName": "PoolNotInitialized"
        }
    },
    "docsPath": "/docs/contract/simulateContract",
    "metaMessages": [
        "Error: PoolNotInitialized(address pool)",
        "                         (0xd71958aeD5E2e835A648Ff832a181F7BdaBbaF13)",
        " ",
        "Contract Call:",
        "  address:   0xB12FcB422aAe6720f882E22C340964a7723f2387\n  function:  queryAddLiquidityUnbalanced(address pool, uint256[] exactAmountsIn, bytes userData)\n  args:                                 (0xd71958aed5e2e835a648ff832a181f7bdabbaf13, [\"0\",\"1000000000000000000\"], 0x)"
    ],
    "shortMessage": "The contract function \"queryAddLiquidityUnbalanced\" reverted.",
    "version": "2.21.22", 
```