### PR TITLE
V3 price impact for nested pools

### DIFF
--- a/.changeset/sour-bears-sin.md
+++ b/.changeset/sour-bears-sin.md
@@ -1,0 +1,6 @@
+---
+"@balancer/sdk": minor
+---
+
+Tidy nested types. Share common with boosted.
+Support for V3 addLiquidityNested PI (including nested boosted).

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -11,7 +11,3 @@ export interface MinimalToken {
 export interface PoolTokenWithBalance extends MinimalToken {
     balance: HumanAmount;
 }
-
-export interface PoolTokenWithUnderlying extends MinimalToken {
-    underlyingToken: MinimalToken | null;
-}

--- a/src/entities/priceImpact/addLiquidityNested.ts
+++ b/src/entities/priceImpact/addLiquidityNested.ts
@@ -1,0 +1,152 @@
+import { InputAmount } from '@/types';
+import { AddLiquidity } from '../addLiquidity';
+import { AddLiquidityNestedInput } from '../addLiquidityNested/types';
+import { PriceImpactAmount } from '../priceImpactAmount';
+import {
+    NestedPoolState,
+    NestedPoolV2,
+    NestedPoolV3,
+    PoolState,
+} from '../types';
+import { isPoolToken } from '../utils/isPoolToken';
+import {
+    AddLiquidityKind,
+    AddLiquidityUnbalancedInput,
+} from '../addLiquidity/types';
+import { PriceImpact } from '.';
+import { ChainId } from '@/utils';
+import { TokenAmount } from '../tokenAmount';
+import { AddLiquidityBoostedUnbalancedInput } from '../addLiquidityBoosted/types';
+import { AddLiquidityBoostedV3 } from '../addLiquidityBoosted';
+
+type AddResult = {
+    priceImpactAmount: PriceImpactAmount;
+    bptOut: TokenAmount;
+};
+
+export async function addLiquidityNested(
+    input: AddLiquidityNestedInput,
+    nestedPoolState: NestedPoolState,
+): Promise<PriceImpactAmount> {
+    if (nestedPoolState.protocolVersion === 1)
+        throw Error('Nested Price Impact not supported for protocolVersion 1');
+
+    const addLiquidity = new AddLiquidity();
+    const addLiquidityBoosted = new AddLiquidityBoostedV3();
+    // sort pools from child to parent
+    const sortedPools = nestedPoolState.pools.sort((a, b) => a.level - b.level);
+    // Price impact amounts from all add actions
+    const priceImpactAmounts: PriceImpactAmount[] = [];
+    // BPT out from each child pool add action
+    const childrenBptOuts: InputAmount[] = [];
+
+    // For each pool (including parent), find PI from the corresponding add operation
+    for (const pool of sortedPools) {
+        let amountsIn: InputAmount[] = [];
+        let isBoostedPool = false;
+        if (pool.level === 0) {
+            // A lower level pool
+            // Find any user input amount related to the current pool & check if pool is boosted
+            amountsIn = input.amountsIn.filter((a) => {
+                const poolToken = isPoolToken(pool.tokens, a.address);
+                if (poolToken.isPoolToken && poolToken.isUnderlyingToken)
+                    isBoostedPool = true;
+                return poolToken.isPoolToken;
+            });
+            // skip pool if no relevant amountsIn
+            if (amountsIn.length === 0) continue;
+        } else {
+            // The parent pool
+            // Find any user input amount or bpt from child adds related to the current pool & check if pool is boosted
+            amountsIn = [...childrenBptOuts, ...input.amountsIn].filter((a) => {
+                const poolToken = isPoolToken(pool.tokens, a.address);
+                if (poolToken.isPoolToken && poolToken.isUnderlyingToken)
+                    isBoostedPool = true;
+                return poolToken.isPoolToken;
+            });
+        }
+        let addResult: AddResult;
+        if (isBoostedPool)
+            addResult = await getAddBoostedUnbalancedResult(
+                addLiquidityBoosted,
+                input.chainId,
+                input.rpcUrl,
+                pool as NestedPoolV3,
+                amountsIn,
+            );
+        else
+            addResult = await getAddUnbalancedResult(
+                addLiquidity,
+                input.chainId,
+                input.rpcUrl,
+                pool as NestedPoolV2,
+                amountsIn,
+                nestedPoolState.protocolVersion,
+            );
+
+        priceImpactAmounts.push(addResult.priceImpactAmount);
+        childrenBptOuts.push(addResult.bptOut.toInputAmount());
+    }
+
+    const priceImpactSum = priceImpactAmounts.reduce(
+        (acc, cur) => acc + cur.amount,
+        0n,
+    );
+
+    return PriceImpactAmount.fromRawAmount(priceImpactSum);
+}
+
+async function getAddUnbalancedResult(
+    addLiquidity: AddLiquidity,
+    chainId: ChainId,
+    rpcUrl: string,
+    pool: NestedPoolV2,
+    amountsIn: InputAmount[],
+    protocolVersion: 2 | 3,
+): Promise<AddResult> {
+    const addLiquidityInput: AddLiquidityUnbalancedInput = {
+        chainId,
+        rpcUrl,
+        amountsIn,
+        kind: AddLiquidityKind.Unbalanced,
+    };
+    const poolState: PoolState = {
+        ...pool,
+        protocolVersion,
+    };
+    const priceImpactAmount = await PriceImpact.addLiquidityUnbalanced(
+        addLiquidityInput,
+        poolState,
+    );
+
+    const { bptOut } = await addLiquidity.query(addLiquidityInput, poolState);
+
+    return { priceImpactAmount, bptOut };
+}
+
+async function getAddBoostedUnbalancedResult(
+    addLiquidityBoosted: AddLiquidityBoostedV3,
+    chainId: ChainId,
+    rpcUrl: string,
+    pool: NestedPoolV3,
+    amountsIn: InputAmount[],
+): Promise<AddResult> {
+    const addLiquidityInput: AddLiquidityBoostedUnbalancedInput = {
+        chainId,
+        rpcUrl,
+        amountsIn,
+        kind: AddLiquidityKind.Unbalanced,
+    };
+
+    const priceImpactAmount = await PriceImpact.addLiquidityUnbalancedBoosted(
+        addLiquidityInput,
+        { ...pool, protocolVersion: 3 },
+    );
+
+    const { bptOut } = await addLiquidityBoosted.query(addLiquidityInput, {
+        ...pool,
+        protocolVersion: 3,
+    });
+
+    return { priceImpactAmount, bptOut };
+}

--- a/src/entities/priceImpact/addLiquidityNested.ts
+++ b/src/entities/priceImpact/addLiquidityNested.ts
@@ -28,9 +28,6 @@ export async function addLiquidityNested(
     input: AddLiquidityNestedInput,
     nestedPoolState: NestedPoolState,
 ): Promise<PriceImpactAmount> {
-    if (nestedPoolState.protocolVersion === 1)
-        throw Error('Nested Price Impact not supported for protocolVersion 1');
-
     const addLiquidity = new AddLiquidity();
     const addLiquidityBoosted = new AddLiquidityBoostedV3();
     // sort pools from child to parent
@@ -102,7 +99,7 @@ async function getAddUnbalancedResult(
     rpcUrl: string,
     pool: NestedPoolV2,
     amountsIn: InputAmount[],
-    protocolVersion: 2 | 3,
+    protocolVersion: 1 | 2 | 3,
 ): Promise<AddResult> {
     const addLiquidityInput: AddLiquidityUnbalancedInput = {
         chainId,

--- a/src/entities/priceImpact/addLiquidityUnbalancedBoosted.ts
+++ b/src/entities/priceImpact/addLiquidityUnbalancedBoosted.ts
@@ -1,10 +1,10 @@
-import { abs, ChainId, max, min } from '../../utils';
+import { abs, ChainId, isSameAddress, max, min } from '../../utils';
 import { InputToken, SwapKind } from '../../types';
 import { PriceImpactAmount } from '../priceImpactAmount';
 import { RemoveLiquidityKind } from '../removeLiquidity/types';
 import { Swap, SwapInput, TokenApi } from '../swap';
 import { TokenAmount } from '../tokenAmount';
-import { PoolStateWithUnderlyings } from '../types';
+import { PoolStateWithUnderlyings, PoolTokenWithUnderlying } from '../types';
 import { priceImpactABA } from '.';
 import { AddLiquidityBoostedUnbalancedInput } from '../addLiquidityBoosted/types';
 import { AddLiquidityBoostedV3 } from '../addLiquidityBoosted';
@@ -12,7 +12,6 @@ import { RemoveLiquidityBoostedV3 } from '../removeLiquidityBoosted';
 import { RemoveLiquidityBoostedProportionalInput } from '../removeLiquidityBoosted/types';
 import { Address, BaseError, ContractFunctionRevertedError } from 'viem';
 import { Token } from '../token';
-import { PoolTokenWithUnderlying } from '@/data';
 
 /**
  * Calculate price impact on add liquidity unbalanced operations
@@ -247,7 +246,9 @@ function getTokenWrapInfo(
     tokens: PoolTokenWithUnderlying[],
     token: InputToken,
 ): TokenWrapInfo {
-    const poolToken = tokens.find((t) => t.address === token.address);
+    const poolToken = tokens.find((t) =>
+        isSameAddress(t.address, token.address),
+    );
     if (poolToken)
         return {
             token: poolToken,
@@ -257,7 +258,7 @@ function getTokenWrapInfo(
 
     const wrapped = tokens
         .filter((t) => t.underlyingToken !== null)
-        .find((t) => t.underlyingToken!.address === token.address);
+        .find((t) => isSameAddress(t.underlyingToken!.address, token.address));
 
     if (!wrapped) throw Error(`Cannot map token to wrapped: ${token.address}`);
     return {

--- a/src/entities/types.ts
+++ b/src/entities/types.ts
@@ -1,9 +1,4 @@
-import {
-    HumanAmount,
-    MinimalToken,
-    PoolTokenWithBalance,
-    PoolTokenWithUnderlying,
-} from '../data';
+import { HumanAmount, MinimalToken, PoolTokenWithBalance } from '../data';
 import { Address, Hex, PoolType } from '../types';
 
 // Returned from API and used as input
@@ -22,6 +17,10 @@ export type PoolStateWithBalances = {
     tokens: PoolTokenWithBalance[];
     totalShares: HumanAmount;
     protocolVersion: 1 | 2 | 3;
+};
+
+export type PoolTokenWithUnderlying = MinimalToken & {
+    underlyingToken: MinimalToken | null;
 };
 
 export type PoolStateWithUnderlyings = {
@@ -45,22 +44,40 @@ export type RemoveLiquidityAmounts = {
     maxBptAmountIn: bigint;
 };
 
-export type NestedPool = {
+type NestedPoolBase = {
     id: Hex;
     address: Address;
     type: PoolType;
     level: number; // 0 is the bottom and the highest level is the top
+};
+
+export type NestedPoolV2 = NestedPoolBase & {
     tokens: MinimalToken[]; // each token should have at least one
 };
 
-export type NestedPoolState = {
+export type NestedPoolV3 = NestedPoolBase & {
+    tokens: PoolTokenWithUnderlying[]; // each token should have at least one
+};
+
+type NestedPoolStateBase = {
     protocolVersion: 1 | 2 | 3;
-    pools: NestedPool[];
     mainTokens: {
         address: Address;
         decimals: number;
     }[];
 };
+
+export type NestedPoolStateV2 = NestedPoolStateBase & {
+    protocolVersion: 1 | 2;
+    pools: NestedPoolV2[];
+};
+
+export type NestedPoolStateV3 = NestedPoolStateBase & {
+    protocolVersion: 3;
+    pools: NestedPoolV3[];
+};
+
+export type NestedPoolState = NestedPoolStateV2 | NestedPoolStateV3;
 
 export enum PoolKind {
     WEIGHTED = 0,

--- a/src/entities/utils/isPoolToken.ts
+++ b/src/entities/utils/isPoolToken.ts
@@ -1,0 +1,42 @@
+import { Address } from 'viem';
+import { isSameAddress } from '@/utils';
+import { PoolTokenWithUnderlying } from '../types';
+import { MinimalToken } from '@/data';
+
+function isPoolTokenWithUnderlying(
+    token: PoolTokenWithUnderlying | MinimalToken,
+): token is PoolTokenWithUnderlying {
+    return 'underlyingToken' in token;
+}
+
+/**
+ * Check if token is either a pool token or underlying pool token.
+ * @param tokens
+ * @param token
+ * @returns
+ */
+export function isPoolToken(
+    tokens: PoolTokenWithUnderlying[] | MinimalToken[],
+    token: Address,
+): { isPoolToken: boolean; isUnderlyingToken: boolean } {
+    let isPoolToken = false;
+    let isUnderlyingToken = false;
+
+    tokens.some((t) => {
+        const isToken = isSameAddress(t.address, token);
+        const isUnderlying =
+            isPoolTokenWithUnderlying(t) &&
+            t.underlyingToken &&
+            isSameAddress(t.underlyingToken.address, token);
+
+        if (isToken || isUnderlying) {
+            isPoolToken = true;
+            isUnderlyingToken = !!isUnderlying;
+            return true;
+        }
+
+        return false;
+    });
+
+    return { isPoolToken, isUnderlyingToken };
+}

--- a/src/entities/utils/validateNestedPoolState.ts
+++ b/src/entities/utils/validateNestedPoolState.ts
@@ -1,4 +1,5 @@
 import { NestedPoolState } from '../types';
+import { isPoolToken } from './isPoolToken';
 
 export function validateNestedPoolState(
     nestedPoolState: NestedPoolState,
@@ -18,9 +19,11 @@ export function validateNestedPoolState(
     const topLevel = Math.max(...nestedPoolState.pools.map((p) => p.level));
 
     nestedPoolState.mainTokens.forEach((t) => {
-        const poolsWithToken = nestedPoolState.pools.filter((p) =>
-            p.tokens.some((pt) => pt.address === t.address),
-        );
+        // Can join with main token or underlying token
+        const poolsWithToken = nestedPoolState.pools.filter((p) => {
+            const poolToken = isPoolToken(p.tokens, t.address);
+            return poolToken.isPoolToken;
+        });
 
         if (poolsWithToken.length < 1)
             throw new Error(

--- a/test/mockData/boostedPool.ts
+++ b/test/mockData/boostedPool.ts
@@ -27,5 +27,4 @@ export const boostedPool_USDC_USDT: PoolStateWithUnderlyings = {
             },
         },
     ],
-    totalShares: '119755.048508537457614083',
 };

--- a/test/mockData/nestedPool.ts
+++ b/test/mockData/nestedPool.ts
@@ -1,0 +1,79 @@
+import { ChainId, NestedPoolState } from '@/index';
+import { POOLS, TOKENS } from 'test/lib/utils';
+
+const chainId = ChainId.SEPOLIA;
+export const NESTED_WITH_BOOSTED_POOL = POOLS[chainId].NESTED_WITH_BOOSTED_POOL;
+export const BOOSTED_POOL = POOLS[chainId].MOCK_BOOSTED_POOL;
+export const stataUSDC = TOKENS[chainId].stataUSDC;
+export const USDC = TOKENS[chainId].USDC_AAVE;
+export const stataUSDT = TOKENS[chainId].stataUSDT;
+export const USDT = TOKENS[chainId].USDT_AAVE;
+export const WETH = TOKENS[chainId].WETH;
+
+export const nestedWithBoostedPool: NestedPoolState = {
+    protocolVersion: 3,
+    pools: [
+        {
+            id: NESTED_WITH_BOOSTED_POOL.id,
+            address: NESTED_WITH_BOOSTED_POOL.address,
+            type: NESTED_WITH_BOOSTED_POOL.type,
+            level: 1,
+            tokens: [
+                {
+                    address: BOOSTED_POOL.address,
+                    decimals: BOOSTED_POOL.decimals,
+                    index: 0,
+                    underlyingToken: null,
+                },
+                {
+                    address: WETH.address,
+                    decimals: WETH.decimals,
+                    index: 1,
+                    underlyingToken: null,
+                },
+            ],
+        },
+        {
+            id: BOOSTED_POOL.id,
+            address: BOOSTED_POOL.address,
+            type: BOOSTED_POOL.type,
+            level: 0,
+            tokens: [
+                {
+                    address: stataUSDC.address,
+                    decimals: stataUSDC.decimals,
+                    index: 0,
+                    underlyingToken: {
+                        address: USDC.address,
+                        decimals: 6,
+                        index: 0,
+                    },
+                },
+                {
+                    address: stataUSDT.address,
+                    decimals: stataUSDT.decimals,
+                    index: 1,
+                    underlyingToken: {
+                        address: USDT.address,
+                        decimals: 6,
+                        index: 1,
+                    },
+                },
+            ],
+        },
+    ],
+    mainTokens: [
+        {
+            address: WETH.address,
+            decimals: WETH.decimals,
+        },
+        {
+            address: USDT.address,
+            decimals: USDT.decimals,
+        },
+        {
+            address: USDC.address,
+            decimals: USDC.decimals,
+        },
+    ],
+};

--- a/test/mockData/partialBoostedPool.ts
+++ b/test/mockData/partialBoostedPool.ts
@@ -23,5 +23,4 @@ export const partialBoostedPool_USDT_stataDAI: PoolStateWithUnderlyings = {
             },
         },
     ],
-    totalShares: '0',
 };

--- a/test/nestedPoolStateValidation.test.ts
+++ b/test/nestedPoolStateValidation.test.ts
@@ -1,8 +1,8 @@
-// pnpm test -- constraintValidation.test.ts
+// pnpm test -- nestedPoolStateValidation.test.ts
 import { describe, expect, test } from 'vitest';
 import {
     NestedPoolState,
-    NestedPool,
+    NestedPoolV2,
     validateNestedPoolState,
 } from '../src/entities';
 import { PoolType } from '@/types';
@@ -52,7 +52,7 @@ describe('nested pool state validations', () => {
                                 BAL/WETH
  */
 // Does not return 8020_BPT pool
-const happyPools: NestedPool[] = [
+const happyPools: NestedPoolV2[] = [
     {
         id: '0x08775ccb6674d6bdceb0797c364c2653ed84f3840002000000000000000004f0',
         address: '0x08775ccb6674d6bdceb0797c364c2653ed84f384',
@@ -130,7 +130,7 @@ const happyPools: NestedPool[] = [
 ];
 
 // Includes 8020_BPT pool
-const deepPools: NestedPool[] = [
+const deepPools: NestedPoolV2[] = [
     { ...happyPools[0], level: 2 },
     { ...happyPools[1], level: 1 },
     { ...happyPools[2], level: 1 },
@@ -157,6 +157,7 @@ const deepPools: NestedPool[] = [
 // Returning main tokens as 1 level
 const happyPoolState: NestedPoolState = {
     pools: [...happyPools],
+    protocolVersion: 2,
     mainTokens: [
         {
             address: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2', // WETH
@@ -198,6 +199,7 @@ const missingMain: NestedPoolState = {
 
 // WETH is token in two pools
 const multiTokenPoolState: NestedPoolState = {
+    protocolVersion: 2,
     pools: [...deepPools],
     mainTokens: [
         {
@@ -225,6 +227,7 @@ const multiTokenPoolState: NestedPoolState = {
 
 // BAL is 2 level of nesting
 const deepPoolState: NestedPoolState = {
+    protocolVersion: 2,
     pools: [...deepPools],
     mainTokens: [
         {

--- a/test/v3/addLiquidityNested/addLiquidityNestedV3.integration.test.ts
+++ b/test/v3/addLiquidityNested/addLiquidityNestedV3.integration.test.ts
@@ -15,7 +15,6 @@ import {
     BALANCER_COMPOSITE_LIQUIDITY_ROUTER,
     CHAINS,
     ChainId,
-    NestedPoolState,
     PERMIT2,
     PublicWalletClient,
     Slippage,
@@ -30,18 +29,18 @@ import {
     approveSpenderOnPermit2,
     approveSpenderOnToken,
     areBigIntsWithinPercent,
-    POOLS,
     sendTransactionGetBalances,
     setTokenBalances,
-    TOKENS,
 } from 'test/lib/utils';
+import {
+    nestedWithBoostedPool,
+    NESTED_WITH_BOOSTED_POOL,
+    USDC,
+    USDT,
+    WETH,
+} from 'test/mockData/nestedPool';
 
 const chainId = ChainId.SEPOLIA;
-const NESTED_WITH_BOOSTED_POOL = POOLS[chainId].NESTED_WITH_BOOSTED_POOL;
-const BOOSTED_POOL = POOLS[chainId].MOCK_BOOSTED_POOL;
-const USDC = TOKENS[chainId].USDC_AAVE;
-const USDT = TOKENS[chainId].USDT_AAVE;
-const WETH = TOKENS[chainId].WETH;
 
 const parentBptToken = new Token(
     chainId,
@@ -102,7 +101,7 @@ describe('V3 add liquidity nested test, with Permit2 direct approval', () => {
         };
         const queryOutput = await addLiquidityNested.query(
             addLiquidityInput,
-            nestedPoolState,
+            nestedWithBoostedPool,
         );
         const expectedAmountsIn = [
             TokenAmount.fromHumanAmount(wethToken, '0.001'),
@@ -152,7 +151,7 @@ describe('V3 add liquidity nested test, with Permit2 direct approval', () => {
 
         const queryOutput = (await addLiquidityNested.query(
             addLiquidityInput,
-            nestedPoolState,
+            nestedWithBoostedPool,
         )) as AddLiquidityNestedQueryOutputV3;
 
         const addLiquidityBuildInput = {
@@ -201,59 +200,3 @@ describe('V3 add liquidity nested test, with Permit2 direct approval', () => {
         );
     });
 });
-
-const nestedPoolState: NestedPoolState = {
-    protocolVersion: 3,
-    pools: [
-        {
-            id: NESTED_WITH_BOOSTED_POOL.id,
-            address: NESTED_WITH_BOOSTED_POOL.address,
-            type: NESTED_WITH_BOOSTED_POOL.type,
-            level: 1,
-            tokens: [
-                {
-                    address: BOOSTED_POOL.address,
-                    decimals: BOOSTED_POOL.decimals,
-                    index: 0,
-                },
-                {
-                    address: WETH.address,
-                    decimals: WETH.decimals,
-                    index: 1,
-                },
-            ],
-        },
-        {
-            id: BOOSTED_POOL.id,
-            address: BOOSTED_POOL.address,
-            type: BOOSTED_POOL.type,
-            level: 0,
-            tokens: [
-                {
-                    address: USDC.address,
-                    decimals: USDC.decimals,
-                    index: 0,
-                },
-                {
-                    address: USDT.address,
-                    decimals: USDT.decimals,
-                    index: 1,
-                },
-            ],
-        },
-    ],
-    mainTokens: [
-        {
-            address: WETH.address,
-            decimals: WETH.decimals,
-        },
-        {
-            address: USDT.address,
-            decimals: USDT.decimals,
-        },
-        {
-            address: USDC.address,
-            decimals: USDC.decimals,
-        },
-    ],
-};

--- a/test/v3/addLiquidityNested/addLiquidityNestedV3Signature.integration.test.ts
+++ b/test/v3/addLiquidityNested/addLiquidityNestedV3Signature.integration.test.ts
@@ -14,7 +14,6 @@ import {
     Address,
     CHAINS,
     ChainId,
-    NestedPoolState,
     PERMIT2,
     PublicWalletClient,
     Slippage,
@@ -30,18 +29,17 @@ import { ANVIL_NETWORKS, startFork } from 'test/anvil/anvil-global-setup';
 import {
     approveSpenderOnToken,
     areBigIntsWithinPercent,
-    POOLS,
     sendTransactionGetBalances,
     setTokenBalances,
-    TOKENS,
 } from 'test/lib/utils';
+import {
+    nestedWithBoostedPool,
+    USDC,
+    USDT,
+    WETH,
+} from 'test/mockData/nestedPool';
 
 const chainId = ChainId.SEPOLIA;
-const NESTED_WITH_BOOSTED_POOL = POOLS[chainId].NESTED_WITH_BOOSTED_POOL;
-const BOOSTED_POOL = POOLS[chainId].MOCK_BOOSTED_POOL;
-const USDT = TOKENS[chainId].USDT_AAVE;
-const USDC = TOKENS[chainId].USDC_AAVE;
-const WETH = TOKENS[chainId].WETH;
 
 // These are the underlying tokens
 const usdcToken = new Token(chainId, USDC.address, USDC.decimals);
@@ -98,7 +96,7 @@ describe('V3 add liquidity nested test, with Permit2 signature', () => {
 
         const queryOutput = (await addLiquidityNested.query(
             addLiquidityInput,
-            nestedPoolState,
+            nestedWithBoostedPool,
         )) as AddLiquidityNestedQueryOutputV3;
 
         const addLiquidityBuildInput = {
@@ -166,59 +164,3 @@ describe('V3 add liquidity nested test, with Permit2 signature', () => {
         );
     });
 });
-
-const nestedPoolState: NestedPoolState = {
-    protocolVersion: 3,
-    pools: [
-        {
-            id: NESTED_WITH_BOOSTED_POOL.id,
-            address: NESTED_WITH_BOOSTED_POOL.address,
-            type: NESTED_WITH_BOOSTED_POOL.type,
-            level: 1,
-            tokens: [
-                {
-                    address: BOOSTED_POOL.address,
-                    decimals: BOOSTED_POOL.decimals,
-                    index: 0,
-                },
-                {
-                    address: WETH.address,
-                    decimals: WETH.decimals,
-                    index: 1,
-                },
-            ],
-        },
-        {
-            id: BOOSTED_POOL.id,
-            address: BOOSTED_POOL.address,
-            type: BOOSTED_POOL.type,
-            level: 0,
-            tokens: [
-                {
-                    address: USDC.address,
-                    decimals: USDC.decimals,
-                    index: 0,
-                },
-                {
-                    address: USDT.address,
-                    decimals: USDT.decimals,
-                    index: 1,
-                },
-            ],
-        },
-    ],
-    mainTokens: [
-        {
-            address: WETH.address,
-            decimals: WETH.decimals,
-        },
-        {
-            address: USDT.address,
-            decimals: USDT.decimals,
-        },
-        {
-            address: USDC.address,
-            decimals: USDC.decimals,
-        },
-    ],
-};

--- a/test/v3/removeLiquidityNested/removeLiquidityNestedV3.integration.test.ts
+++ b/test/v3/removeLiquidityNested/removeLiquidityNestedV3.integration.test.ts
@@ -15,7 +15,6 @@ import {
     Address,
     ChainId,
     CHAINS,
-    NestedPoolState,
     PublicWalletClient,
     Token,
     RemoveLiquidityNestedInput,
@@ -28,21 +27,21 @@ import {
 import { ANVIL_NETWORKS, startFork } from 'test/anvil/anvil-global-setup';
 import {
     approveSpenderOnToken,
-    POOLS,
     sendTransactionGetBalances,
-    TOKENS,
 } from 'test/lib/utils';
 import {
     GetNestedBpt,
     validateTokenAmounts,
 } from 'test/lib/utils/removeNestedHelpers';
+import {
+    nestedWithBoostedPool,
+    NESTED_WITH_BOOSTED_POOL,
+    USDC,
+    USDT,
+    WETH,
+} from 'test/mockData/nestedPool';
 
 const chainId = ChainId.SEPOLIA;
-const NESTED_WITH_BOOSTED_POOL = POOLS[chainId].NESTED_WITH_BOOSTED_POOL;
-const BOOSTED_POOL = POOLS[chainId].MOCK_BOOSTED_POOL;
-const USDT = TOKENS[chainId].USDT_AAVE;
-const USDC = TOKENS[chainId].USDC_AAVE;
-const WETH = TOKENS[chainId].WETH;
 
 const parentBptToken = new Token(
     chainId,
@@ -83,7 +82,7 @@ describe('V3 remove liquidity nested test, with Permit direct approval', () => {
             rpcUrl,
             testAddress,
             client,
-            nestedPoolState,
+            nestedWithBoostedPool,
             [
                 {
                     address: WETH.address,
@@ -109,7 +108,7 @@ describe('V3 remove liquidity nested test, with Permit direct approval', () => {
         };
         const queryOutput = await removeLiquidityNested.query(
             removeLiquidityInput,
-            nestedPoolState,
+            nestedWithBoostedPool,
         );
         expect(queryOutput.protocolVersion).toEqual(3);
         expect(queryOutput.bptAmountIn.token).to.deep.eq(parentBptToken);
@@ -117,7 +116,7 @@ describe('V3 remove liquidity nested test, with Permit direct approval', () => {
             removeLiquidityInput.bptAmountIn,
         );
         expect(queryOutput.amountsOut.length).to.eq(
-            nestedPoolState.mainTokens.length,
+            nestedWithBoostedPool.mainTokens.length,
         );
         validateTokenAmounts(queryOutput.amountsOut, mainTokens);
     });
@@ -139,7 +138,7 @@ describe('V3 remove liquidity nested test, with Permit direct approval', () => {
 
         const queryOutput = await removeLiquidityNested.query(
             removeLiquidityInput,
-            nestedPoolState,
+            nestedWithBoostedPool,
         );
 
         const removeLiquidityBuildInput = {
@@ -186,59 +185,3 @@ describe('V3 remove liquidity nested test, with Permit direct approval', () => {
         expect(expectedDeltas).to.deep.eq(balanceDeltas);
     });
 });
-
-const nestedPoolState: NestedPoolState = {
-    protocolVersion: 3,
-    pools: [
-        {
-            id: NESTED_WITH_BOOSTED_POOL.id,
-            address: NESTED_WITH_BOOSTED_POOL.address,
-            type: NESTED_WITH_BOOSTED_POOL.type,
-            level: 1,
-            tokens: [
-                {
-                    address: BOOSTED_POOL.address,
-                    decimals: BOOSTED_POOL.decimals,
-                    index: 0,
-                },
-                {
-                    address: WETH.address,
-                    decimals: WETH.decimals,
-                    index: 1,
-                },
-            ],
-        },
-        {
-            id: BOOSTED_POOL.id,
-            address: BOOSTED_POOL.address,
-            type: BOOSTED_POOL.type,
-            level: 0,
-            tokens: [
-                {
-                    address: USDC.address,
-                    decimals: USDC.decimals,
-                    index: 0,
-                },
-                {
-                    address: USDT.address,
-                    decimals: USDT.decimals,
-                    index: 1,
-                },
-            ],
-        },
-    ],
-    mainTokens: [
-        {
-            address: WETH.address,
-            decimals: WETH.decimals,
-        },
-        {
-            address: USDT.address,
-            decimals: USDT.decimals,
-        },
-        {
-            address: USDC.address,
-            decimals: USDC.decimals,
-        },
-    ],
-};

--- a/test/v3/removeLiquidityNested/removeLiquidityNestedV3Signature.integration.test.ts
+++ b/test/v3/removeLiquidityNested/removeLiquidityNestedV3Signature.integration.test.ts
@@ -15,7 +15,6 @@ import {
     Address,
     ChainId,
     CHAINS,
-    NestedPoolState,
     PublicWalletClient,
     Token,
     RemoveLiquidityNestedInput,
@@ -29,18 +28,17 @@ import {
 import { ANVIL_NETWORKS, startFork } from 'test/anvil/anvil-global-setup';
 import {
     areBigIntsWithinPercent,
-    POOLS,
     sendTransactionGetBalances,
-    TOKENS,
 } from 'test/lib/utils';
 import { GetNestedBpt } from 'test/lib/utils/removeNestedHelpers';
+import {
+    nestedWithBoostedPool,
+    USDC,
+    USDT,
+    WETH,
+} from 'test/mockData/nestedPool';
 
 const chainId = ChainId.SEPOLIA;
-const NESTED_WITH_BOOSTED_POOL = POOLS[chainId].NESTED_WITH_BOOSTED_POOL;
-const BOOSTED_POOL = POOLS[chainId].MOCK_BOOSTED_POOL;
-const USDT = TOKENS[chainId].USDT_AAVE;
-const USDC = TOKENS[chainId].USDC_AAVE;
-const WETH = TOKENS[chainId].WETH;
 
 // These are the underlying tokens
 const usdtToken = new Token(chainId, USDT.address, USDT.decimals);
@@ -76,7 +74,7 @@ describe('V3 remove liquidity nested test, with Permit signature', () => {
             rpcUrl,
             testAddress,
             client,
-            nestedPoolState,
+            nestedWithBoostedPool,
             [
                 {
                     address: WETH.address,
@@ -103,7 +101,7 @@ describe('V3 remove liquidity nested test, with Permit signature', () => {
 
         const queryOutput = await removeLiquidityNested.query(
             removeLiquidityInput,
-            nestedPoolState,
+            nestedWithBoostedPool,
         );
 
         const removeLiquidityBuildInput = {
@@ -162,59 +160,3 @@ describe('V3 remove liquidity nested test, with Permit signature', () => {
         });
     });
 });
-
-const nestedPoolState: NestedPoolState = {
-    protocolVersion: 3,
-    pools: [
-        {
-            id: NESTED_WITH_BOOSTED_POOL.id,
-            address: NESTED_WITH_BOOSTED_POOL.address,
-            type: NESTED_WITH_BOOSTED_POOL.type,
-            level: 1,
-            tokens: [
-                {
-                    address: BOOSTED_POOL.address,
-                    decimals: BOOSTED_POOL.decimals,
-                    index: 0,
-                },
-                {
-                    address: WETH.address,
-                    decimals: WETH.decimals,
-                    index: 1,
-                },
-            ],
-        },
-        {
-            id: BOOSTED_POOL.id,
-            address: BOOSTED_POOL.address,
-            type: BOOSTED_POOL.type,
-            level: 0,
-            tokens: [
-                {
-                    address: USDC.address,
-                    decimals: USDC.decimals,
-                    index: 0,
-                },
-                {
-                    address: USDT.address,
-                    decimals: USDT.decimals,
-                    index: 1,
-                },
-            ],
-        },
-    ],
-    mainTokens: [
-        {
-            address: WETH.address,
-            decimals: WETH.decimals,
-        },
-        {
-            address: USDT.address,
-            decimals: USDT.decimals,
-        },
-        {
-            address: USDC.address,
-            decimals: USDC.decimals,
-        },
-    ],
-};


### PR DESCRIPTION
Also refactors nested add/remove to have different pool state for V2/V3. V3 use a new poolState requiring tokens with underlying info:

```
export type PoolTokenWithUnderlying = MinimalToken & {
    underlyingToken: MinimalToken | null;
};

type NestedPoolBase = {
    id: Hex;
    address: Address;
    type: PoolType;
    level: number; // 0 is the bottom and the highest level is the top
};

export type NestedPoolV2 = NestedPoolBase & {
    tokens: MinimalToken[]; // each token should have at least one
};

export type NestedPoolV3 = NestedPoolBase & {
    tokens: PoolTokenWithUnderlying[]; // each token should have at least one
};

type NestedPoolStateBase = {
    protocolVersion: 1 | 2 | 3;
    mainTokens: {
        address: Address;
        decimals: number;
    }[];
};

export type NestedPoolStateV2 = NestedPoolStateBase & {
    protocolVersion: 1 | 2;
    pools: NestedPoolV2[];
};

export type NestedPoolStateV3 = NestedPoolStateBase & {
    protocolVersion: 3;
    pools: NestedPoolV3[];
};
```