### PR TITLE
375 priceimpact error messaging improvement

### DIFF
--- a/.changeset/silent-ligers-whisper.md
+++ b/.changeset/silent-ligers-whisper.md
@@ -1,0 +1,7 @@
+---
+"@balancer/sdk": patch
+---
+
+PriceImpact error handling and messaging improvements.
+* Catch any errors with initial add/remove steps - these are thrown because the user input is valid, e.g. would cause INVARIANT_GROWTH errors
+* Catch any errors in query during unbalanced calc steps and throw message that will help with debug - e.g. caused by delta amounts

--- a/src/entities/priceImpact/addLiquidityUnbalancedBoosted.ts
+++ b/src/entities/priceImpact/addLiquidityUnbalancedBoosted.ts
@@ -47,7 +47,17 @@ export async function addLiquidityUnbalancedBoosted(
 
     // simulate adding liquidity to get amounts in
     const addLiquidity = new AddLiquidityBoostedV3();
-    const { amountsIn, bptOut } = await addLiquidity.query(input, poolState);
+    let amountsIn: TokenAmount[];
+    let bptOut: TokenAmount;
+    try {
+        const queryResult = await addLiquidity.query(input, poolState);
+        amountsIn = queryResult.amountsIn;
+        bptOut = queryResult.bptOut;
+    } catch (err) {
+        throw new Error(
+            `addLiquidity operation will fail at SC level with user defined input.\n${err}`,
+        );
+    }
     const poolTokens = amountsIn.map((a) => a.token);
 
     // simulate removing liquidity to get amounts out

--- a/src/entities/priceImpact/index.ts
+++ b/src/entities/priceImpact/index.ts
@@ -302,10 +302,17 @@ export class PriceImpact {
 
         // simulate removing liquidity to get amounts out
         const removeLiquidity = new RemoveLiquidity();
-        const { bptIn, amountsOut } = await removeLiquidity.query(
-            input,
-            poolState,
-        );
+        let amountsOut: TokenAmount[];
+        let bptIn: TokenAmount;
+        try {
+            const queryResult = await removeLiquidity.query(input, poolState);
+            amountsOut = queryResult.amountsOut;
+            bptIn = queryResult.bptIn;
+        } catch (err) {
+            throw new Error(
+                `removeLiquidity operation will fail at SC level with user defined input.\n${err}`,
+            );
+        }
 
         // simulate adding liquidity to get amounts in
         const addLiquidity = new AddLiquidity();
@@ -342,10 +349,20 @@ export class PriceImpact {
 
         // simulate removing liquidity to get amounts out
         const removeLiquidityNested = new RemoveLiquidityNested();
-        const { bptAmountIn, amountsOut } = await removeLiquidityNested.query(
-            input,
-            nestedPoolState,
-        );
+        let amountsOut: TokenAmount[];
+        let bptAmountIn: TokenAmount;
+        try {
+            const queryResult = await removeLiquidityNested.query(
+                input,
+                nestedPoolState,
+            );
+            amountsOut = queryResult.amountsOut;
+            bptAmountIn = queryResult.bptAmountIn;
+        } catch (err) {
+            throw new Error(
+                `removeLiquidity operation will fail at SC level with user defined input.\n${err}`,
+            );
+        }
 
         // simulate adding liquidity to get amounts in
         const addLiquidityNested = new AddLiquidityNested();

--- a/src/entities/priceImpact/index.ts
+++ b/src/entities/priceImpact/index.ts
@@ -26,6 +26,7 @@ import { AddLiquidityNested } from '../addLiquidityNested';
 import { AddLiquidityBoostedUnbalancedInput } from '../addLiquidityBoosted/types';
 import { addLiquidityUnbalancedBoosted } from './addLiquidityUnbalancedBoosted';
 import { addLiquidityNested } from './addLiquidityNested';
+import { Token } from '../token';
 
 export class PriceImpact {
     /**
@@ -42,7 +43,15 @@ export class PriceImpact {
 
         // simulate adding liquidity to get amounts in
         const addLiquidity = new AddLiquidity();
-        const { amountsIn } = await addLiquidity.query(input, poolState);
+        let amountsIn: TokenAmount[];
+        try {
+            const queryResult = await addLiquidity.query(input, poolState);
+            amountsIn = queryResult.amountsIn;
+        } catch (err) {
+            throw new Error(
+                `addLiquiditySingleToken operation will fail at SC level with user defined input.\n${err}`,
+            );
+        }
 
         // simulate removing liquidity to get amounts out
         const removeLiquidity = new RemoveLiquidity();
@@ -101,11 +110,19 @@ export class PriceImpact {
 
         // simulate adding liquidity to get amounts in
         const addLiquidity = new AddLiquidity();
-        const { amountsIn, bptOut } = await addLiquidity.query(
-            input,
-            poolState,
-        );
-        const poolTokens = amountsIn.map((a) => a.token);
+        let amountsIn: TokenAmount[];
+        let bptOut: TokenAmount;
+        let poolTokens: Token[];
+        try {
+            const queryResult = await addLiquidity.query(input, poolState);
+            amountsIn = queryResult.amountsIn;
+            bptOut = queryResult.bptOut;
+            poolTokens = amountsIn.map((a) => a.token);
+        } catch (err) {
+            throw new Error(
+                `addLiquidityUnbalanced operation will fail at SC level with user defined input.\n${err}`,
+            );
+        }
 
         // simulate removing liquidity to get amounts out
         const removeLiquidity = new RemoveLiquidity();

--- a/test/mockData/weightedWethBalPool.ts
+++ b/test/mockData/weightedWethBalPool.ts
@@ -1,0 +1,28 @@
+import { PoolState } from '@/entities';
+import { PoolType } from '@/types';
+import { ChainId } from '@/utils';
+import { POOLS, TOKENS } from 'test/lib/utils';
+
+const chainId = ChainId.SEPOLIA;
+export const MOCK_WETH_BAL_POOL = POOLS[chainId].MOCK_WETH_BAL_POOL;
+export const WETH = TOKENS[chainId].WETH;
+const BAL = TOKENS[chainId].BAL;
+
+export const weightedWethBal: PoolState = {
+    id: MOCK_WETH_BAL_POOL.id,
+    address: MOCK_WETH_BAL_POOL.address,
+    type: PoolType.Weighted,
+    protocolVersion: 3,
+    tokens: [
+        {
+            address: WETH.address,
+            decimals: WETH.decimals,
+            index: 0,
+        },
+        {
+            address: BAL.address,
+            decimals: BAL.decimals,
+            index: 1,
+        },
+    ],
+};

--- a/test/v3/priceImpact/priceImpactErrors.V3.integration.test.ts
+++ b/test/v3/priceImpact/priceImpactErrors.V3.integration.test.ts
@@ -9,11 +9,14 @@ import {
     AddLiquidityKind,
     ChainId,
     PriceImpact,
+    RemoveLiquidityKind,
+    RemoveLiquiditySingleTokenExactInInput,
 } from 'src';
 
 import { ANVIL_NETWORKS, startFork } from 'test/anvil/anvil-global-setup';
 import { TOKENS } from 'test/lib/utils/addresses';
 import { boostedPool_USDC_USDT } from 'test/mockData/boostedPool';
+import { weightedWethBal, WETH } from 'test/mockData/weightedWethBalPool';
 
 const chainId = ChainId.SEPOLIA;
 const USDC = TOKENS[chainId].USDC_AAVE;
@@ -45,7 +48,27 @@ describe('PriceImpact Errors V3', () => {
                 boostedPool_USDC_USDT,
             ),
         ).rejects.toThrowError(
-            'AddLiquidity operation will fail at SC level with user defined input.',
+            'operation will fail at SC level with user defined input.',
+        );
+    });
+
+    test('Expect Error for failing remove input', async () => {
+        const removeLiquidityInput: RemoveLiquiditySingleTokenExactInInput = {
+            chainId,
+            rpcUrl,
+            bptIn: {
+                rawAmount: 1000000000000000000000n,
+                decimals: 18,
+                address: weightedWethBal.address,
+            },
+            tokenOut: WETH.address,
+            kind: RemoveLiquidityKind.SingleTokenExactIn,
+        };
+
+        await expect(() =>
+            PriceImpact.removeLiquidity(removeLiquidityInput, weightedWethBal),
+        ).rejects.toThrowError(
+            'removeLiquidity operation will fail at SC level with user defined input',
         );
     });
 });

--- a/test/v3/priceImpact/priceImpactErrors.V3.integration.test.ts
+++ b/test/v3/priceImpact/priceImpactErrors.V3.integration.test.ts
@@ -1,0 +1,51 @@
+// pnpm test -- priceImpact/priceImpactErrors.V3.integration.test.ts
+
+import dotenv from 'dotenv';
+dotenv.config();
+
+import { Address } from 'viem';
+import {
+    AddLiquidityBoostedUnbalancedInput,
+    AddLiquidityKind,
+    ChainId,
+    PriceImpact,
+} from 'src';
+
+import { ANVIL_NETWORKS, startFork } from 'test/anvil/anvil-global-setup';
+import { TOKENS } from 'test/lib/utils/addresses';
+import { boostedPool_USDC_USDT } from 'test/mockData/boostedPool';
+
+const chainId = ChainId.SEPOLIA;
+const USDC = TOKENS[chainId].USDC_AAVE;
+
+describe('PriceImpact Errors V3', () => {
+    let rpcUrl: string;
+    beforeAll(async () => {
+        ({ rpcUrl } = await startFork(ANVIL_NETWORKS.SEPOLIA));
+    });
+
+    test('Expect Error for failing add input', async () => {
+        const addLiquidityInput: AddLiquidityBoostedUnbalancedInput = {
+            chainId,
+            rpcUrl,
+            amountsIn: [
+                {
+                    rawAmount: 10000000000000000n,
+                    decimals: 6,
+                    address: USDC.address as Address,
+                },
+            ],
+            kind: AddLiquidityKind.Unbalanced,
+            userData: '0x',
+        };
+
+        await expect(() =>
+            PriceImpact.addLiquidityUnbalancedBoosted(
+                addLiquidityInput,
+                boostedPool_USDC_USDT,
+            ),
+        ).rejects.toThrowError(
+            'AddLiquidity operation will fail at SC level with user defined input.',
+        );
+    });
+});


### PR DESCRIPTION
* Catch any errors with initial add/remove steps - these are thrown because the user input is valid, e.g. would cause INVARIANT_GROWTH errors
* Catch any errors in query during unbalanced calc steps and throw message that will help with debug - e.g. caused by delta amounts