### PR TITLE
fix: nested single token remove v2 validation

### DIFF
--- a/.changeset/tricky-points-smell.md
+++ b/.changeset/tricky-points-smell.md
@@ -1,0 +1,5 @@
+---
+"@balancer/sdk": patch
+---
+
+fix: nested single token remove v2 validation

--- a/src/entities/utils/isPoolToken.ts
+++ b/src/entities/utils/isPoolToken.ts
@@ -26,7 +26,7 @@ export function isPoolToken(
         const isToken = isSameAddress(t.address, token);
         const isUnderlying =
             isPoolTokenWithUnderlying(t) &&
-            t.underlyingToken &&
+            t.underlyingToken?.address &&
             isSameAddress(t.underlyingToken.address, token);
 
         if (isToken || isUnderlying) {

--- a/src/entities/utils/validateNestedPoolState.test.ts
+++ b/src/entities/utils/validateNestedPoolState.test.ts
@@ -1,10 +1,6 @@
 // pnpm test -- nestedPoolStateValidation.test.ts
 import { describe, expect, test } from 'vitest';
-import {
-    NestedPoolState,
-    NestedPoolV2,
-    validateNestedPoolState,
-} from '../src/entities';
+import { NestedPoolState, NestedPoolV2, validateNestedPoolState } from '..';
 import { PoolType } from '@/types';
 
 describe('nested pool state validations', () => {
@@ -45,7 +41,7 @@ describe('nested pool state validations', () => {
                         TOP
                 3POOL_BPT/auraBal_BPT/WETH
 
-        3POOL_BPT           auraBal_BPT         
+        3POOL_BPT           auraBal_BPT
         DAI/USDC/USDT       auraBal/8020_BPT
 
                                 8020_BPT


### PR DESCRIPTION
Using `mapPoolToNestedPoolStateV2` with an V2 pool such as:

```
  id: '0x08775ccb6674d6bdceb0797c364c2653ed84f3840002000000000000000004f0',
  address: '0x08775ccb6674d6bdceb0797c364c2653ed84f384',
```

returns something like: 

```
  [
      {
        "address": "0x08775ccb6674d6bdceb0797c364c2653ed84f384",
        "id": "0x08775ccb6674d6bdceb0797c364c2653ed84f3840002000000000000000004f0",
        "level": 1,
        "tokens": [
          {
            "address": "0x79c58f70905f734641735bc61e45c19dd9ad60bc",
            "decimals": 18,
            "index": 0,
            "underlyingToken": null,
          },
          {
            "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
            "decimals": 18,
            "index": 1,
            "underlyingToken": null,
          },
        ],
        "type": "Weighted",
      },
      {
        "address": "0x79c58f70905f734641735bc61e45c19dd9ad60bc",
        "id": "0x79c58f70905f734641735bc61e45c19dd9ad60bc0000000000000000000004e7",
        "level": 0,
        "tokens": [
          {
            "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
            "decimals": 18,
            "index": 0,
            "underlyingToken": null,
          },
          {
            "address": "0x79c58f70905f734641735bc61e45c19dd9ad60bc",
            "decimals": 18,
            "index": 1,
            "underlyingToken": null,
          },
          {
            "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
            "decimals": 6,
            "index": 2,
            "underlyingToken": null,
          },
          {
            "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
            "decimals": 6,
            "index": 3,
            "underlyingToken": null,
          },
        ],
        "type": "ComposableStable",
      },
    ]
```
with explicit `"underlyingToken": null,` fields.

That breaks v2 nested validation.

The current fix is checking with optional `underlyingToken?address` although a better fix could be not sending `underlyingToken` when it is not defined. 

This PR also renames and moves `validateNestedPoolState.test.ts` file together with the file that it tests.







