### PR TITLE
Fix pool init error for pool creation UI

### DIFF
--- a/src/abi/index.ts
+++ b/src/abi/index.ts
@@ -18,3 +18,4 @@ export * from './weightedPool.V3';
 export * from './vaultAdmin.V3';
 export * from './stablePoolFactory.V3';
 export * from './balancerCompositeLiquidityRouter';
+export * from './vaultExplorer.V3';

--- a/src/abi/vaultExplorer.V3.ts
+++ b/src/abi/vaultExplorer.V3.ts
@@ -1,0 +1,737 @@
+export const vaultExplorerAbi_V3 = [
+    {
+        inputs: [
+            { internalType: 'contract IVault', name: 'vault', type: 'address' },
+        ],
+        stateMutability: 'nonpayable',
+        type: 'constructor',
+    },
+    {
+        inputs: [
+            { internalType: 'address', name: 'token', type: 'address' },
+            { internalType: 'address', name: 'owner', type: 'address' },
+            { internalType: 'address', name: 'spender', type: 'address' },
+        ],
+        name: 'allowance',
+        outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'areBuffersPaused',
+        outputs: [{ internalType: 'bool', name: '', type: 'bool' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [
+            { internalType: 'address', name: 'token', type: 'address' },
+            { internalType: 'address', name: 'account', type: 'address' },
+        ],
+        name: 'balanceOf',
+        outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [{ internalType: 'address', name: 'pool', type: 'address' }],
+        name: 'collectAggregateFees',
+        outputs: [],
+        stateMutability: 'nonpayable',
+        type: 'function',
+    },
+    {
+        inputs: [
+            { internalType: 'address', name: 'pool', type: 'address' },
+            {
+                components: [
+                    {
+                        internalType: 'enum SwapKind',
+                        name: 'kind',
+                        type: 'uint8',
+                    },
+                    {
+                        internalType: 'uint256',
+                        name: 'amountGivenScaled18',
+                        type: 'uint256',
+                    },
+                    {
+                        internalType: 'uint256[]',
+                        name: 'balancesScaled18',
+                        type: 'uint256[]',
+                    },
+                    {
+                        internalType: 'uint256',
+                        name: 'indexIn',
+                        type: 'uint256',
+                    },
+                    {
+                        internalType: 'uint256',
+                        name: 'indexOut',
+                        type: 'uint256',
+                    },
+                    {
+                        internalType: 'address',
+                        name: 'router',
+                        type: 'address',
+                    },
+                    { internalType: 'bytes', name: 'userData', type: 'bytes' },
+                ],
+                internalType: 'struct PoolSwapParams',
+                name: 'swapParams',
+                type: 'tuple',
+            },
+        ],
+        name: 'computeDynamicSwapFeePercentage',
+        outputs: [
+            {
+                internalType: 'uint256',
+                name: 'dynamicSwapFee',
+                type: 'uint256',
+            },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [{ internalType: 'address', name: 'pool', type: 'address' }],
+        name: 'getAggregateFeePercentages',
+        outputs: [
+            { internalType: 'uint256', name: '', type: 'uint256' },
+            { internalType: 'uint256', name: '', type: 'uint256' },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [
+            { internalType: 'address', name: 'pool', type: 'address' },
+            { internalType: 'contract IERC20', name: 'token', type: 'address' },
+        ],
+        name: 'getAggregateSwapFeeAmount',
+        outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [
+            { internalType: 'address', name: 'pool', type: 'address' },
+            { internalType: 'contract IERC20', name: 'token', type: 'address' },
+        ],
+        name: 'getAggregateYieldFeeAmount',
+        outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'getAuthorizer',
+        outputs: [{ internalType: 'address', name: '', type: 'address' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [{ internalType: 'address', name: 'pool', type: 'address' }],
+        name: 'getBptRate',
+        outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [
+            {
+                internalType: 'contract IERC4626',
+                name: 'wrappedToken',
+                type: 'address',
+            },
+        ],
+        name: 'getBufferAsset',
+        outputs: [{ internalType: 'address', name: '', type: 'address' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [
+            {
+                internalType: 'contract IERC4626',
+                name: 'token',
+                type: 'address',
+            },
+        ],
+        name: 'getBufferBalance',
+        outputs: [
+            { internalType: 'uint256', name: '', type: 'uint256' },
+            { internalType: 'uint256', name: '', type: 'uint256' },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'getBufferMinimumTotalSupply',
+        outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [
+            {
+                internalType: 'contract IERC4626',
+                name: 'token',
+                type: 'address',
+            },
+            { internalType: 'address', name: 'user', type: 'address' },
+        ],
+        name: 'getBufferOwnerShares',
+        outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'getBufferPeriodDuration',
+        outputs: [{ internalType: 'uint32', name: '', type: 'uint32' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'getBufferPeriodEndTime',
+        outputs: [{ internalType: 'uint32', name: '', type: 'uint32' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [
+            {
+                internalType: 'contract IERC4626',
+                name: 'token',
+                type: 'address',
+            },
+        ],
+        name: 'getBufferTotalShares',
+        outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [{ internalType: 'address', name: 'pool', type: 'address' }],
+        name: 'getCurrentLiveBalances',
+        outputs: [{ internalType: 'uint256[]', name: '', type: 'uint256[]' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [{ internalType: 'address', name: 'pool', type: 'address' }],
+        name: 'getHooksConfig',
+        outputs: [
+            {
+                components: [
+                    {
+                        internalType: 'bool',
+                        name: 'enableHookAdjustedAmounts',
+                        type: 'bool',
+                    },
+                    {
+                        internalType: 'bool',
+                        name: 'shouldCallBeforeInitialize',
+                        type: 'bool',
+                    },
+                    {
+                        internalType: 'bool',
+                        name: 'shouldCallAfterInitialize',
+                        type: 'bool',
+                    },
+                    {
+                        internalType: 'bool',
+                        name: 'shouldCallComputeDynamicSwapFee',
+                        type: 'bool',
+                    },
+                    {
+                        internalType: 'bool',
+                        name: 'shouldCallBeforeSwap',
+                        type: 'bool',
+                    },
+                    {
+                        internalType: 'bool',
+                        name: 'shouldCallAfterSwap',
+                        type: 'bool',
+                    },
+                    {
+                        internalType: 'bool',
+                        name: 'shouldCallBeforeAddLiquidity',
+                        type: 'bool',
+                    },
+                    {
+                        internalType: 'bool',
+                        name: 'shouldCallAfterAddLiquidity',
+                        type: 'bool',
+                    },
+                    {
+                        internalType: 'bool',
+                        name: 'shouldCallBeforeRemoveLiquidity',
+                        type: 'bool',
+                    },
+                    {
+                        internalType: 'bool',
+                        name: 'shouldCallAfterRemoveLiquidity',
+                        type: 'bool',
+                    },
+                    {
+                        internalType: 'address',
+                        name: 'hooksContract',
+                        type: 'address',
+                    },
+                ],
+                internalType: 'struct HooksConfig',
+                name: '',
+                type: 'tuple',
+            },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'getMaximumPoolTokens',
+        outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'getMinimumPoolTokens',
+        outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'getMinimumTradeAmount',
+        outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'getMinimumWrapAmount',
+        outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'getNonzeroDeltaCount',
+        outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'getPauseWindowEndTime',
+        outputs: [{ internalType: 'uint32', name: '', type: 'uint32' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [{ internalType: 'address', name: 'pool', type: 'address' }],
+        name: 'getPoolConfig',
+        outputs: [
+            {
+                components: [
+                    {
+                        components: [
+                            {
+                                internalType: 'bool',
+                                name: 'disableUnbalancedLiquidity',
+                                type: 'bool',
+                            },
+                            {
+                                internalType: 'bool',
+                                name: 'enableAddLiquidityCustom',
+                                type: 'bool',
+                            },
+                            {
+                                internalType: 'bool',
+                                name: 'enableRemoveLiquidityCustom',
+                                type: 'bool',
+                            },
+                            {
+                                internalType: 'bool',
+                                name: 'enableDonation',
+                                type: 'bool',
+                            },
+                        ],
+                        internalType: 'struct LiquidityManagement',
+                        name: 'liquidityManagement',
+                        type: 'tuple',
+                    },
+                    {
+                        internalType: 'uint256',
+                        name: 'staticSwapFeePercentage',
+                        type: 'uint256',
+                    },
+                    {
+                        internalType: 'uint256',
+                        name: 'aggregateSwapFeePercentage',
+                        type: 'uint256',
+                    },
+                    {
+                        internalType: 'uint256',
+                        name: 'aggregateYieldFeePercentage',
+                        type: 'uint256',
+                    },
+                    {
+                        internalType: 'uint40',
+                        name: 'tokenDecimalDiffs',
+                        type: 'uint40',
+                    },
+                    {
+                        internalType: 'uint32',
+                        name: 'pauseWindowEndTime',
+                        type: 'uint32',
+                    },
+                    {
+                        internalType: 'bool',
+                        name: 'isPoolRegistered',
+                        type: 'bool',
+                    },
+                    {
+                        internalType: 'bool',
+                        name: 'isPoolInitialized',
+                        type: 'bool',
+                    },
+                    {
+                        internalType: 'bool',
+                        name: 'isPoolPaused',
+                        type: 'bool',
+                    },
+                    {
+                        internalType: 'bool',
+                        name: 'isPoolInRecoveryMode',
+                        type: 'bool',
+                    },
+                ],
+                internalType: 'struct PoolConfig',
+                name: '',
+                type: 'tuple',
+            },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [{ internalType: 'address', name: 'pool', type: 'address' }],
+        name: 'getPoolData',
+        outputs: [
+            {
+                components: [
+                    {
+                        internalType: 'PoolConfigBits',
+                        name: 'poolConfigBits',
+                        type: 'bytes32',
+                    },
+                    {
+                        internalType: 'contract IERC20[]',
+                        name: 'tokens',
+                        type: 'address[]',
+                    },
+                    {
+                        components: [
+                            {
+                                internalType: 'enum TokenType',
+                                name: 'tokenType',
+                                type: 'uint8',
+                            },
+                            {
+                                internalType: 'contract IRateProvider',
+                                name: 'rateProvider',
+                                type: 'address',
+                            },
+                            {
+                                internalType: 'bool',
+                                name: 'paysYieldFees',
+                                type: 'bool',
+                            },
+                        ],
+                        internalType: 'struct TokenInfo[]',
+                        name: 'tokenInfo',
+                        type: 'tuple[]',
+                    },
+                    {
+                        internalType: 'uint256[]',
+                        name: 'balancesRaw',
+                        type: 'uint256[]',
+                    },
+                    {
+                        internalType: 'uint256[]',
+                        name: 'balancesLiveScaled18',
+                        type: 'uint256[]',
+                    },
+                    {
+                        internalType: 'uint256[]',
+                        name: 'tokenRates',
+                        type: 'uint256[]',
+                    },
+                    {
+                        internalType: 'uint256[]',
+                        name: 'decimalScalingFactors',
+                        type: 'uint256[]',
+                    },
+                ],
+                internalType: 'struct PoolData',
+                name: '',
+                type: 'tuple',
+            },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'getPoolMinimumTotalSupply',
+        outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [{ internalType: 'address', name: 'pool', type: 'address' }],
+        name: 'getPoolPausedState',
+        outputs: [
+            { internalType: 'bool', name: '', type: 'bool' },
+            { internalType: 'uint32', name: '', type: 'uint32' },
+            { internalType: 'uint32', name: '', type: 'uint32' },
+            { internalType: 'address', name: '', type: 'address' },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [{ internalType: 'address', name: 'pool', type: 'address' }],
+        name: 'getPoolRoleAccounts',
+        outputs: [
+            {
+                components: [
+                    {
+                        internalType: 'address',
+                        name: 'pauseManager',
+                        type: 'address',
+                    },
+                    {
+                        internalType: 'address',
+                        name: 'swapFeeManager',
+                        type: 'address',
+                    },
+                    {
+                        internalType: 'address',
+                        name: 'poolCreator',
+                        type: 'address',
+                    },
+                ],
+                internalType: 'struct PoolRoleAccounts',
+                name: '',
+                type: 'tuple',
+            },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [
+            { internalType: 'address', name: 'pool', type: 'address' },
+            { internalType: 'contract IERC20', name: 'token', type: 'address' },
+        ],
+        name: 'getPoolTokenCountAndIndexOfToken',
+        outputs: [
+            { internalType: 'uint256', name: '', type: 'uint256' },
+            { internalType: 'uint256', name: '', type: 'uint256' },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [{ internalType: 'address', name: 'pool', type: 'address' }],
+        name: 'getPoolTokenInfo',
+        outputs: [
+            {
+                internalType: 'contract IERC20[]',
+                name: 'tokens',
+                type: 'address[]',
+            },
+            {
+                components: [
+                    {
+                        internalType: 'enum TokenType',
+                        name: 'tokenType',
+                        type: 'uint8',
+                    },
+                    {
+                        internalType: 'contract IRateProvider',
+                        name: 'rateProvider',
+                        type: 'address',
+                    },
+                    {
+                        internalType: 'bool',
+                        name: 'paysYieldFees',
+                        type: 'bool',
+                    },
+                ],
+                internalType: 'struct TokenInfo[]',
+                name: 'tokenInfo',
+                type: 'tuple[]',
+            },
+            {
+                internalType: 'uint256[]',
+                name: 'balancesRaw',
+                type: 'uint256[]',
+            },
+            {
+                internalType: 'uint256[]',
+                name: 'scalingFactors',
+                type: 'uint256[]',
+            },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [{ internalType: 'address', name: 'pool', type: 'address' }],
+        name: 'getPoolTokenRates',
+        outputs: [
+            { internalType: 'uint256[]', name: '', type: 'uint256[]' },
+            { internalType: 'uint256[]', name: '', type: 'uint256[]' },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [{ internalType: 'address', name: 'pool', type: 'address' }],
+        name: 'getPoolTokens',
+        outputs: [
+            { internalType: 'contract IERC20[]', name: '', type: 'address[]' },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'getProtocolFeeController',
+        outputs: [{ internalType: 'address', name: '', type: 'address' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [
+            { internalType: 'contract IERC20', name: 'token', type: 'address' },
+        ],
+        name: 'getReservesOf',
+        outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [{ internalType: 'address', name: 'pool', type: 'address' }],
+        name: 'getStaticSwapFeePercentage',
+        outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [
+            { internalType: 'contract IERC20', name: 'token', type: 'address' },
+        ],
+        name: 'getTokenDelta',
+        outputs: [{ internalType: 'int256', name: '', type: 'int256' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'getVault',
+        outputs: [{ internalType: 'address', name: '', type: 'address' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'getVaultAdmin',
+        outputs: [{ internalType: 'address', name: '', type: 'address' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'getVaultExtension',
+        outputs: [{ internalType: 'address', name: '', type: 'address' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'getVaultPausedState',
+        outputs: [
+            { internalType: 'bool', name: '', type: 'bool' },
+            { internalType: 'uint32', name: '', type: 'uint32' },
+            { internalType: 'uint32', name: '', type: 'uint32' },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [{ internalType: 'address', name: 'pool', type: 'address' }],
+        name: 'isPoolInRecoveryMode',
+        outputs: [{ internalType: 'bool', name: '', type: 'bool' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [{ internalType: 'address', name: 'pool', type: 'address' }],
+        name: 'isPoolInitialized',
+        outputs: [{ internalType: 'bool', name: '', type: 'bool' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [{ internalType: 'address', name: 'pool', type: 'address' }],
+        name: 'isPoolPaused',
+        outputs: [{ internalType: 'bool', name: '', type: 'bool' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [{ internalType: 'address', name: 'pool', type: 'address' }],
+        name: 'isPoolRegistered',
+        outputs: [{ internalType: 'bool', name: '', type: 'bool' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'isQueryDisabled',
+        outputs: [{ internalType: 'bool', name: '', type: 'bool' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'isUnlocked',
+        outputs: [{ internalType: 'bool', name: '', type: 'bool' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'isVaultPaused',
+        outputs: [{ internalType: 'bool', name: '', type: 'bool' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [{ internalType: 'address', name: 'token', type: 'address' }],
+        name: 'totalSupply',
+        outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+] as const;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -157,6 +157,10 @@ export const VAULT_ADMIN: Record<number, Address> = {
     [ChainId.SEPOLIA]: '0x2AD9162D9b388b75eB40cBF996AbE8E968670c5C',
 };
 
+export const VAULT_EXPLORER_V3: Record<number, Address> = {
+    [ChainId.SEPOLIA]: '0xa9F171e84A95c103aD4aFAC3Ec83810f9cA193a8',
+};
+
 export const BALANCER_QUERIES: Record<number, Address> = {
     [ChainId.ARBITRUM_ONE]: '0xE39B5e3B6D74016b2F6A9673D7d7493B6DF549d5',
     [ChainId.AVALANCHE]: '0xC128468b7Ce63eA702C1f104D55A2566b13D3ABD',

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -1,6 +1,6 @@
 import { Address, Client, Hex, PublicClient, getContract } from 'viem';
-import { vaultV2Abi, vaultExtensionAbi_V3 } from '../abi';
-import { VAULT, VAULT_V3 } from './constants';
+import { vaultV2Abi, vaultExplorerAbi_V3 } from '../abi';
+import { VAULT, VAULT_EXPLORER_V3 } from './constants';
 
 export async function getTokenDecimals(
     tokenAddress: Address,
@@ -69,8 +69,8 @@ export async function getPoolTokensV3(
     try {
         const chainId = await client.getChainId();
         const vaultV3 = getContract({
-            abi: vaultExtensionAbi_V3,
-            address: VAULT_V3[chainId],
+            abi: vaultExplorerAbi_V3,
+            address: VAULT_EXPLORER_V3[chainId],
             client: client,
         });
         return (await vaultV3.read.getPoolTokens([poolAddress])) as Address[];

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -34,7 +34,7 @@ export async function getTokenDecimals(
     } catch (e) {
         console.warn(e);
         throw new Error(
-            `Error: Unable to get Token Decimals from token: ${tokenAddress}`,
+            `Unable to get Token Decimals from token: ${tokenAddress}`,
         );
     }
 }
@@ -57,7 +57,7 @@ export async function getPoolTokensV2(
     } catch (e) {
         console.warn(e);
         throw new Error(
-            `Error: Unable to get pool tokens using this pool id: ${poolId}`,
+            `Unable to get pool tokens using this pool id: ${poolId}`,
         );
     }
 }
@@ -77,7 +77,7 @@ export async function getPoolTokensV3(
     } catch (e) {
         console.warn(e);
         throw new Error(
-            `Error: Unable to get pool tokens using this pool address: ${poolAddress}`,
+            `Unable to get pool tokens using this pool address: ${poolAddress}`,
         );
     }
 }

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -68,12 +68,14 @@ export async function getPoolTokensV3(
 ): Promise<Address[]> {
     try {
         const chainId = await client.getChainId();
-        const vaultV3 = getContract({
+        const vaultExplorer = getContract({
             abi: vaultExplorerAbi_V3,
             address: VAULT_EXPLORER_V3[chainId],
             client: client,
         });
-        return (await vaultV3.read.getPoolTokens([poolAddress])) as Address[];
+        return (await vaultExplorer.read.getPoolTokens([
+            poolAddress,
+        ])) as Address[];
     } catch (e) {
         console.warn(e);
         throw new Error(


### PR DESCRIPTION
I can't seem to figure out why SDK query for poolState is failing. See[ code comment below](https://github.com/balancer/b-sdk/pull/509#discussion_r1863946915)

I have confirmed using the vaultExplorer contract that the pool is registered and `getPoolTokens` works there. 

At this point, I'm unsure if bug is in SDK or pool creation UI

### Resources
- pool address: `0xF5A25990da505a9d4C3E0d876f3951E9EDF9ABC3`
- vault address: `0xBC582d2628FcD404254a1e12CB714967Ce428915`
- vault explorer address: `0xa9F171e84A95c103aD4aFAC3Ec83810f9cA193a8`
- [Tenderly call](https://www.tdly.co/shared/simulation/10b62509-7b2d-4e39-bbd9-92d9378cd0fc)  at vault with vaultExtension ABI

