### PR TITLE
chore: log multicall v2 pool state error

### DIFF
--- a/.changeset/chilled-hornets-explode.md
+++ b/.changeset/chilled-hornets-explode.md
@@ -1,0 +1,5 @@
+---
+"@balancer/sdk": patch
+---
+
+chore: debug v2 pool state multicall errors

--- a/src/entities/utils/getPoolStateWithBalancesV2.ts
+++ b/src/entities/utils/getPoolStateWithBalancesV2.ts
@@ -34,6 +34,16 @@ export const getPoolStateWithBalancesV2 = async (
     });
 
     if (outputs.some((output) => output.status === 'failure')) {
+        console.log(
+            'Multicall error/s getting pool state with balances for v2 pool',
+            {
+                errors: outputs
+                    .filter((o) => o.status === 'failure')
+                    .map((o) => o.error),
+                chainId,
+                poolId: poolState.id,
+            },
+        );
         throw new Error(
             'Error: Unable to get pool state with balances for v2 pool.',
         );


### PR DESCRIPTION
We are hitting this error quite frequently from our integration tests in GHA. 

This PR adds a console.log to debug the issue.