### PR TITLE
Fix price impact with near proportional inputs for AddLiquidityNested

### DIFF
--- a/.changeset/chilled-phones-explain.md
+++ b/.changeset/chilled-phones-explain.md
@@ -1,0 +1,5 @@
+---
+"@balancer/sdk": patch
+---
+
+Fix price impact with near proportional inputs for AddLiquidityNested

--- a/test/anvil/anvil-global-setup.ts
+++ b/test/anvil/anvil-global-setup.ts
@@ -66,7 +66,7 @@ export const ANVIL_NETWORKS: Record<NetworksWithFork, NetworkSetup> = {
         rpcEnv: 'SEPOLIA_RPC_URL',
         fallBackRpc: 'https://sepolia.gateway.tenderly.co',
         port: ANVIL_PORTS.SEPOLIA,
-        forkBlockNumber: 7220370n,
+        forkBlockNumber: 7245070n,
     },
     OPTIMISM: {
         rpcEnv: 'OPTIMISM_RPC_URL',

--- a/test/mockData/partialBoostedPool.ts
+++ b/test/mockData/partialBoostedPool.ts
@@ -1,8 +1,8 @@
 import { PoolStateWithUnderlyings } from '@/entities';
 
 export const partialBoostedPool_USDT_stataDAI: PoolStateWithUnderlyings = {
-    id: '0xCE7601b157e0871332D2295F274a0f4314a1585D',
-    address: '0xCE7601b157e0871332D2295F274a0f4314a1585D',
+    id: '0x070810362cb6fd4b44f87a225ab0c20aeb194a63',
+    address: '0x070810362cb6fd4b44f87a225ab0c20aeb194a63',
     type: 'Stable',
     protocolVersion: 3,
     tokens: [

--- a/test/v3/priceImpact/priceImpact.V3.integration.test.ts
+++ b/test/v3/priceImpact/priceImpact.V3.integration.test.ts
@@ -10,7 +10,6 @@ import {
     AddLiquidityNestedInput,
     ChainId,
     PriceImpact,
-    PriceImpactAmount,
 } from 'src';
 
 import { ANVIL_NETWORKS, startFork } from 'test/anvil/anvil-global-setup';
@@ -25,19 +24,17 @@ const USDT = TOKENS[chainId].USDT_AAVE;
 const DAI = TOKENS[chainId].DAI_AAVE;
 const WETH = TOKENS[chainId].WETH;
 
+/**
+ * FIXME: tests are here just as a sanity check. We should find a way to
+ * properly validate results.
+ */
 describe('PriceImpact V3', () => {
     let rpcUrl: string;
     beforeAll(async () => {
         ({ rpcUrl } = await startFork(ANVIL_NETWORKS.SEPOLIA));
     });
-    /**
-     * FIXME: Test pending a reference value for comparison/validation, because
-     * there is no corresponding method in previous SDK to validate the result.
-     * We should be able to infer that it is correct because it follows the same
-     * ABA approach as price impact for other actions (addLiquidity, swap, etc.)
-     */
     describe('Full Boosted Pool Boosted Pool AddLiquidity', () => {
-        test.skip('Close to proportional', async () => {
+        test('Close to proportional', async () => {
             const addLiquidityInput: AddLiquidityBoostedUnbalancedInput = {
                 chainId,
                 rpcUrl,
@@ -61,8 +58,7 @@ describe('PriceImpact V3', () => {
                     addLiquidityInput,
                     boostedPool_USDC_USDT,
                 );
-            const priceImpactSpot = PriceImpactAmount.fromDecimal('0.000057');
-            expect(priceImpactABA.decimal).eq(priceImpactSpot.decimal);
+            expect(priceImpactABA.decimal).greaterThan(0);
         });
 
         test('Unbalanced', async () => {
@@ -89,12 +85,10 @@ describe('PriceImpact V3', () => {
                     addLiquidityInput,
                     boostedPool_USDC_USDT,
                 );
-            const priceImpactSpot =
-                PriceImpactAmount.fromDecimal('0.00058238995');
-            expect(priceImpactABA.decimal).eq(priceImpactSpot.decimal);
+            expect(priceImpactABA.decimal).greaterThan(0);
         });
 
-        test.skip('Single token input', async () => {
+        test('Single token input', async () => {
             const addLiquidityInput: AddLiquidityBoostedUnbalancedInput = {
                 chainId,
                 rpcUrl,
@@ -113,12 +107,11 @@ describe('PriceImpact V3', () => {
                     addLiquidityInput,
                     boostedPool_USDC_USDT,
                 );
-            const priceImpactSpot = PriceImpactAmount.fromDecimal('0.0004755');
-            expect(priceImpactABA.decimal).eq(priceImpactSpot.decimal);
+            expect(priceImpactABA.decimal).greaterThan(0);
         });
     });
 
-    describe.skip('Partial Boosted Pool Boosted Pool AddLiquidity', () => {
+    describe('Partial Boosted Pool Boosted Pool AddLiquidity', () => {
         test('Close to proportional', async () => {
             const addLiquidityInput: AddLiquidityBoostedUnbalancedInput = {
                 chainId,
@@ -143,10 +136,7 @@ describe('PriceImpact V3', () => {
                     addLiquidityInput,
                     partialBoostedPool_USDT_stataDAI,
                 );
-            const priceImpactSpot = PriceImpactAmount.fromDecimal(
-                '0.029220310653853106',
-            );
-            expect(priceImpactABA.decimal).eq(priceImpactSpot.decimal);
+            expect(priceImpactABA.decimal).greaterThan(0);
         });
 
         test('Unbalanced', async () => {
@@ -173,15 +163,11 @@ describe('PriceImpact V3', () => {
                     addLiquidityInput,
                     partialBoostedPool_USDT_stataDAI,
                 );
-            const priceImpactSpot = PriceImpactAmount.fromDecimal(
-                '0.006768518949421069',
-            );
-            expect(priceImpactABA.decimal).eq(priceImpactSpot.decimal);
+            expect(priceImpactABA.decimal).greaterThan(0);
         });
     });
 
-    // FIXME: zeroOutDeltas is swapping a huge amount (~200 WETH) and hitting MaxInRatio
-    describe.skip('Nested pool', () => {
+    describe('Nested pool', () => {
         test('Close to proportional', async () => {
             const addLiquidityInput: AddLiquidityNestedInput = {
                 amountsIn: [
@@ -203,9 +189,7 @@ describe('PriceImpact V3', () => {
                 addLiquidityInput,
                 nestedWithBoostedPool,
             );
-            const priceImpactSpot =
-                PriceImpactAmount.fromDecimal('0.00206614703619');
-            expect(priceImpactABA.decimal).eq(priceImpactSpot.decimal);
+            expect(priceImpactABA.decimal).greaterThan(0);
         });
     });
 });

--- a/test/v3/priceImpact/priceImpact.V3.integration.test.ts
+++ b/test/v3/priceImpact/priceImpact.V3.integration.test.ts
@@ -10,6 +10,7 @@ import {
     AddLiquidityNestedInput,
     ChainId,
     PriceImpact,
+    PriceImpactAmount,
 } from 'src';
 
 import { ANVIL_NETWORKS, startFork } from 'test/anvil/anvil-global-setup';
@@ -58,7 +59,8 @@ describe('PriceImpact V3', () => {
                     addLiquidityInput,
                     boostedPool_USDC_USDT,
                 );
-            expect(priceImpactABA.decimal).greaterThan(0);
+            const priceImpactSpot = PriceImpactAmount.fromDecimal('0.000042');
+            expect(priceImpactABA.decimal).eq(priceImpactSpot.decimal);
         });
 
         test('Unbalanced', async () => {
@@ -85,7 +87,9 @@ describe('PriceImpact V3', () => {
                     addLiquidityInput,
                     boostedPool_USDC_USDT,
                 );
-            expect(priceImpactABA.decimal).greaterThan(0);
+            const priceImpactSpot =
+                PriceImpactAmount.fromDecimal('0.0005511004');
+            expect(priceImpactABA.decimal).eq(priceImpactSpot.decimal);
         });
 
         test('Single token input', async () => {
@@ -107,7 +111,8 @@ describe('PriceImpact V3', () => {
                     addLiquidityInput,
                     boostedPool_USDC_USDT,
                 );
-            expect(priceImpactABA.decimal).greaterThan(0);
+            const priceImpactSpot = PriceImpactAmount.fromDecimal('0.000492');
+            expect(priceImpactABA.decimal).eq(priceImpactSpot.decimal);
         });
     });
 
@@ -136,7 +141,8 @@ describe('PriceImpact V3', () => {
                     addLiquidityInput,
                     partialBoostedPool_USDT_stataDAI,
                 );
-            expect(priceImpactABA.decimal).greaterThan(0);
+            const priceImpactSpot = PriceImpactAmount.fromDecimal('0.0000045');
+            expect(priceImpactABA.decimal).eq(priceImpactSpot.decimal);
         });
 
         test('Unbalanced', async () => {
@@ -163,7 +169,9 @@ describe('PriceImpact V3', () => {
                     addLiquidityInput,
                     partialBoostedPool_USDT_stataDAI,
                 );
-            expect(priceImpactABA.decimal).greaterThan(0);
+            const priceImpactSpot =
+                PriceImpactAmount.fromDecimal('0.000396375');
+            expect(priceImpactABA.decimal).eq(priceImpactSpot.decimal);
         });
     });
 
@@ -189,7 +197,10 @@ describe('PriceImpact V3', () => {
                 addLiquidityInput,
                 nestedWithBoostedPool,
             );
-            expect(priceImpactABA.decimal).greaterThan(0);
+            const priceImpactSpot = PriceImpactAmount.fromDecimal(
+                '0.005213821423105922',
+            );
+            expect(priceImpactABA.decimal).eq(priceImpactSpot.decimal);
         });
     });
 });


### PR DESCRIPTION
Close #525 

Main:
- Move try/catch handler to inner Price Impact function so it covers other places where it's used

Other:
- Bump sepolia global blockNumber
- Remove hardcoded amounts from Price Impact integration tests (we'll need to find a better approach)