### PR TITLE
Add extra integration tests for gyro pools

### DIFF
--- a/.changeset/wild-paws-whisper.md
+++ b/.changeset/wild-paws-whisper.md
@@ -1,0 +1,5 @@
+---
+"@balancer/sdk": patch
+---
+
+Add extra integration tests for gyro pools

--- a/test/lib/utils/addLiquidityHelper.ts
+++ b/test/lib/utils/addLiquidityHelper.ts
@@ -414,7 +414,7 @@ export function assertAddLiquidityProportional(
                     Number(
                         a.amount - addLiquidityInput.referenceAmount.rawAmount,
                     ),
-                ).closeTo(0, 1);
+                ).closeTo(0, 1000); // 1000 wei tolerance
         });
     }
 

--- a/test/lib/utils/addLiquidityHelper.ts
+++ b/test/lib/utils/addLiquidityHelper.ts
@@ -20,13 +20,14 @@ import {
     AddLiquidityKind,
     ChainId,
     isSameAddress,
+    PublicWalletClient,
 } from 'src';
 import { getTokensForBalanceCheck } from './getTokensForBalanceCheck';
 import { TxOutput, sendTransactionGetBalances } from './helper';
 import { AddLiquidityTxInput } from './types';
 import { AddLiquidityV2BaseBuildCallInput } from '@/entities/addLiquidity/addLiquidityV2/types';
 import { AddLiquidityV2ComposableStableQueryOutput } from '@/entities/addLiquidity/addLiquidityV2/composableStable/types';
-import { Client, Hex, PublicActions, WalletActions } from 'viem';
+import { Hex, TestActions } from 'viem';
 
 type AddLiquidityOutput = {
     addLiquidityQueryOutput: AddLiquidityQueryOutput;
@@ -52,7 +53,7 @@ async function sdkAddLiquidity({
     testAddress: Address;
     wethIsEth?: boolean;
     fromInternalBalance?: boolean;
-    client: Client & PublicActions & WalletActions;
+    client: PublicWalletClient & TestActions;
     usePermit2Signatures?: boolean;
 }): Promise<{
     addLiquidityBuildCallOutput: AddLiquidityBuildCallOutput;

--- a/test/v2/addLiquidity/gyro2.integration.test.ts
+++ b/test/v2/addLiquidity/gyro2.integration.test.ts
@@ -28,15 +28,15 @@ import {
     AddLiquidityUnbalancedInput,
     AddLiquiditySingleTokenInput,
     PoolType,
+    addLiquidityProportionalOnlyError,
 } from '../../../src';
-import { forkSetup } from '../../lib/utils/helper';
 import {
+    AddLiquidityTxInput,
     assertAddLiquidityProportional,
     doAddLiquidity,
-} from '../../lib/utils/addLiquidityHelper';
-import { AddLiquidityTxInput } from '../../lib/utils/types';
+    forkSetup,
+} from '../../lib/utils';
 import { ANVIL_NETWORKS, startFork } from '../../anvil/anvil-global-setup';
-import { InputValidatorGyro } from '../../../src/entities/inputValidator/gyro/inputValidatorGyro';
 
 const { rpcUrl } = await startFork(ANVIL_NETWORKS.POLYGON);
 const chainId = ChainId.POLYGON;
@@ -92,7 +92,7 @@ describe('Gyro2 add liquidity test', () => {
 
     describe('proportional', () => {
         let addLiquidityInput: AddLiquidityProportionalInput;
-        beforeAll(() => {
+        test('with bpt', async () => {
             const referenceAmount: InputAmount = {
                 rawAmount: parseEther('1'),
                 decimals: 18,
@@ -104,8 +104,7 @@ describe('Gyro2 add liquidity test', () => {
                 rpcUrl,
                 kind: AddLiquidityKind.Proportional,
             };
-        });
-        test('with tokens', async () => {
+
             const addLiquidityOutput = await doAddLiquidity({
                 ...txInput,
                 addLiquidityInput,
@@ -119,7 +118,33 @@ describe('Gyro2 add liquidity test', () => {
                 chainId,
             );
         });
-        //Removed test with native, because there are no GyroE V1 pool with wrapped native asset in any network
+
+        test('with reference amount (non-bpt)', async () => {
+            const referenceAmount: InputAmount = {
+                rawAmount: 1000000n,
+                decimals: poolState.tokens[0].decimals,
+                address: poolState.tokens[0].address,
+            };
+            addLiquidityInput = {
+                referenceAmount,
+                chainId,
+                rpcUrl,
+                kind: AddLiquidityKind.Proportional,
+            };
+
+            const addLiquidityOutput = await doAddLiquidity({
+                ...txInput,
+                addLiquidityInput,
+            });
+
+            assertAddLiquidityProportional(
+                txInput.poolState,
+                addLiquidityInput,
+                addLiquidityOutput,
+                txInput.slippage,
+                chainId,
+            );
+        });
     });
 
     describe('unbalanced', () => {
@@ -148,7 +173,10 @@ describe('Gyro2 add liquidity test', () => {
                     addLiquidityInput,
                 }),
             ).rejects.toThrowError(
-                InputValidatorGyro.addLiquidityKindNotSupportedByGyro,
+                addLiquidityProportionalOnlyError(
+                    addLiquidityInput.kind,
+                    poolState.type,
+                ),
             );
         });
     });
@@ -178,7 +206,10 @@ describe('Gyro2 add liquidity test', () => {
                     addLiquidityInput,
                 }),
             ).rejects.toThrowError(
-                InputValidatorGyro.addLiquidityKindNotSupportedByGyro,
+                addLiquidityProportionalOnlyError(
+                    addLiquidityInput.kind,
+                    poolState.type,
+                ),
             );
         });
     });

--- a/test/v2/addLiquidity/gyroE.integration.test.ts
+++ b/test/v2/addLiquidity/gyroE.integration.test.ts
@@ -28,22 +28,22 @@ import {
     AddLiquidityUnbalancedInput,
     AddLiquiditySingleTokenInput,
     PoolType,
+    addLiquidityProportionalOnlyError,
 } from '../../../src';
-import { forkSetup } from '../../lib/utils/helper';
 import {
+    AddLiquidityTxInput,
     assertAddLiquidityProportional,
     doAddLiquidity,
-} from '../../lib/utils/addLiquidityHelper';
-import { AddLiquidityTxInput } from '../../lib/utils/types';
+    forkSetup,
+} from '../../lib/utils';
 import { ANVIL_NETWORKS, startFork } from '../../anvil/anvil-global-setup';
-import { InputValidatorGyro } from '../../../src/entities/inputValidator/gyro/inputValidatorGyro';
 
 const { rpcUrl } = await startFork(ANVIL_NETWORKS.POLYGON);
 const chainId = ChainId.POLYGON;
 const poolId =
     '0xa489c057de6c3177380ea264ebdf686b7f564f510002000000000000000008e2'; // ECLP-wstETH-wETH
 
-describe('gyroE V2 add liquidity test', () => {
+describe('GyroE add liquidity test', () => {
     let txInput: AddLiquidityTxInput;
     let poolState: PoolState;
 
@@ -92,7 +92,7 @@ describe('gyroE V2 add liquidity test', () => {
 
     describe('proportional', () => {
         let addLiquidityInput: AddLiquidityProportionalInput;
-        beforeAll(() => {
+        test('with bpt', async () => {
             const referenceAmount: InputAmount = {
                 rawAmount: parseEther('1'),
                 decimals: 18,
@@ -104,8 +104,32 @@ describe('gyroE V2 add liquidity test', () => {
                 rpcUrl,
                 kind: AddLiquidityKind.Proportional,
             };
+            const addLiquidityOutput = await doAddLiquidity({
+                ...txInput,
+                addLiquidityInput,
+            });
+
+            assertAddLiquidityProportional(
+                txInput.poolState,
+                addLiquidityInput,
+                addLiquidityOutput,
+                txInput.slippage,
+                chainId,
+            );
         });
-        test('with tokens', async () => {
+
+        test('with reference amount (non-bpt)', async () => {
+            const referenceAmount: InputAmount = {
+                rawAmount: parseUnits('1', poolState.tokens[0].decimals),
+                decimals: poolState.tokens[0].decimals,
+                address: poolState.tokens[0].address,
+            };
+            addLiquidityInput = {
+                referenceAmount,
+                chainId,
+                rpcUrl,
+                kind: AddLiquidityKind.Proportional,
+            };
             const addLiquidityOutput = await doAddLiquidity({
                 ...txInput,
                 addLiquidityInput,
@@ -147,7 +171,10 @@ describe('gyroE V2 add liquidity test', () => {
                     addLiquidityInput,
                 }),
             ).rejects.toThrowError(
-                InputValidatorGyro.addLiquidityKindNotSupportedByGyro,
+                addLiquidityProportionalOnlyError(
+                    addLiquidityInput.kind,
+                    poolState.type,
+                ),
             );
         });
         //Removed test with native, because there are no GyroE V1 pool with wrapped native asset in any network
@@ -178,7 +205,10 @@ describe('gyroE V2 add liquidity test', () => {
                     addLiquidityInput,
                 }),
             ).rejects.toThrowError(
-                InputValidatorGyro.addLiquidityKindNotSupportedByGyro,
+                addLiquidityProportionalOnlyError(
+                    addLiquidityInput.kind,
+                    poolState.type,
+                ),
             );
         });
     });

--- a/test/v2/addLiquidity/gyroEV2.integration.test.ts
+++ b/test/v2/addLiquidity/gyroEV2.integration.test.ts
@@ -90,7 +90,7 @@ describe('GyroE V2 add liquidity test', () => {
         );
     });
 
-    describe.only('proportional', () => {
+    describe('proportional', () => {
         let addLiquidityInput: AddLiquidityProportionalInput;
         describe('with bpt', () => {
             beforeAll(() => {

--- a/test/v2/removeLiquidity/gyro2.integration.test.ts
+++ b/test/v2/removeLiquidity/gyro2.integration.test.ts
@@ -27,16 +27,16 @@ import {
     InputAmount,
     PoolType,
     RemoveLiquiditySingleTokenExactOutInput,
+    removeLiquidityProportionalOnlyError,
 } from '../../../src';
-import { forkSetup } from '../../lib/utils/helper';
 import {
     assertRemoveLiquidityProportional,
     doRemoveLiquidity,
-} from '../../lib/utils/removeLiquidityHelper';
-import { RemoveLiquidityTxInput } from '../../lib/utils/types';
+    forkSetup,
+    RemoveLiquidityTxInput,
+    TOKENS,
+} from '../../lib/utils';
 import { ANVIL_NETWORKS, startFork } from '../../anvil/anvil-global-setup';
-import { InputValidatorGyro } from '../../../src/entities/inputValidator/gyro/inputValidatorGyro';
-import { TOKENS } from 'test/lib/utils/addresses';
 
 const chainId = ChainId.POLYGON;
 const { rpcUrl } = await startFork(ANVIL_NETWORKS.POLYGON);
@@ -47,13 +47,13 @@ const USDC = TOKENS[chainId].USDC;
 
 describe('Gyro2 remove liquidity test', () => {
     let txInput: RemoveLiquidityTxInput;
-    let poolInput: PoolState;
+    let poolState: PoolState;
     beforeAll(async () => {
         // setup mock api
         const api = new MockApi();
 
         // get pool state from api
-        poolInput = await api.getPool(poolId);
+        poolState = await api.getPool(poolId);
 
         const client = createTestClient({
             mode: 'anvil',
@@ -67,7 +67,7 @@ describe('Gyro2 remove liquidity test', () => {
             client,
             removeLiquidity: new RemoveLiquidity(),
             slippage: Slippage.fromPercentage('1'), // 1%
-            poolState: poolInput,
+            poolState,
             testAddress: '0xe84f75fc9caa49876d0ba18d309da4231d44e94d', // MATIC Holder Wallet, must hold amount of matic to approve tokens
             removeLiquidityInput: {} as RemoveLiquidityInput,
         };
@@ -89,7 +89,7 @@ describe('Gyro2 remove liquidity test', () => {
             const bptIn: InputAmount = {
                 rawAmount: parseEther('0.01'),
                 decimals: 18,
-                address: poolInput.address,
+                address: poolState.address,
             };
             input = {
                 bptIn,
@@ -119,7 +119,7 @@ describe('Gyro2 remove liquidity test', () => {
         let input: Omit<RemoveLiquidityUnbalancedInput, 'amountsOut'>;
         let amountsOut: InputAmount[];
         beforeAll(() => {
-            amountsOut = poolInput.tokens.map((t) => ({
+            amountsOut = poolState.tokens.map((t) => ({
                 rawAmount: parseUnits('0.001', t.decimals),
                 decimals: t.decimals,
                 address: t.address,
@@ -138,7 +138,10 @@ describe('Gyro2 remove liquidity test', () => {
             await expect(() =>
                 doRemoveLiquidity({ ...txInput, removeLiquidityInput }),
             ).rejects.toThrowError(
-                InputValidatorGyro.removeLiquidityKindNotSupportedByGyro,
+                removeLiquidityProportionalOnlyError(
+                    removeLiquidityInput.kind,
+                    poolState.type,
+                ),
             );
         });
     });
@@ -166,21 +169,24 @@ describe('Gyro2 remove liquidity test', () => {
             await expect(() =>
                 doRemoveLiquidity({ ...txInput, removeLiquidityInput }),
             ).rejects.toThrowError(
-                InputValidatorGyro.removeLiquidityKindNotSupportedByGyro,
+                removeLiquidityProportionalOnlyError(
+                    removeLiquidityInput.kind,
+                    poolState.type,
+                ),
             );
         });
     });
 
     describe('single token exact in', () => {
-        let input: RemoveLiquiditySingleTokenExactInInput;
+        let removeLiquidityInput: RemoveLiquiditySingleTokenExactInInput;
         beforeAll(() => {
             const bptIn: InputAmount = {
                 rawAmount: parseEther('1'),
                 decimals: 18,
-                address: poolInput.address,
+                address: poolState.address,
             };
             const tokenOut = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'; // WETH
-            input = {
+            removeLiquidityInput = {
                 chainId,
                 rpcUrl,
                 bptIn,
@@ -190,9 +196,12 @@ describe('Gyro2 remove liquidity test', () => {
         });
         test('must throw remove liquidity kind not supported error', async () => {
             await expect(() =>
-                doRemoveLiquidity({ ...txInput, removeLiquidityInput: input }),
+                doRemoveLiquidity({ ...txInput, removeLiquidityInput }),
             ).rejects.toThrowError(
-                InputValidatorGyro.removeLiquidityKindNotSupportedByGyro,
+                removeLiquidityProportionalOnlyError(
+                    removeLiquidityInput.kind,
+                    poolState.type,
+                ),
             );
         });
     });

--- a/test/v2/removeLiquidity/gyro3.integration.test.ts
+++ b/test/v2/removeLiquidity/gyro3.integration.test.ts
@@ -27,16 +27,16 @@ import {
     InputAmount,
     PoolType,
     RemoveLiquiditySingleTokenExactOutInput,
+    removeLiquidityProportionalOnlyError,
 } from '../../../src';
-import { forkSetup } from '../../lib/utils/helper';
 import {
     assertRemoveLiquidityProportional,
     doRemoveLiquidity,
-} from '../../lib/utils/removeLiquidityHelper';
-import { RemoveLiquidityTxInput } from '../../lib/utils/types';
+    forkSetup,
+    RemoveLiquidityTxInput,
+    TOKENS,
+} from '../../lib/utils';
 import { ANVIL_NETWORKS, startFork } from '../../anvil/anvil-global-setup';
-import { InputValidatorGyro } from '../../../src/entities/inputValidator/gyro/inputValidatorGyro';
-import { TOKENS } from 'test/lib/utils/addresses';
 
 const chainId = ChainId.POLYGON;
 const { rpcUrl } = await startFork(ANVIL_NETWORKS.POLYGON);
@@ -47,13 +47,13 @@ const USDC = TOKENS[chainId].USDC;
 
 describe('Gyro3 remove liquidity test', () => {
     let txInput: RemoveLiquidityTxInput;
-    let poolInput: PoolState;
+    let poolState: PoolState;
     beforeAll(async () => {
         // setup mock api
         const api = new MockApi();
 
         // get pool state from api
-        poolInput = await api.getPool(poolId);
+        poolState = await api.getPool(poolId);
 
         const client = createTestClient({
             mode: 'anvil',
@@ -67,7 +67,7 @@ describe('Gyro3 remove liquidity test', () => {
             client,
             removeLiquidity: new RemoveLiquidity(),
             slippage: Slippage.fromPercentage('1'), // 1%
-            poolState: poolInput,
+            poolState: poolState,
             testAddress: '0xe84f75fc9caa49876d0ba18d309da4231d44e94d', // MATIC Holder Wallet, must hold amount of matic to approve tokens
             removeLiquidityInput: {} as RemoveLiquidityInput,
         };
@@ -89,7 +89,7 @@ describe('Gyro3 remove liquidity test', () => {
             const bptIn: InputAmount = {
                 rawAmount: parseEther('0.01'),
                 decimals: 18,
-                address: poolInput.address,
+                address: poolState.address,
             };
             input = {
                 bptIn,
@@ -119,7 +119,7 @@ describe('Gyro3 remove liquidity test', () => {
         let input: Omit<RemoveLiquidityUnbalancedInput, 'amountsOut'>;
         let amountsOut: InputAmount[];
         beforeAll(() => {
-            amountsOut = poolInput.tokens.map((t) => ({
+            amountsOut = poolState.tokens.map((t) => ({
                 rawAmount: parseUnits('0.001', t.decimals),
                 decimals: t.decimals,
                 address: t.address,
@@ -138,7 +138,10 @@ describe('Gyro3 remove liquidity test', () => {
             await expect(() =>
                 doRemoveLiquidity({ ...txInput, removeLiquidityInput }),
             ).rejects.toThrowError(
-                InputValidatorGyro.removeLiquidityKindNotSupportedByGyro,
+                removeLiquidityProportionalOnlyError(
+                    removeLiquidityInput.kind,
+                    poolState.type,
+                ),
             );
         });
     });
@@ -166,7 +169,10 @@ describe('Gyro3 remove liquidity test', () => {
             await expect(() =>
                 doRemoveLiquidity({ ...txInput, removeLiquidityInput }),
             ).rejects.toThrowError(
-                InputValidatorGyro.removeLiquidityKindNotSupportedByGyro,
+                removeLiquidityProportionalOnlyError(
+                    removeLiquidityInput.kind,
+                    poolState.type,
+                ),
             );
         });
     });
@@ -177,7 +183,7 @@ describe('Gyro3 remove liquidity test', () => {
             const bptIn: InputAmount = {
                 rawAmount: parseEther('1'),
                 decimals: 18,
-                address: poolInput.address,
+                address: poolState.address,
             };
             const tokenOut = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'; // WETH
             input = {
@@ -192,7 +198,10 @@ describe('Gyro3 remove liquidity test', () => {
             await expect(() =>
                 doRemoveLiquidity({ ...txInput, removeLiquidityInput: input }),
             ).rejects.toThrowError(
-                InputValidatorGyro.removeLiquidityKindNotSupportedByGyro,
+                removeLiquidityProportionalOnlyError(
+                    input.kind,
+                    poolState.type,
+                ),
             );
         });
     });

--- a/test/v2/removeLiquidity/gyroE.integration.test.ts
+++ b/test/v2/removeLiquidity/gyroE.integration.test.ts
@@ -27,16 +27,16 @@ import {
     InputAmount,
     PoolType,
     RemoveLiquiditySingleTokenExactOutInput,
+    removeLiquidityProportionalOnlyError,
 } from '../../../src';
-import { forkSetup } from '../../lib/utils/helper';
 import {
     assertRemoveLiquidityProportional,
     doRemoveLiquidity,
-} from '../../lib/utils/removeLiquidityHelper';
-import { RemoveLiquidityTxInput } from '../../lib/utils/types';
+    forkSetup,
+    RemoveLiquidityTxInput,
+    TOKENS,
+} from '../../lib/utils';
 import { ANVIL_NETWORKS, startFork } from '../../anvil/anvil-global-setup';
-import { InputValidatorGyro } from '../../../src/entities/inputValidator/gyro/inputValidatorGyro';
-import { TOKENS } from 'test/lib/utils/addresses';
 
 const chainId = ChainId.POLYGON;
 const { rpcUrl } = await startFork(ANVIL_NETWORKS.POLYGON);
@@ -47,13 +47,13 @@ const USDC = TOKENS[chainId].USDC;
 
 describe('GyroE V1 remove liquidity test', () => {
     let txInput: RemoveLiquidityTxInput;
-    let poolInput: PoolState;
+    let poolState: PoolState;
     beforeAll(async () => {
         // setup mock api
         const api = new MockApi();
 
         // get pool state from api
-        poolInput = await api.getPool(poolId);
+        poolState = await api.getPool(poolId);
 
         const client = createTestClient({
             mode: 'anvil',
@@ -67,7 +67,7 @@ describe('GyroE V1 remove liquidity test', () => {
             client,
             removeLiquidity: new RemoveLiquidity(),
             slippage: Slippage.fromPercentage('1'), // 1%
-            poolState: poolInput,
+            poolState: poolState,
             testAddress: '0xe84f75fc9caa49876d0ba18d309da4231d44e94d', // MATIC Holder Wallet, must hold amount of matic to approve tokens
             removeLiquidityInput: {} as RemoveLiquidityInput,
         };
@@ -89,7 +89,7 @@ describe('GyroE V1 remove liquidity test', () => {
             const bptIn: InputAmount = {
                 rawAmount: parseEther('1'),
                 decimals: 18,
-                address: poolInput.address,
+                address: poolState.address,
             };
             input = {
                 bptIn,
@@ -119,7 +119,7 @@ describe('GyroE V1 remove liquidity test', () => {
         let input: Omit<RemoveLiquidityUnbalancedInput, 'amountsOut'>;
         let amountsOut: InputAmount[];
         beforeAll(() => {
-            amountsOut = poolInput.tokens.map((t) => ({
+            amountsOut = poolState.tokens.map((t) => ({
                 rawAmount: parseUnits('1', t.decimals),
                 decimals: t.decimals,
                 address: t.address,
@@ -138,7 +138,10 @@ describe('GyroE V1 remove liquidity test', () => {
             await expect(() =>
                 doRemoveLiquidity({ ...txInput, removeLiquidityInput }),
             ).rejects.toThrowError(
-                InputValidatorGyro.removeLiquidityKindNotSupportedByGyro,
+                removeLiquidityProportionalOnlyError(
+                    removeLiquidityInput.kind,
+                    poolState.type,
+                ),
             );
         });
     });
@@ -166,7 +169,10 @@ describe('GyroE V1 remove liquidity test', () => {
             await expect(() =>
                 doRemoveLiquidity({ ...txInput, removeLiquidityInput }),
             ).rejects.toThrowError(
-                InputValidatorGyro.removeLiquidityKindNotSupportedByGyro,
+                removeLiquidityProportionalOnlyError(
+                    removeLiquidityInput.kind,
+                    poolState.type,
+                ),
             );
         });
     });
@@ -177,7 +183,7 @@ describe('GyroE V1 remove liquidity test', () => {
             const bptIn: InputAmount = {
                 rawAmount: parseEther('1'),
                 decimals: 18,
-                address: poolInput.address,
+                address: poolState.address,
             };
             const tokenOut = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'; // WETH
             input = {
@@ -192,7 +198,10 @@ describe('GyroE V1 remove liquidity test', () => {
             await expect(() =>
                 doRemoveLiquidity({ ...txInput, removeLiquidityInput: input }),
             ).rejects.toThrowError(
-                InputValidatorGyro.removeLiquidityKindNotSupportedByGyro,
+                removeLiquidityProportionalOnlyError(
+                    input.kind,
+                    poolState.type,
+                ),
             );
         });
     });

--- a/test/v2/removeLiquidity/gyroEV2.integration.test.ts
+++ b/test/v2/removeLiquidity/gyroEV2.integration.test.ts
@@ -27,16 +27,16 @@ import {
     InputAmount,
     PoolType,
     RemoveLiquiditySingleTokenExactOutInput,
+    removeLiquidityProportionalOnlyError,
 } from '../../../src';
-import { forkSetup } from '../../lib/utils/helper';
 import {
     assertRemoveLiquidityProportional,
     doRemoveLiquidity,
-} from '../../lib/utils/removeLiquidityHelper';
-import { RemoveLiquidityTxInput } from '../../lib/utils/types';
+    forkSetup,
+    RemoveLiquidityTxInput,
+    TOKENS,
+} from '../../lib/utils';
 import { ANVIL_NETWORKS, startFork } from '../../anvil/anvil-global-setup';
-import { InputValidatorGyro } from '../../../src/entities/inputValidator/gyro/inputValidatorGyro';
-import { TOKENS } from 'test/lib/utils/addresses';
 
 const chainId = ChainId.MAINNET;
 const { rpcUrl } = await startFork(ANVIL_NETWORKS.MAINNET);
@@ -47,13 +47,13 @@ const wETH = TOKENS[chainId].WETH;
 
 describe('GyroE V2 remove liquidity test', () => {
     let txInput: RemoveLiquidityTxInput;
-    let poolInput: PoolState;
+    let poolState: PoolState;
     beforeAll(async () => {
         // setup mock api
         const api = new MockApi();
 
         // get pool state from api
-        poolInput = await api.getPool(poolId);
+        poolState = await api.getPool(poolId);
 
         const client = createTestClient({
             mode: 'anvil',
@@ -67,7 +67,7 @@ describe('GyroE V2 remove liquidity test', () => {
             client,
             removeLiquidity: new RemoveLiquidity(),
             slippage: Slippage.fromPercentage('1'), // 1%
-            poolState: poolInput,
+            poolState: poolState,
             testAddress: '0x10a19e7ee7d7f8a52822f6817de8ea18204f2e4f', // Balancer DAO Multisig
             removeLiquidityInput: {} as RemoveLiquidityInput,
         };
@@ -89,7 +89,7 @@ describe('GyroE V2 remove liquidity test', () => {
             const bptIn: InputAmount = {
                 rawAmount: parseEther('0.01'),
                 decimals: 18,
-                address: poolInput.address,
+                address: poolState.address,
             };
             input = {
                 bptIn,
@@ -138,7 +138,7 @@ describe('GyroE V2 remove liquidity test', () => {
         let input: Omit<RemoveLiquidityUnbalancedInput, 'amountsOut'>;
         let amountsOut: InputAmount[];
         beforeAll(() => {
-            amountsOut = poolInput.tokens.map((t) => ({
+            amountsOut = poolState.tokens.map((t) => ({
                 rawAmount: parseUnits('0.001', t.decimals),
                 decimals: t.decimals,
                 address: t.address,
@@ -157,7 +157,10 @@ describe('GyroE V2 remove liquidity test', () => {
             await expect(() =>
                 doRemoveLiquidity({ ...txInput, removeLiquidityInput }),
             ).rejects.toThrowError(
-                InputValidatorGyro.removeLiquidityKindNotSupportedByGyro,
+                removeLiquidityProportionalOnlyError(
+                    removeLiquidityInput.kind,
+                    poolState.type,
+                ),
             );
         });
     });
@@ -185,7 +188,10 @@ describe('GyroE V2 remove liquidity test', () => {
             await expect(() =>
                 doRemoveLiquidity({ ...txInput, removeLiquidityInput }),
             ).rejects.toThrowError(
-                InputValidatorGyro.removeLiquidityKindNotSupportedByGyro,
+                removeLiquidityProportionalOnlyError(
+                    removeLiquidityInput.kind,
+                    poolState.type,
+                ),
             );
         });
     });
@@ -196,7 +202,7 @@ describe('GyroE V2 remove liquidity test', () => {
             const bptIn: InputAmount = {
                 rawAmount: parseEther('1'),
                 decimals: 18,
-                address: poolInput.address,
+                address: poolState.address,
             };
             const tokenOut = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'; // WETH
             input = {
@@ -211,7 +217,10 @@ describe('GyroE V2 remove liquidity test', () => {
             await expect(() =>
                 doRemoveLiquidity({ ...txInput, removeLiquidityInput: input }),
             ).rejects.toThrowError(
-                InputValidatorGyro.removeLiquidityKindNotSupportedByGyro,
+                removeLiquidityProportionalOnlyError(
+                    input.kind,
+                    poolState.type,
+                ),
             );
         });
     });


### PR DESCRIPTION
Main changes:
- Add extra integration tests for add liquidity proportional with referenceAmount (non-bpt) for gyro pools.


Other than that, I took the opportunity to fix some lint warnings we had on missing custom errors that were hanging around for a while and for some reason weren't being properly flagged by the linter.
