### PR TITLE
fix: override multicall3 for sonic in viem chain definition

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -17,8 +17,23 @@ import {
     sepolia,
     mode,
     fraxtal,
-    sonic
+    sonic as sonicOriginal,
 } from 'viem/chains';
+
+const sonicContractsWithMulticall3 = {
+    // TODO: there are other missing contract properties in sonic definition in the current viem/wagmi version
+    // They could cause other issues ()
+    ...sonicOriginal.contracts,
+    multicall3: {
+        address: '0xcA11bde05977b3631167028862bE2a173976CA11',
+        blockCreated: 598328,
+    },
+};
+
+export const sonic: Chain = {
+    ...sonicOriginal,
+    contracts: sonicContractsWithMulticall3,
+} as Chain;
 
 export const ZERO_ADDRESS: Address =
     '0x0000000000000000000000000000000000000000';


### PR DESCRIPTION
Simulations are failing in sonic cause multicall3 address is not yet defined in viem.
This is a temporary workaround until the viem/wagmi team releases a version fixing it.