### PR TITLE
Add permit2 for init pool

### DIFF
--- a/.changeset/two-ants-act.md
+++ b/.changeset/two-ants-act.md
@@ -1,0 +1,5 @@
+---
+"@balancer/sdk": minor
+---
+
+permit2 helpers for pool init

--- a/examples/createAndInitPool/createAndInitPoolV3.ts
+++ b/examples/createAndInitPool/createAndInitPoolV3.ts
@@ -158,9 +158,7 @@ export async function runAgainstNetwork() {
         chain: CHAINS[chainId],
         transport: http(rpcUrl),
         account: privateKeyToAccount(process.env.PRIVATE_KEY as `0x${string}`),
-    })
-        .extend(walletActions)
-        .extend(publicActions);
+    }).extend(publicActions);
 
     const { account } = client;
 

--- a/examples/createAndInitPool/createAndInitPoolV3.ts
+++ b/examples/createAndInitPool/createAndInitPoolV3.ts
@@ -21,6 +21,7 @@ import {
     getContract,
     Address,
     parseEther,
+    Account,
 } from 'viem';
 import { privateKeyToAccount } from 'viem/accounts';
 import {
@@ -180,7 +181,7 @@ export async function runAgainstNetwork() {
     const initPoolCall = await buildInitPoolCall({
         client,
         rpcUrl,
-        account: account.address,
+        account: account,
         poolAddress,
     });
 
@@ -235,7 +236,7 @@ async function buildInitPoolCall({
 }: {
     client: PublicWalletClient;
     rpcUrl: string;
-    account: Address;
+    account: Address | Account;
     poolAddress: Address;
 }) {
     // Fetch the necessary pool state

--- a/src/entities/initPool/index.ts
+++ b/src/entities/initPool/index.ts
@@ -9,7 +9,7 @@ import {
 } from './types';
 import { InitPoolV2 } from './initPoolV2';
 import { InitPoolV3 } from './initPoolV3';
-
+import { Permit2 } from '@/entities/permit2Helper';
 export * from './types';
 
 export class InitPool {
@@ -35,5 +35,16 @@ export class InitPool {
                     `SDK does not support init for vault version: ${poolState.protocolVersion}`,
                 );
         }
+    }
+
+    buildCallWithPermit2(
+        input: InitPoolInputV3,
+        poolState: PoolState,
+        permit2: Permit2,
+    ): InitPoolBuildOutput {
+        this.inputValidator.validateInitPool(input, poolState);
+
+        const initPool = new InitPoolV3();
+        return initPool.buildCallWithPermit2(input, poolState, permit2);
     }
 }

--- a/src/entities/permit2Helper/index.ts
+++ b/src/entities/permit2Helper/index.ts
@@ -358,7 +358,7 @@ const getNonce = async (
         functionName: 'allowance',
         args: [owner, token, spender],
     });
-    const nonce = result[1];
+    const nonce = result[2];
 
     return nonce;
 };

--- a/src/entities/permit2Helper/index.ts
+++ b/src/entities/permit2Helper/index.ts
@@ -76,7 +76,7 @@ export class Permit2Helper {
     static async signAddLiquidityApproval(
         input: AddLiquidityBaseBuildCallInput & {
             client: PublicWalletClient;
-            owner: Address;
+            owner: Address | Account;
             nonces?: number[];
             expirations?: number[];
         },
@@ -109,7 +109,7 @@ export class Permit2Helper {
         amountsIn: TokenAmount[];
         chainId: ChainId;
         client: PublicWalletClient;
-        owner: Address;
+        owner: Address | Account;
         nonces?: number[];
         expirations?: number[];
     }): Promise<Permit2> {
@@ -140,7 +140,7 @@ export class Permit2Helper {
     static async signAddLiquidityBoostedApproval(
         input: AddLiquidityBaseBuildCallInput & {
             client: PublicWalletClient;
-            owner: Address;
+            owner: Address | Account;
             nonces?: number[];
             expirations?: number[];
         },
@@ -173,7 +173,7 @@ export class Permit2Helper {
     static async signAddLiquidityBufferApproval(
         input: AddLiquidityBufferBuildCallInput & {
             client: PublicWalletClient;
-            owner: Address;
+            owner: Address | Account;
             nonces?: number[];
             expirations?: number[];
         },
@@ -206,7 +206,7 @@ export class Permit2Helper {
     static async signInitBufferApproval(
         input: InitBufferBuildCallInput & {
             client: PublicWalletClient;
-            owner: Address;
+            owner: Address | Account;
             nonces?: number[];
             expirations?: number[];
         },
@@ -239,7 +239,7 @@ export class Permit2Helper {
     static async signSwapApproval(
         input: SwapBuildCallInputBase & {
             client: PublicWalletClient;
-            owner: Address;
+            owner: Address | Account;
             nonce?: number;
             expiration?: number;
         },

--- a/src/entities/permit2Helper/index.ts
+++ b/src/entities/permit2Helper/index.ts
@@ -1,5 +1,5 @@
 import { Address, Hex, SwapKind } from '@/types';
-import { Client, PublicActions, WalletActions } from 'viem';
+import { Client, PublicActions, WalletActions, Account } from 'viem';
 import {
     AllowanceTransfer,
     Permit2Batch,
@@ -45,7 +45,7 @@ export class Permit2Helper {
     static async signInitPoolApproval(
         input: InitPoolInputV3 & {
             client: PublicWalletClient;
-            owner: Address;
+            owner: Address | Account;
             nonces?: number[];
             expirations?: number[];
         },
@@ -290,7 +290,7 @@ export class Permit2Helper {
 
 const signPermit2 = async (
     client: Client & WalletActions,
-    owner: Address,
+    owner: Address | Account,
     spender: Address,
     details: PermitDetails[],
     sigDeadline = MaxSigDeadline,
@@ -323,15 +323,16 @@ const signPermit2 = async (
 const getDetails = async (
     client: Client & PublicActions,
     token: Address,
-    owner: Address,
+    owner: Address | Account,
     spender: Address,
     amount = MaxAllowanceTransferAmount,
     expiration = Number(MaxAllowanceExpiration),
     nonce?: number,
 ) => {
+    const _owner = typeof owner === 'string' ? owner : owner.address;
     let _nonce: number;
     if (nonce === undefined) {
-        _nonce = await getNonce(client, token, owner, spender);
+        _nonce = await getNonce(client, token, _owner, spender);
     } else {
         _nonce = nonce;
     }

--- a/test/v3/createPool/stable/stable.integration.test.ts
+++ b/test/v3/createPool/stable/stable.integration.test.ts
@@ -123,7 +123,6 @@ describe('create stable pool test', () => {
             poolState.tokens.map((t) => parseUnits('100', t.decimals)),
         );
 
-        // Approve on token contracts for Permit2 contract to spend tokens
         await approveSpenderOnTokens(
             client,
             testAddress,

--- a/test/v3/createPool/stable/stable.integration.test.ts
+++ b/test/v3/createPool/stable/stable.integration.test.ts
@@ -18,7 +18,9 @@ import {
     TokenType,
     CreatePoolV3StableInput,
     InitPoolDataProvider,
-    Slippage,
+    Permit2Helper,
+    PERMIT2,
+    InitPool,
 } from 'src';
 import { ANVIL_NETWORKS, startFork } from '../../../anvil/anvil-global-setup';
 import { doCreatePool } from '../../../lib/utils/createPoolHelper';
@@ -26,8 +28,12 @@ import { TOKENS } from 'test/lib/utils/addresses';
 import { PublicWalletClient } from '@/utils';
 import { VAULT_V3 } from 'src/utils/constants';
 import { vaultExtensionAbi_V3 } from 'src/abi/';
-import { doInitPool, assertInitPool } from 'test/lib/utils/initPoolHelper';
-import { forkSetup } from 'test/lib/utils/helper';
+import { assertInitPool } from 'test/lib/utils/initPoolHelper';
+import {
+    setTokenBalances,
+    approveSpenderOnTokens,
+    sendTransactionGetBalances,
+} from 'test/lib/utils/helper';
 
 const { rpcUrl } = await startFork(ANVIL_NETWORKS.SEPOLIA);
 const protocolVersion = 3;
@@ -109,14 +115,20 @@ describe('create stable pool test', () => {
             protocolVersion,
         );
 
-        await forkSetup(
+        await setTokenBalances(
             client,
             testAddress,
             poolState.tokens.map((t) => t.address),
             [scDAI.slot!, scUSD.slot!],
             poolState.tokens.map((t) => parseUnits('100', t.decimals)),
-            undefined,
-            protocolVersion,
+        );
+
+        // Approve on token contracts for Permit2 contract to spend tokens
+        await approveSpenderOnTokens(
+            client,
+            testAddress,
+            poolState.tokens.map((t) => t.address),
+            PERMIT2[chainId],
         );
 
         const initPoolInput = {
@@ -136,14 +148,27 @@ describe('create stable pool test', () => {
             chainId,
         };
 
-        const addLiquidityOutput = await doInitPool({
+        const initPool = new InitPool();
+        const permit2 = await Permit2Helper.signInitPoolApproval({
+            ...initPoolInput,
             client,
-            testAddress,
+            owner: testAddress,
+        });
+        const initPoolBuildOutput = initPool.buildCallWithPermit2(
             initPoolInput,
             poolState,
-            slippage: Slippage.fromPercentage('0.01'),
-        });
+            permit2,
+        );
 
-        assertInitPool(initPoolInput, addLiquidityOutput);
+        const txOutput = await sendTransactionGetBalances(
+            [scDAI.address, scUSD.address],
+            client,
+            testAddress,
+            initPoolBuildOutput.to,
+            initPoolBuildOutput.callData,
+            initPoolBuildOutput.value,
+        );
+
+        assertInitPool(initPoolInput, { txOutput, initPoolBuildOutput });
     }, 120_000);
 });


### PR DESCRIPTION
Closes #476 

### Summary
- For testing, we could modify [doInitPool](https://github.com/balancer/b-sdk/blob/74d61ab3476134b2406bc14f33e81b8e83752798/test/lib/utils/initPoolHelper.ts#L23-L46)  to handle both v2 and v3, but I'm proposing we favor the more straightforward approach
- Refactored pool creation example to offer functions for both fork and live network
- Refactored `getDetails` of `Permit2Helper` to allow for type `Account` so that `client.signTypedData` can be run with a script