### PR TITLE
Fix getPoolStateWithBalancesV3 helper

### DIFF
--- a/.changeset/silver-eels-peel.md
+++ b/.changeset/silver-eels-peel.md
@@ -1,0 +1,5 @@
+---
+"@balancer/sdk": patch
+---
+
+Fix getPoolStateWithBalancesV3 helper

--- a/src/entities/utils/getPoolStateWithBalancesV3.ts
+++ b/src/entities/utils/getPoolStateWithBalancesV3.ts
@@ -163,7 +163,7 @@ const getTokenAmountsAndTotalShares = async (
     const getBalanceContracts = {
         address: VAULT_V3[chainId],
         abi: vaultExtensionAbi_V3,
-        functionName: 'getCurrentLiveBalances' as const,
+        functionName: 'getPoolTokenInfo' as const,
         args: [poolState.address] as const,
     };
 
@@ -181,10 +181,19 @@ const getTokenAmountsAndTotalShares = async (
 
     // extract total supply and balances from multicall outputs
     const totalShares = outputs[0].result as bigint;
-    const balancesScale18 = outputs[1].result as bigint[];
+    const [_, __, balancesRaw] = outputs[1].result as readonly [
+        readonly `0x${string}`[],
+        readonly {
+            tokenType: number;
+            rateProvider: `0x${string}`;
+            paysYieldFees: boolean;
+        }[],
+        readonly bigint[],
+        readonly bigint[],
+    ];
     const poolTokens = getSortedTokens(poolState.tokens, chainId);
     const tokenAmounts = poolTokens.map((token, i) =>
-        TokenAmount.fromScale18Amount(token, balancesScale18[i]),
+        TokenAmount.fromRawAmount(token, balancesRaw[i]),
     );
 
     return { tokenAmounts, totalShares };

--- a/test/anvil/anvil-global-setup.ts
+++ b/test/anvil/anvil-global-setup.ts
@@ -102,7 +102,7 @@ export const ANVIL_NETWORKS: Record<NetworksWithFork, NetworkSetup> = {
         rpcEnv: 'GNOSIS_CHAIN_RPC_URL',
         fallBackRpc: 'https://rpc.ankr.com/gnosis',
         port: ANVIL_PORTS.GNOSIS_CHAIN,
-        forkBlockNumber: 35214423n,
+        forkBlockNumber: 38091627n,
     },
 };
 

--- a/test/lib/utils/addresses.ts
+++ b/test/lib/utils/addresses.ts
@@ -197,6 +197,16 @@ export const TOKENS: Record<number, Record<string, TestToken>> = {
             decimals: 18,
             slot: 3,
         },
+        sDAI: {
+            address: '0xaf204776c7245bf4147c2612bf6e5972ee483701',
+            decimals: 18,
+            slot: 0,
+        },
+        BRLA: {
+            address: '0xfecb3f7c54e2caae9dc6ac9060a822d47e053760',
+            decimals: 18,
+            slot: 51,
+        },
     },
 };
 
@@ -250,6 +260,13 @@ export const POOLS: Record<number, Record<string, TestPool>> = {
             id: '0x32296969ef14eb0c6d29669c550d4a0449130230000200000000000000000080',
             address: '0x32296969ef14eb0c6d29669c550d4a0449130230',
             type: PoolType.MetaStable,
+            decimals: 18,
+            slot: 0,
+        },
+        steakUSDC_csUSDL: {
+            id: '0x5dd88b3aa3143173eb26552923922bdf33f50949',
+            address: '0x5dd88b3aa3143173eb26552923922bdf33f50949',
+            type: PoolType.Stable,
             decimals: 18,
             slot: 0,
         },
@@ -344,6 +361,15 @@ export const POOLS: Record<number, Record<string, TestPool>> = {
         MOCK_STABLE_POOL: {
             address: '0x5b17fb19b8c44f126e87882e7baa32153edcaf1d',
             id: '0x5b17fb19b8c44f126e87882e7baa32153edcaf1d',
+            type: PoolType.Stable,
+            decimals: 18,
+            slot: 0,
+        },
+    },
+    [ChainId.GNOSIS_CHAIN]: {
+        SDAI_BRLA_POOL: {
+            address: '0xa91c3c043051e7e680b61d79b3a733d3e2c0fb5e',
+            id: '0xa91c3c043051e7e680b61d79b3a733d3e2c0fb5e',
             type: PoolType.Stable,
             decimals: 18,
             slot: 0,

--- a/test/mockData/boostedPool.ts
+++ b/test/mockData/boostedPool.ts
@@ -1,5 +1,7 @@
 import { PoolStateWithUnderlyings } from '@/entities';
 
+// mainnet
+
 export const boostedPool_USDC_USDT: PoolStateWithUnderlyings = {
     id: '0x59fa488dda749cdd41772bb068bb23ee955a6d7a',
     address: '0x59fa488dda749cdd41772bb068bb23ee955a6d7a',
@@ -25,6 +27,62 @@ export const boostedPool_USDC_USDT: PoolStateWithUnderlyings = {
                 decimals: 6,
                 index: 1,
             },
+        },
+    ],
+};
+
+export const boostedPool_steakUSDC_csUSDL: PoolStateWithUnderlyings = {
+    id: '0x5dd88b3aa3143173eb26552923922bdf33f50949',
+    address: '0x5dd88b3aa3143173eb26552923922bdf33f50949',
+    type: 'Stable',
+    protocolVersion: 3,
+    tokens: [
+        {
+            index: 0,
+            address: '0xbeef01735c132ada46aa9aa4c54623caa92a64cb',
+            decimals: 18,
+            underlyingToken: {
+                address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48', // USDC
+                decimals: 6,
+                index: 0,
+            },
+        },
+        {
+            index: 1,
+            address: '0xbeefc01767ed5086f35decb6c00e6c12bc7476c1',
+            decimals: 18,
+            underlyingToken: {
+                address: '0x7751e2f4b8ae93ef6b79d86419d42fe3295a4559', // wUSDL
+                decimals: 18,
+                index: 1,
+            },
+        },
+    ],
+};
+
+// gnosis-chain
+
+export const boostedPool_sDAI_BRLA: PoolStateWithUnderlyings = {
+    id: '0xa91c3c043051e7e680b61d79b3a733d3e2c0fb5e',
+    address: '0xa91c3c043051e7e680b61d79b3a733d3e2c0fb5e',
+    type: 'Stable',
+    protocolVersion: 3,
+    tokens: [
+        {
+            index: 0,
+            address: '0xaf204776c7245bf4147c2612bf6e5972ee483701',
+            decimals: 18,
+            underlyingToken: {
+                address: '0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d', // wxdai
+                decimals: 18,
+                index: 0,
+            },
+        },
+        {
+            index: 1,
+            address: '0xfecb3f7c54e2caae9dc6ac9060a822d47e053760',
+            decimals: 18,
+            underlyingToken: null,
         },
     ],
 };

--- a/test/v3/addLiquidity/addLiquidity.integration-gnosis.test.ts
+++ b/test/v3/addLiquidity/addLiquidity.integration-gnosis.test.ts
@@ -50,7 +50,7 @@ const chainId = ChainId.GNOSIS_CHAIN;
 const sDAI = TOKENS[chainId].sDAI;
 const BRLA = TOKENS[chainId].BRLA;
 
-describe('add liquidity test', () => {
+describe.skip('add liquidity test', () => {
     let client: PublicWalletClient & TestActions;
     let txInput: AddLiquidityTxInput;
     let poolState: PoolState;

--- a/test/v3/addLiquidity/addLiquidity.integration-gnosis.test.ts
+++ b/test/v3/addLiquidity/addLiquidity.integration-gnosis.test.ts
@@ -1,0 +1,248 @@
+// pnpm test -- v3/addLiquidity/addLiquidity.integration-gnosis.test.ts
+
+import { config } from 'dotenv';
+config();
+
+import {
+    Address,
+    createTestClient,
+    http,
+    parseUnits,
+    publicActions,
+    TestActions,
+    walletActions,
+} from 'viem';
+
+import {
+    AddLiquidityUnbalancedInput,
+    AddLiquiditySingleTokenInput,
+    AddLiquidityProportionalInput,
+    AddLiquidityKind,
+    Slippage,
+    Hex,
+    PoolState,
+    CHAINS,
+    ChainId,
+    AddLiquidity,
+    AddLiquidityInput,
+    InputAmount,
+    PERMIT2,
+    PublicWalletClient,
+} from '@/index';
+import {
+    AddLiquidityTxInput,
+    assertAddLiquidityUnbalanced,
+    assertAddLiquiditySingleToken,
+    assertAddLiquidityProportional,
+    doAddLiquidity,
+    TOKENS,
+    setTokenBalances,
+    approveSpenderOnTokens,
+    approveTokens,
+} from '../../lib/utils';
+import { ANVIL_NETWORKS, startFork } from '../../anvil/anvil-global-setup';
+import { boostedPool_sDAI_BRLA } from 'test/mockData/boostedPool';
+
+const protocolVersion = 3;
+
+const chainId = ChainId.GNOSIS_CHAIN;
+
+const sDAI = TOKENS[chainId].sDAI;
+const BRLA = TOKENS[chainId].BRLA;
+
+describe('add liquidity test', () => {
+    let client: PublicWalletClient & TestActions;
+    let txInput: AddLiquidityTxInput;
+    let poolState: PoolState;
+    let tokens: Address[];
+    let rpcUrl: string;
+    let snapshot: Hex;
+
+    beforeAll(async () => {
+        // get pool state from testData
+        poolState = boostedPool_sDAI_BRLA;
+
+        ({ rpcUrl } = await startFork(ANVIL_NETWORKS[ChainId[chainId]]));
+
+        client = createTestClient({
+            mode: 'anvil',
+            chain: CHAINS[chainId],
+            transport: http(rpcUrl),
+        })
+            .extend(publicActions)
+            .extend(walletActions);
+
+        const testAddress = (await client.getAddresses())[0];
+
+        txInput = {
+            client,
+            addLiquidity: new AddLiquidity(),
+            slippage: Slippage.fromPercentage('1'), // 1%
+            poolState,
+            testAddress,
+            addLiquidityInput: {} as AddLiquidityInput,
+        };
+
+        tokens = [...poolState.tokens.map((t) => t.address)];
+
+        await setTokenBalances(
+            client,
+            testAddress,
+            tokens,
+            [sDAI.slot, BRLA.slot] as number[],
+            [...poolState.tokens.map((t) => parseUnits('100', t.decimals))],
+        );
+
+        await approveSpenderOnTokens(
+            client,
+            testAddress,
+            tokens,
+            PERMIT2[chainId],
+        );
+
+        await approveTokens(
+            client,
+            txInput.testAddress,
+            tokens,
+            protocolVersion,
+        );
+
+        snapshot = await client.snapshot();
+    });
+
+    beforeEach(async () => {
+        await client.revert({
+            id: snapshot,
+        });
+        snapshot = await client.snapshot();
+    });
+
+    describe('add liquidity unbalanced', () => {
+        let addLiquidityInput: AddLiquidityUnbalancedInput;
+        beforeAll(() => {
+            addLiquidityInput = {
+                chainId,
+                rpcUrl,
+                kind: AddLiquidityKind.Unbalanced,
+                amountsIn: txInput.poolState.tokens.map((t) => ({
+                    rawAmount: parseUnits('0.01', t.decimals),
+                    decimals: t.decimals,
+                    address: t.address,
+                })),
+            };
+        });
+        test('token inputs', async () => {
+            const addLiquidityOutput = await doAddLiquidity({
+                ...txInput,
+                addLiquidityInput,
+            });
+            assertAddLiquidityUnbalanced(
+                txInput.poolState,
+                addLiquidityInput,
+                addLiquidityOutput,
+                txInput.slippage,
+                chainId,
+                protocolVersion,
+            );
+        });
+    });
+
+    describe('add liquidity single asset', () => {
+        let addLiquidityInput: AddLiquiditySingleTokenInput;
+        beforeAll(() => {
+            const tokenIn = sDAI.address;
+            addLiquidityInput = {
+                tokenIn,
+                chainId,
+                rpcUrl,
+                kind: AddLiquidityKind.SingleToken,
+                bptOut: {
+                    rawAmount: parseUnits('1', 18),
+                    decimals: 18,
+                    address: poolState.address,
+                },
+            };
+        });
+        test('with token', async () => {
+            const addLiquidityOutput = await doAddLiquidity({
+                ...txInput,
+                addLiquidityInput,
+            });
+
+            assertAddLiquiditySingleToken(
+                txInput.poolState,
+                addLiquidityInput,
+                addLiquidityOutput,
+                txInput.slippage,
+                chainId,
+                protocolVersion,
+            );
+        });
+    });
+    describe('add liquidity proportional', () => {
+        let addLiquidityInput: AddLiquidityProportionalInput;
+        describe('with bptOut as referenceAmount', () => {
+            beforeAll(() => {
+                const referenceAmount: InputAmount = {
+                    rawAmount: parseUnits('1', 18),
+                    decimals: 18,
+                    address: poolState.address,
+                };
+
+                addLiquidityInput = {
+                    referenceAmount,
+                    kind: AddLiquidityKind.Proportional,
+                    chainId: chainId,
+                    rpcUrl: rpcUrl,
+                };
+            });
+            test('with token', async () => {
+                const addLiquidityOutput = await doAddLiquidity({
+                    ...txInput,
+                    addLiquidityInput,
+                });
+
+                assertAddLiquidityProportional(
+                    txInput.poolState,
+                    addLiquidityInput,
+                    addLiquidityOutput,
+                    txInput.slippage,
+                    chainId,
+                    protocolVersion,
+                );
+            });
+        });
+        describe('with amountIn as referenceAmount', () => {
+            beforeAll(() => {
+                const token = txInput.poolState.tokens[1];
+                const referenceAmount: InputAmount = {
+                    rawAmount: parseUnits('1.5', token.decimals),
+                    decimals: token.decimals,
+                    address: token.address,
+                };
+
+                addLiquidityInput = {
+                    referenceAmount,
+                    kind: AddLiquidityKind.Proportional,
+                    chainId: chainId,
+                    rpcUrl: rpcUrl,
+                };
+            });
+            test('with token', async () => {
+                const addLiquidityOutput = await doAddLiquidity({
+                    ...txInput,
+                    addLiquidityInput,
+                });
+
+                assertAddLiquidityProportional(
+                    txInput.poolState,
+                    addLiquidityInput,
+                    addLiquidityOutput,
+                    txInput.slippage,
+                    chainId,
+                    protocolVersion,
+                );
+            });
+        });
+    });
+});

--- a/test/v3/addLiquidity/addLiquidity.integration-gnosis.test.ts
+++ b/test/v3/addLiquidity/addLiquidity.integration-gnosis.test.ts
@@ -50,7 +50,8 @@ const chainId = ChainId.GNOSIS_CHAIN;
 const sDAI = TOKENS[chainId].sDAI;
 const BRLA = TOKENS[chainId].BRLA;
 
-describe('add liquidity test', () => {
+// skipping until we figure out why test is failing on CI
+describe.skip('add liquidity test', () => {
     let client: PublicWalletClient & TestActions;
     let txInput: AddLiquidityTxInput;
     let poolState: PoolState;

--- a/test/v3/addLiquidity/addLiquidity.integration-gnosis.test.ts
+++ b/test/v3/addLiquidity/addLiquidity.integration-gnosis.test.ts
@@ -50,7 +50,7 @@ const chainId = ChainId.GNOSIS_CHAIN;
 const sDAI = TOKENS[chainId].sDAI;
 const BRLA = TOKENS[chainId].BRLA;
 
-describe.skip('add liquidity test', () => {
+describe('add liquidity test', () => {
     let client: PublicWalletClient & TestActions;
     let txInput: AddLiquidityTxInput;
     let poolState: PoolState;


### PR DESCRIPTION
Closes #561 

getPoolStateWithBalances should use raw balances instead of live balances when used to calculate proportional amounts

this PR fixes an issue where karpatkey is trying to add liquidity to the [sDAI/BRLA pool](https://balancer.fi/pools/gnosis/v3/0xa91c3c043051e7e680b61d79b3a733d3e2c0fb5e) on gnosis chain

