### PR TITLE
New composite router for boosted pool operations

### DIFF
--- a/.changeset/red-buttons-check.md
+++ b/.changeset/red-buttons-check.md
@@ -1,5 +1,5 @@
 ---
-"@balancer/sdk": minor
+"@balancer/sdk": major
 ---
 
 new composite router for boosted operations with ability to wrap/unwrap single token

--- a/.changeset/red-buttons-check.md
+++ b/.changeset/red-buttons-check.md
@@ -1,0 +1,5 @@
+---
+"@balancer/sdk": minor
+---
+
+new composite router for boosted operations with ability to wrap/unwrap single token

--- a/examples/addLiquidity/addLiquidityNested.V3.ts
+++ b/examples/addLiquidity/addLiquidityNested.V3.ts
@@ -24,7 +24,7 @@ import {
     AddLiquidityNestedInput,
     TEST_API_ENDPOINT,
     PERMIT2,
-    BALANCER_COMPOSITE_LIQUIDITY_ROUTER,
+    BALANCER_COMPOSITE_LIQUIDITY_ROUTER_NESTED,
 } from '../../src';
 import {
     ANVIL_NETWORKS,
@@ -133,7 +133,7 @@ const addLiquidityNested = async () => {
             client,
             userAccount,
             amount.token.address,
-            BALANCER_COMPOSITE_LIQUIDITY_ROUTER[chainId],
+            BALANCER_COMPOSITE_LIQUIDITY_ROUTER_NESTED[chainId],
         );
     }
 

--- a/src/abi/balancerCompositeLiquidityRouterBoosted.ts
+++ b/src/abi/balancerCompositeLiquidityRouterBoosted.ts
@@ -1,0 +1,499 @@
+export const balancerCompositeLiquidityRouterBoostedAbi = [
+    {
+        inputs: [
+            { internalType: 'contract IVault', name: 'vault', type: 'address' },
+            { internalType: 'contract IWETH', name: 'weth', type: 'address' },
+            {
+                internalType: 'contract IPermit2',
+                name: 'permit2',
+                type: 'address',
+            },
+            { internalType: 'string', name: 'routerVersion', type: 'string' },
+        ],
+        stateMutability: 'nonpayable',
+        type: 'constructor',
+    },
+    {
+        inputs: [{ internalType: 'address', name: 'target', type: 'address' }],
+        name: 'AddressEmptyCode',
+        type: 'error',
+    },
+    {
+        inputs: [{ internalType: 'address', name: 'account', type: 'address' }],
+        name: 'AddressInsufficientBalance',
+        type: 'error',
+    },
+    {
+        inputs: [
+            {
+                internalType: 'contract IERC20',
+                name: 'tokenIn',
+                type: 'address',
+            },
+            { internalType: 'uint256', name: 'amountIn', type: 'uint256' },
+            { internalType: 'uint256', name: 'maxAmountIn', type: 'uint256' },
+        ],
+        name: 'AmountInAboveMax',
+        type: 'error',
+    },
+    {
+        inputs: [
+            {
+                internalType: 'contract IERC20',
+                name: 'tokenOut',
+                type: 'address',
+            },
+            { internalType: 'uint256', name: 'amountOut', type: 'uint256' },
+            { internalType: 'uint256', name: 'minAmountOut', type: 'uint256' },
+        ],
+        name: 'AmountOutBelowMin',
+        type: 'error',
+    },
+    {
+        inputs: [
+            {
+                internalType: 'contract IERC4626',
+                name: 'wrappedToken',
+                type: 'address',
+            },
+        ],
+        name: 'BufferNotInitialized',
+        type: 'error',
+    },
+    { inputs: [], name: 'ErrorSelectorNotFound', type: 'error' },
+    { inputs: [], name: 'EthTransfer', type: 'error' },
+    { inputs: [], name: 'FailedInnerCall', type: 'error' },
+    { inputs: [], name: 'InputLengthMismatch', type: 'error' },
+    { inputs: [], name: 'InsufficientEth', type: 'error' },
+    { inputs: [], name: 'ReentrancyGuardReentrantCall', type: 'error' },
+    {
+        inputs: [
+            { internalType: 'uint8', name: 'bits', type: 'uint8' },
+            { internalType: 'uint256', name: 'value', type: 'uint256' },
+        ],
+        name: 'SafeCastOverflowedUintDowncast',
+        type: 'error',
+    },
+    {
+        inputs: [{ internalType: 'address', name: 'token', type: 'address' }],
+        name: 'SafeERC20FailedOperation',
+        type: 'error',
+    },
+    {
+        inputs: [{ internalType: 'address', name: 'sender', type: 'address' }],
+        name: 'SenderIsNotVault',
+        type: 'error',
+    },
+    { inputs: [], name: 'SwapDeadline', type: 'error' },
+    {
+        inputs: [
+            {
+                internalType: 'address[]',
+                name: 'expectedTokensOut',
+                type: 'address[]',
+            },
+            { internalType: 'address[]', name: 'tokensOut', type: 'address[]' },
+        ],
+        name: 'WrongTokensOut',
+        type: 'error',
+    },
+    {
+        inputs: [
+            {
+                components: [
+                    {
+                        internalType: 'address',
+                        name: 'sender',
+                        type: 'address',
+                    },
+                    { internalType: 'address', name: 'pool', type: 'address' },
+                    {
+                        internalType: 'uint256[]',
+                        name: 'maxAmountsIn',
+                        type: 'uint256[]',
+                    },
+                    {
+                        internalType: 'uint256',
+                        name: 'minBptAmountOut',
+                        type: 'uint256',
+                    },
+                    {
+                        internalType: 'enum AddLiquidityKind',
+                        name: 'kind',
+                        type: 'uint8',
+                    },
+                    { internalType: 'bool', name: 'wethIsEth', type: 'bool' },
+                    { internalType: 'bytes', name: 'userData', type: 'bytes' },
+                ],
+                internalType: 'struct IRouterCommon.AddLiquidityHookParams',
+                name: 'params',
+                type: 'tuple',
+            },
+            { internalType: 'bool[]', name: 'wrapUnderlying', type: 'bool[]' },
+        ],
+        name: 'addLiquidityERC4626PoolProportionalHook',
+        outputs: [
+            { internalType: 'address[]', name: 'tokensIn', type: 'address[]' },
+            { internalType: 'uint256[]', name: 'amountsIn', type: 'uint256[]' },
+        ],
+        stateMutability: 'nonpayable',
+        type: 'function',
+    },
+    {
+        inputs: [
+            {
+                components: [
+                    {
+                        internalType: 'address',
+                        name: 'sender',
+                        type: 'address',
+                    },
+                    { internalType: 'address', name: 'pool', type: 'address' },
+                    {
+                        internalType: 'uint256[]',
+                        name: 'maxAmountsIn',
+                        type: 'uint256[]',
+                    },
+                    {
+                        internalType: 'uint256',
+                        name: 'minBptAmountOut',
+                        type: 'uint256',
+                    },
+                    {
+                        internalType: 'enum AddLiquidityKind',
+                        name: 'kind',
+                        type: 'uint8',
+                    },
+                    { internalType: 'bool', name: 'wethIsEth', type: 'bool' },
+                    { internalType: 'bytes', name: 'userData', type: 'bytes' },
+                ],
+                internalType: 'struct IRouterCommon.AddLiquidityHookParams',
+                name: 'params',
+                type: 'tuple',
+            },
+            { internalType: 'bool[]', name: 'wrapUnderlying', type: 'bool[]' },
+        ],
+        name: 'addLiquidityERC4626PoolUnbalancedHook',
+        outputs: [
+            { internalType: 'uint256', name: 'bptAmountOut', type: 'uint256' },
+        ],
+        stateMutability: 'nonpayable',
+        type: 'function',
+    },
+    {
+        inputs: [
+            { internalType: 'address', name: 'pool', type: 'address' },
+            { internalType: 'bool[]', name: 'wrapUnderlying', type: 'bool[]' },
+            {
+                internalType: 'uint256[]',
+                name: 'maxAmountsIn',
+                type: 'uint256[]',
+            },
+            {
+                internalType: 'uint256',
+                name: 'exactBptAmountOut',
+                type: 'uint256',
+            },
+            { internalType: 'bool', name: 'wethIsEth', type: 'bool' },
+            { internalType: 'bytes', name: 'userData', type: 'bytes' },
+        ],
+        name: 'addLiquidityProportionalToERC4626Pool',
+        outputs: [
+            { internalType: 'address[]', name: 'tokensIn', type: 'address[]' },
+            { internalType: 'uint256[]', name: 'amountsIn', type: 'uint256[]' },
+        ],
+        stateMutability: 'payable',
+        type: 'function',
+    },
+    {
+        inputs: [
+            { internalType: 'address', name: 'pool', type: 'address' },
+            { internalType: 'bool[]', name: 'wrapUnderlying', type: 'bool[]' },
+            {
+                internalType: 'uint256[]',
+                name: 'exactAmountsIn',
+                type: 'uint256[]',
+            },
+            {
+                internalType: 'uint256',
+                name: 'minBptAmountOut',
+                type: 'uint256',
+            },
+            { internalType: 'bool', name: 'wethIsEth', type: 'bool' },
+            { internalType: 'bytes', name: 'userData', type: 'bytes' },
+        ],
+        name: 'addLiquidityUnbalancedToERC4626Pool',
+        outputs: [
+            { internalType: 'uint256', name: 'bptAmountOut', type: 'uint256' },
+        ],
+        stateMutability: 'payable',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'getPermit2',
+        outputs: [
+            { internalType: 'contract IPermit2', name: '', type: 'address' },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'getSender',
+        outputs: [{ internalType: 'address', name: '', type: 'address' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'getWeth',
+        outputs: [
+            { internalType: 'contract IWETH', name: '', type: 'address' },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [{ internalType: 'bytes[]', name: 'data', type: 'bytes[]' }],
+        name: 'multicall',
+        outputs: [
+            { internalType: 'bytes[]', name: 'results', type: 'bytes[]' },
+        ],
+        stateMutability: 'payable',
+        type: 'function',
+    },
+    {
+        inputs: [
+            {
+                components: [
+                    { internalType: 'address', name: 'token', type: 'address' },
+                    { internalType: 'address', name: 'owner', type: 'address' },
+                    {
+                        internalType: 'address',
+                        name: 'spender',
+                        type: 'address',
+                    },
+                    {
+                        internalType: 'uint256',
+                        name: 'amount',
+                        type: 'uint256',
+                    },
+                    { internalType: 'uint256', name: 'nonce', type: 'uint256' },
+                    {
+                        internalType: 'uint256',
+                        name: 'deadline',
+                        type: 'uint256',
+                    },
+                ],
+                internalType: 'struct IRouterCommon.PermitApproval[]',
+                name: 'permitBatch',
+                type: 'tuple[]',
+            },
+            {
+                internalType: 'bytes[]',
+                name: 'permitSignatures',
+                type: 'bytes[]',
+            },
+            {
+                components: [
+                    {
+                        components: [
+                            {
+                                internalType: 'address',
+                                name: 'token',
+                                type: 'address',
+                            },
+                            {
+                                internalType: 'uint160',
+                                name: 'amount',
+                                type: 'uint160',
+                            },
+                            {
+                                internalType: 'uint48',
+                                name: 'expiration',
+                                type: 'uint48',
+                            },
+                            {
+                                internalType: 'uint48',
+                                name: 'nonce',
+                                type: 'uint48',
+                            },
+                        ],
+                        internalType:
+                            'struct IAllowanceTransfer.PermitDetails[]',
+                        name: 'details',
+                        type: 'tuple[]',
+                    },
+                    {
+                        internalType: 'address',
+                        name: 'spender',
+                        type: 'address',
+                    },
+                    {
+                        internalType: 'uint256',
+                        name: 'sigDeadline',
+                        type: 'uint256',
+                    },
+                ],
+                internalType: 'struct IAllowanceTransfer.PermitBatch',
+                name: 'permit2Batch',
+                type: 'tuple',
+            },
+            { internalType: 'bytes', name: 'permit2Signature', type: 'bytes' },
+            { internalType: 'bytes[]', name: 'multicallData', type: 'bytes[]' },
+        ],
+        name: 'permitBatchAndCall',
+        outputs: [
+            { internalType: 'bytes[]', name: 'results', type: 'bytes[]' },
+        ],
+        stateMutability: 'payable',
+        type: 'function',
+    },
+    {
+        inputs: [
+            { internalType: 'address', name: 'pool', type: 'address' },
+            { internalType: 'bool[]', name: 'wrapUnderlying', type: 'bool[]' },
+            {
+                internalType: 'uint256',
+                name: 'exactBptAmountOut',
+                type: 'uint256',
+            },
+            { internalType: 'address', name: 'sender', type: 'address' },
+            { internalType: 'bytes', name: 'userData', type: 'bytes' },
+        ],
+        name: 'queryAddLiquidityProportionalToERC4626Pool',
+        outputs: [
+            { internalType: 'address[]', name: 'tokensIn', type: 'address[]' },
+            { internalType: 'uint256[]', name: 'amountsIn', type: 'uint256[]' },
+        ],
+        stateMutability: 'nonpayable',
+        type: 'function',
+    },
+    {
+        inputs: [
+            { internalType: 'address', name: 'pool', type: 'address' },
+            { internalType: 'bool[]', name: 'wrapUnderlying', type: 'bool[]' },
+            {
+                internalType: 'uint256[]',
+                name: 'exactAmountsIn',
+                type: 'uint256[]',
+            },
+            { internalType: 'address', name: 'sender', type: 'address' },
+            { internalType: 'bytes', name: 'userData', type: 'bytes' },
+        ],
+        name: 'queryAddLiquidityUnbalancedToERC4626Pool',
+        outputs: [
+            { internalType: 'uint256', name: 'bptAmountOut', type: 'uint256' },
+        ],
+        stateMutability: 'nonpayable',
+        type: 'function',
+    },
+    {
+        inputs: [
+            { internalType: 'address', name: 'pool', type: 'address' },
+            { internalType: 'bool[]', name: 'unwrapWrapped', type: 'bool[]' },
+            {
+                internalType: 'uint256',
+                name: 'exactBptAmountIn',
+                type: 'uint256',
+            },
+            { internalType: 'address', name: 'sender', type: 'address' },
+            { internalType: 'bytes', name: 'userData', type: 'bytes' },
+        ],
+        name: 'queryRemoveLiquidityProportionalFromERC4626Pool',
+        outputs: [
+            { internalType: 'address[]', name: 'tokensOut', type: 'address[]' },
+            {
+                internalType: 'uint256[]',
+                name: 'amountsOut',
+                type: 'uint256[]',
+            },
+        ],
+        stateMutability: 'nonpayable',
+        type: 'function',
+    },
+    {
+        inputs: [
+            {
+                components: [
+                    {
+                        internalType: 'address',
+                        name: 'sender',
+                        type: 'address',
+                    },
+                    { internalType: 'address', name: 'pool', type: 'address' },
+                    {
+                        internalType: 'uint256[]',
+                        name: 'minAmountsOut',
+                        type: 'uint256[]',
+                    },
+                    {
+                        internalType: 'uint256',
+                        name: 'maxBptAmountIn',
+                        type: 'uint256',
+                    },
+                    {
+                        internalType: 'enum RemoveLiquidityKind',
+                        name: 'kind',
+                        type: 'uint8',
+                    },
+                    { internalType: 'bool', name: 'wethIsEth', type: 'bool' },
+                    { internalType: 'bytes', name: 'userData', type: 'bytes' },
+                ],
+                internalType: 'struct IRouterCommon.RemoveLiquidityHookParams',
+                name: 'params',
+                type: 'tuple',
+            },
+            { internalType: 'bool[]', name: 'unwrapWrapped', type: 'bool[]' },
+        ],
+        name: 'removeLiquidityERC4626PoolProportionalHook',
+        outputs: [
+            { internalType: 'address[]', name: 'tokensOut', type: 'address[]' },
+            {
+                internalType: 'uint256[]',
+                name: 'amountsOut',
+                type: 'uint256[]',
+            },
+        ],
+        stateMutability: 'nonpayable',
+        type: 'function',
+    },
+    {
+        inputs: [
+            { internalType: 'address', name: 'pool', type: 'address' },
+            { internalType: 'bool[]', name: 'unwrapWrapped', type: 'bool[]' },
+            {
+                internalType: 'uint256',
+                name: 'exactBptAmountIn',
+                type: 'uint256',
+            },
+            {
+                internalType: 'uint256[]',
+                name: 'minAmountsOut',
+                type: 'uint256[]',
+            },
+            { internalType: 'bool', name: 'wethIsEth', type: 'bool' },
+            { internalType: 'bytes', name: 'userData', type: 'bytes' },
+        ],
+        name: 'removeLiquidityProportionalFromERC4626Pool',
+        outputs: [
+            { internalType: 'address[]', name: 'tokensOut', type: 'address[]' },
+            {
+                internalType: 'uint256[]',
+                name: 'amountsOut',
+                type: 'uint256[]',
+            },
+        ],
+        stateMutability: 'payable',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'version',
+        outputs: [{ internalType: 'string', name: '', type: 'string' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    { stateMutability: 'payable', type: 'receive' },
+] as const;

--- a/src/abi/balancerCompositeLiquidityRouterNested.ts
+++ b/src/abi/balancerCompositeLiquidityRouterNested.ts
@@ -1,4 +1,4 @@
-export const balancerCompositeLiquidityRouterAbi = [
+export const balancerCompositeLiquidityRouterNestedAbi = [
     {
         inputs: [
             { internalType: 'contract IVault', name: 'vault', type: 'address' },

--- a/src/abi/index.ts
+++ b/src/abi/index.ts
@@ -17,4 +17,5 @@ export * from './weightedPoolV4.V2';
 export * from './weightedPool.V3';
 export * from './vaultAdmin.V3';
 export * from './stablePoolFactory.V3';
-export * from './balancerCompositeLiquidityRouter';
+export * from './balancerCompositeLiquidityRouterNested';
+export * from './balancerCompositeLiquidityRouterBoosted';

--- a/src/entities/addLiquidity/index.ts
+++ b/src/entities/addLiquidity/index.ts
@@ -17,7 +17,7 @@ import { Hex } from 'viem';
 
 export class AddLiquidity implements AddLiquidityBase {
     constructor(public config?: AddLiquidityConfig) {}
-    protected readonly inputValidator: InputValidator = new InputValidator();
+    private readonly inputValidator: InputValidator = new InputValidator();
 
     query(
         input: AddLiquidityInput,

--- a/src/entities/addLiquidity/index.ts
+++ b/src/entities/addLiquidity/index.ts
@@ -17,7 +17,7 @@ import { Hex } from 'viem';
 
 export class AddLiquidity implements AddLiquidityBase {
     constructor(public config?: AddLiquidityConfig) {}
-    private readonly inputValidator: InputValidator = new InputValidator();
+    protected readonly inputValidator: InputValidator = new InputValidator();
 
     query(
         input: AddLiquidityInput,

--- a/src/entities/addLiquidityBoosted/doAddLiquidityPropotionalQuery.ts
+++ b/src/entities/addLiquidityBoosted/doAddLiquidityPropotionalQuery.ts
@@ -21,14 +21,14 @@ export const doAddLiquidityProportionalQuery = async (
     exactBptAmountOut: bigint,
     wrapUnderlying: boolean[],
     block?: bigint,
-): Promise<bigint[]> => {
+): Promise<[Address[], bigint[]]> => {
     const client = createPublicClient({
         transport: http(rpcUrl),
         chain: CHAINS[chainId],
     });
 
     const {
-        result: [, exactAmountsIn],
+        result: [tokensIn, exactAmountsIn],
     } = await client.simulateContract({
         address: BALANCER_COMPOSITE_LIQUIDITY_ROUTER_BOOSTED[chainId],
         abi: [
@@ -47,5 +47,6 @@ export const doAddLiquidityProportionalQuery = async (
         ],
         blockNumber: block,
     });
-    return [...exactAmountsIn];
+
+    return [[...tokensIn], [...exactAmountsIn]];
 };

--- a/src/entities/addLiquidityBoosted/doAddLiquidityPropotionalQuery.ts
+++ b/src/entities/addLiquidityBoosted/doAddLiquidityPropotionalQuery.ts
@@ -1,8 +1,12 @@
 import { createPublicClient, Hex, http } from 'viem';
-import { BALANCER_COMPOSITE_LIQUIDITY_ROUTER, ChainId, CHAINS } from '@/utils';
+import {
+    BALANCER_COMPOSITE_LIQUIDITY_ROUTER_BOOSTED,
+    ChainId,
+    CHAINS,
+} from '@/utils';
 import { Address } from '@/types';
 import {
-    balancerCompositeLiquidityRouterAbi,
+    balancerCompositeLiquidityRouterBoostedAbi,
     permit2Abi,
     vaultExtensionAbi_V3,
     vaultV3Abi,
@@ -15,6 +19,7 @@ export const doAddLiquidityProportionalQuery = async (
     userData: Hex,
     poolAddress: Address,
     exactBptAmountOut: bigint,
+    wrapUnderlying: boolean[],
     block?: bigint,
 ): Promise<bigint[]> => {
     const client = createPublicClient({
@@ -22,16 +27,24 @@ export const doAddLiquidityProportionalQuery = async (
         chain: CHAINS[chainId],
     });
 
-    const { result: exactAmountsIn } = await client.simulateContract({
-        address: BALANCER_COMPOSITE_LIQUIDITY_ROUTER[chainId],
+    const {
+        result: [, exactAmountsIn],
+    } = await client.simulateContract({
+        address: BALANCER_COMPOSITE_LIQUIDITY_ROUTER_BOOSTED[chainId],
         abi: [
-            ...balancerCompositeLiquidityRouterAbi,
+            ...balancerCompositeLiquidityRouterBoostedAbi,
             ...vaultV3Abi,
             ...vaultExtensionAbi_V3,
             ...permit2Abi,
         ],
         functionName: 'queryAddLiquidityProportionalToERC4626Pool',
-        args: [poolAddress, exactBptAmountOut, sender, userData],
+        args: [
+            poolAddress,
+            wrapUnderlying,
+            exactBptAmountOut,
+            sender,
+            userData,
+        ],
         blockNumber: block,
     });
     return [...exactAmountsIn];

--- a/src/entities/addLiquidityBoosted/doAddLiquidityUnbalancedQuery.ts
+++ b/src/entities/addLiquidityBoosted/doAddLiquidityUnbalancedQuery.ts
@@ -1,11 +1,15 @@
 import { createPublicClient, Hex, http } from 'viem';
 
-import { BALANCER_COMPOSITE_LIQUIDITY_ROUTER, ChainId, CHAINS } from '@/utils';
+import {
+    BALANCER_COMPOSITE_LIQUIDITY_ROUTER_BOOSTED,
+    ChainId,
+    CHAINS,
+} from '@/utils';
 
 import { Address } from '@/types';
 
 import {
-    balancerCompositeLiquidityRouterAbi,
+    balancerCompositeLiquidityRouterBoostedAbi,
     permit2Abi,
     vaultExtensionAbi_V3,
     vaultV3Abi,
@@ -17,6 +21,7 @@ export const doAddLiquidityUnbalancedQuery = async (
     sender: Address,
     userData: Hex,
     poolAddress: Address,
+    wrapUnderlying: boolean[],
     exactUnderlyingAmountsIn: bigint[],
     block?: bigint,
 ): Promise<bigint> => {
@@ -26,15 +31,21 @@ export const doAddLiquidityUnbalancedQuery = async (
     });
 
     const { result: bptAmountOut } = await client.simulateContract({
-        address: BALANCER_COMPOSITE_LIQUIDITY_ROUTER[chainId],
+        address: BALANCER_COMPOSITE_LIQUIDITY_ROUTER_BOOSTED[chainId],
         abi: [
-            ...balancerCompositeLiquidityRouterAbi,
+            ...balancerCompositeLiquidityRouterBoostedAbi,
             ...vaultV3Abi,
             ...vaultExtensionAbi_V3,
             ...permit2Abi,
         ],
         functionName: 'queryAddLiquidityUnbalancedToERC4626Pool',
-        args: [poolAddress, exactUnderlyingAmountsIn, sender, userData],
+        args: [
+            poolAddress,
+            wrapUnderlying,
+            exactUnderlyingAmountsIn,
+            sender,
+            userData,
+        ],
         blockNumber: block,
     });
     return bptAmountOut;

--- a/src/entities/addLiquidityBoosted/index.ts
+++ b/src/entities/addLiquidityBoosted/index.ts
@@ -26,8 +26,11 @@ import {
 import { doAddLiquidityUnbalancedQuery } from './doAddLiquidityUnbalancedQuery';
 import { doAddLiquidityProportionalQuery } from './doAddLiquidityPropotionalQuery';
 import { Token } from '../token';
-import { BALANCER_COMPOSITE_LIQUIDITY_ROUTER } from '@/utils';
-import { balancerCompositeLiquidityRouterAbi, balancerRouterAbi } from '@/abi';
+import { BALANCER_COMPOSITE_LIQUIDITY_ROUTER_BOOSTED } from '@/utils';
+import {
+    balancerCompositeLiquidityRouterBoostedAbi,
+    balancerRouterAbi,
+} from '@/abi';
 
 import { InputValidator } from '../inputValidator/inputValidator';
 
@@ -85,6 +88,7 @@ export class AddLiquidityBoostedV3 {
                     input.sender ?? zeroAddress,
                     input.userData ?? '0x',
                     poolState.address,
+                    input.wrapUnderlying,
                     maxAmountsIn,
                     block,
                 );
@@ -109,6 +113,7 @@ export class AddLiquidityBoostedV3 {
                         input.userData ?? '0x',
                         poolState.address,
                         bptAmount.rawAmount,
+                        input.wrapUnderlying,
                         block,
                     );
 
@@ -132,12 +137,13 @@ export class AddLiquidityBoostedV3 {
             poolId: poolState.id,
             poolType: poolState.type,
             addLiquidityKind: input.kind,
+            wrapUnderlying: input.wrapUnderlying,
             bptOut,
             amountsIn,
             chainId: input.chainId,
             protocolVersion: 3,
             userData: input.userData ?? '0x',
-            to: BALANCER_COMPOSITE_LIQUIDITY_ROUTER[input.chainId],
+            to: BALANCER_COMPOSITE_LIQUIDITY_ROUTER_BOOSTED[input.chainId],
         };
 
         return output;
@@ -150,6 +156,7 @@ export class AddLiquidityBoostedV3 {
         const wethIsEth = input.wethIsEth ?? false;
         const args = [
             input.poolId,
+            input.wrapUnderlying,
             amounts.maxAmountsIn,
             amounts.minimumBpt,
             wethIsEth,
@@ -159,7 +166,7 @@ export class AddLiquidityBoostedV3 {
         switch (input.addLiquidityKind) {
             case AddLiquidityKind.Unbalanced: {
                 callData = encodeFunctionData({
-                    abi: balancerCompositeLiquidityRouterAbi,
+                    abi: balancerCompositeLiquidityRouterBoostedAbi,
                     functionName: 'addLiquidityUnbalancedToERC4626Pool',
                     args,
                 });
@@ -167,7 +174,7 @@ export class AddLiquidityBoostedV3 {
             }
             case AddLiquidityKind.Proportional: {
                 callData = encodeFunctionData({
-                    abi: balancerCompositeLiquidityRouterAbi,
+                    abi: balancerCompositeLiquidityRouterBoostedAbi,
                     functionName: 'addLiquidityProportionalToERC4626Pool',
                     args,
                 });
@@ -182,7 +189,7 @@ export class AddLiquidityBoostedV3 {
 
         return {
             callData,
-            to: BALANCER_COMPOSITE_LIQUIDITY_ROUTER[input.chainId],
+            to: BALANCER_COMPOSITE_LIQUIDITY_ROUTER_BOOSTED[input.chainId],
             value,
             minBptOut: TokenAmount.fromRawAmount(
                 input.bptOut.token,

--- a/src/entities/addLiquidityBoosted/index.ts
+++ b/src/entities/addLiquidityBoosted/index.ts
@@ -38,9 +38,11 @@ import {
     AddLiquidityBoostedInput,
     AddLiquidityBoostedQueryOutput,
 } from './types';
-import { AddLiquidity } from '../addLiquidity';
+import { InputValidator } from '../inputValidator/inputValidator';
 
-export class AddLiquidityBoostedV3 extends AddLiquidity {
+export class AddLiquidityBoostedV3 {
+    private readonly inputValidator: InputValidator = new InputValidator();
+
     async query(
         input: AddLiquidityBoostedInput,
         poolState: PoolStateWithUnderlyings,

--- a/src/entities/addLiquidityBoosted/index.ts
+++ b/src/entities/addLiquidityBoosted/index.ts
@@ -32,18 +32,15 @@ import {
     balancerRouterAbi,
 } from '@/abi';
 
-import { InputValidator } from '../inputValidator/inputValidator';
-
 import { Hex } from '@/types';
 import {
     AddLiquidityBoostedBuildCallInput,
     AddLiquidityBoostedInput,
     AddLiquidityBoostedQueryOutput,
 } from './types';
+import { AddLiquidity } from '../addLiquidity';
 
-export class AddLiquidityBoostedV3 {
-    private readonly inputValidator: InputValidator = new InputValidator();
-
+export class AddLiquidityBoostedV3 extends AddLiquidity {
     async query(
         input: AddLiquidityBoostedInput,
         poolState: PoolStateWithUnderlyings,

--- a/src/entities/addLiquidityBoosted/index.ts
+++ b/src/entities/addLiquidityBoosted/index.ts
@@ -153,7 +153,7 @@ export class AddLiquidityBoostedV3 {
                     );
 
                 amountsIn = tokensIn.map((t, i) => {
-                    const tokenInAddress = t.toLowerCase() as `0x${string}`;
+                    const tokenInAddress = t.toLowerCase() as Address;
                     const { decimals } = poolStateTokenMap[tokenInAddress];
                     const token = new Token(
                         input.chainId,

--- a/src/entities/addLiquidityBoosted/types.ts
+++ b/src/entities/addLiquidityBoosted/types.ts
@@ -7,9 +7,9 @@ import { Slippage } from '../slippage';
 export type AddLiquidityBoostedProportionalInput = {
     chainId: number;
     rpcUrl: string;
+    tokensIn: Address[];
     referenceAmount: InputAmount;
     kind: AddLiquidityKind.Proportional;
-    wrapUnderlying: boolean[];
     sender?: Address;
     userData?: Hex;
 };
@@ -19,7 +19,6 @@ export type AddLiquidityBoostedUnbalancedInput = {
     rpcUrl: string;
     amountsIn: InputAmount[];
     kind: AddLiquidityKind.Unbalanced;
-    wrapUnderlying: boolean[];
     sender?: Address;
     userData?: Hex;
 };

--- a/src/entities/addLiquidityBoosted/types.ts
+++ b/src/entities/addLiquidityBoosted/types.ts
@@ -9,6 +9,7 @@ export type AddLiquidityBoostedProportionalInput = {
     rpcUrl: string;
     referenceAmount: InputAmount;
     kind: AddLiquidityKind.Proportional;
+    wrapUnderlying: boolean[];
     sender?: Address;
     userData?: Hex;
 };
@@ -18,6 +19,7 @@ export type AddLiquidityBoostedUnbalancedInput = {
     rpcUrl: string;
     amountsIn: InputAmount[];
     kind: AddLiquidityKind.Unbalanced;
+    wrapUnderlying: boolean[];
     sender?: Address;
     userData?: Hex;
 };
@@ -30,6 +32,7 @@ export type AddLiquidityBoostedQueryOutput = {
     poolId: Hex;
     poolType: string;
     addLiquidityKind: AddLiquidityKind;
+    wrapUnderlying: boolean[];
     bptOut: TokenAmount;
     amountsIn: TokenAmount[];
     chainId: number;

--- a/src/entities/addLiquidityNested/addLiquidityNestedV2/types.ts
+++ b/src/entities/addLiquidityNested/addLiquidityNestedV2/types.ts
@@ -1,15 +1,13 @@
 import { Address, Hex } from 'viem';
-import { InputAmount, PoolType } from '../../../types';
+import { PoolType } from '../../../types';
 import { ChainId } from '../../../utils';
 import { Token } from '../../token';
 import { TokenAmount } from '../../tokenAmount';
 import { PoolKind } from '../../types';
 import { Slippage } from '@/entities/slippage';
+import { AddLiquidityNestedBaseInput } from '../types';
 
-export type AddLiquidityNestedInputV2 = {
-    amountsIn: InputAmount[];
-    chainId: ChainId;
-    rpcUrl: string;
+export type AddLiquidityNestedInputV2 = AddLiquidityNestedBaseInput & {
     fromInternalBalance?: boolean;
 };
 

--- a/src/entities/addLiquidityNested/addLiquidityNestedV3/index.ts
+++ b/src/entities/addLiquidityNested/addLiquidityNestedV3/index.ts
@@ -14,9 +14,9 @@ import {
 import { Token } from '@/entities/token';
 import { getAmounts, getValue } from '@/entities/utils';
 import { TokenAmount } from '@/entities/tokenAmount';
-import { BALANCER_COMPOSITE_LIQUIDITY_ROUTER, CHAINS } from '@/utils';
+import { BALANCER_COMPOSITE_LIQUIDITY_ROUTER_NESTED, CHAINS } from '@/utils';
 import {
-    balancerCompositeLiquidityRouterAbi,
+    balancerCompositeLiquidityRouterNestedAbi,
     permit2Abi,
     vaultExtensionAbi_V3,
     vaultV3Abi,
@@ -70,7 +70,7 @@ export class AddLiquidityNestedV3 {
         const bptToken = new Token(input.chainId, parentPool.address, 18);
 
         return {
-            to: BALANCER_COMPOSITE_LIQUIDITY_ROUTER[input.chainId],
+            to: BALANCER_COMPOSITE_LIQUIDITY_ROUTER_NESTED[input.chainId],
             parentPool: parentPool.address,
             chainId: input.chainId,
             amountsIn: mainTokens.map((t, i) =>
@@ -90,7 +90,7 @@ export class AddLiquidityNestedV3 {
         const minBptOut = input.slippage.applyTo(input.bptOut.amount, -1);
         const wethIsEth = input.wethIsEth ?? false;
         const callData = encodeFunctionData({
-            abi: balancerCompositeLiquidityRouterAbi,
+            abi: balancerCompositeLiquidityRouterNestedAbi,
             functionName: 'addLiquidityUnbalancedNestedPool',
             args: [
                 input.parentPool,
@@ -103,7 +103,7 @@ export class AddLiquidityNestedV3 {
         });
         return {
             callData,
-            to: BALANCER_COMPOSITE_LIQUIDITY_ROUTER[input.chainId],
+            to: BALANCER_COMPOSITE_LIQUIDITY_ROUTER_NESTED[input.chainId],
             value: getValue(input.amountsIn, wethIsEth),
             minBptOut,
         };
@@ -124,7 +124,7 @@ export class AddLiquidityNestedV3 {
         ] as const;
 
         const callData = encodeFunctionData({
-            abi: balancerCompositeLiquidityRouterAbi,
+            abi: balancerCompositeLiquidityRouterNestedAbi,
             functionName: 'permitBatchAndCall',
             args,
         });
@@ -150,9 +150,9 @@ export class AddLiquidityNestedV3 {
         });
 
         const { result: bptAmountOut } = await client.simulateContract({
-            address: BALANCER_COMPOSITE_LIQUIDITY_ROUTER[chainId],
+            address: BALANCER_COMPOSITE_LIQUIDITY_ROUTER_NESTED[chainId],
             abi: [
-                ...balancerCompositeLiquidityRouterAbi,
+                ...balancerCompositeLiquidityRouterNestedAbi,
                 ...vaultV3Abi,
                 ...vaultExtensionAbi_V3,
                 ...permit2Abi,

--- a/src/entities/addLiquidityNested/addLiquidityNestedV3/types.ts
+++ b/src/entities/addLiquidityNested/addLiquidityNestedV3/types.ts
@@ -1,13 +1,11 @@
 import { Slippage } from '@/entities/slippage';
 import { TokenAmount } from '@/entities/tokenAmount';
-import { InputAmount } from '@/types';
 import { ChainId } from '@/utils';
 import { Address, Hex } from 'viem';
+import { AddLiquidityNestedBaseInput } from '../types';
 
-export type AddLiquidityNestedInputV3 = {
-    amountsIn: InputAmount[];
-    chainId: ChainId;
-    rpcUrl: string;
+export type AddLiquidityNestedInputV3 = AddLiquidityNestedBaseInput & {
+    wrapUnderlying?: boolean[];
     sender?: Address;
     userData?: Hex;
 };

--- a/src/entities/addLiquidityNested/addLiquidityNestedV3/types.ts
+++ b/src/entities/addLiquidityNested/addLiquidityNestedV3/types.ts
@@ -5,7 +5,6 @@ import { Address, Hex } from 'viem';
 import { AddLiquidityNestedBaseInput } from '../types';
 
 export type AddLiquidityNestedInputV3 = AddLiquidityNestedBaseInput & {
-    wrapUnderlying?: boolean[];
     sender?: Address;
     userData?: Hex;
 };

--- a/src/entities/addLiquidityNested/types.ts
+++ b/src/entities/addLiquidityNested/types.ts
@@ -9,6 +9,14 @@ import {
     AddLiquidityNestedInputV3,
     AddLiquidityNestedQueryOutputV3,
 } from './addLiquidityNestedV3/types';
+import { InputAmount } from '@/types';
+import { ChainId } from '@/utils';
+
+export type AddLiquidityNestedBaseInput = {
+    amountsIn: InputAmount[];
+    chainId: ChainId;
+    rpcUrl: string;
+};
 
 export type AddLiquidityNestedInput =
     | AddLiquidityNestedInputV2

--- a/src/entities/inputValidator/boosted/inputValidatorBoosted.ts
+++ b/src/entities/inputValidator/boosted/inputValidatorBoosted.ts
@@ -14,20 +14,22 @@ export class InputValidatorBoosted extends InputValidatorBase {
         }
 
         if (addLiquidityInput.kind === AddLiquidityKind.Unbalanced) {
-            // Child tokens are the lower most tokens of the pool, this will be the underlying token if it exists
-            const childTokens = poolState.tokens.map((t) => {
-                if (t.underlyingToken)
-                    return t.underlyingToken.address.toLowerCase();
-                return t.address.toLowerCase();
-            });
+            // List of all tokens that can be added to the pool
+            const poolTokens = poolState.tokens
+                .flatMap((token) => [
+                    token.address,
+                    token.underlyingToken?.address,
+                ])
+                .filter(Boolean);
+
             addLiquidityInput.amountsIn.forEach((a) => {
                 if (
-                    !childTokens.includes(
+                    !poolTokens.includes(
                         a.address.toLowerCase() as `0x${string}`,
                     )
                 ) {
                     throw new Error(
-                        `Address ${a.address} is not contained in the pool's child tokens.`,
+                        `Address ${a.address} is not contained in the pool's parent or child tokens.`,
                     );
                 }
             });

--- a/src/entities/inputValidator/boosted/inputValidatorBoosted.ts
+++ b/src/entities/inputValidator/boosted/inputValidatorBoosted.ts
@@ -3,6 +3,7 @@ import { PoolStateWithUnderlyings } from '@/entities/types';
 import { InputValidatorBase } from '../inputValidatorBase';
 import { AddLiquidityKind } from '@/entities/addLiquidity/types';
 import { AddLiquidityBoostedInput } from '@/entities/addLiquidityBoosted/types';
+import { isSameAddress } from '@/utils';
 
 export class InputValidatorBoosted extends InputValidatorBase {
     validateAddLiquidityBoosted(
@@ -30,6 +31,29 @@ export class InputValidatorBoosted extends InputValidatorBase {
                     );
                 }
             });
+        }
+
+        if (addLiquidityInput.kind === AddLiquidityKind.Proportional) {
+            // if referenceAmount is not the BPT, it must be included in tokensIn
+            if (
+                !isSameAddress(
+                    addLiquidityInput.referenceAmount.address,
+                    poolState.address,
+                )
+            ) {
+                if (
+                    addLiquidityInput.tokensIn.findIndex((tokenIn) =>
+                        isSameAddress(
+                            tokenIn,
+                            addLiquidityInput.referenceAmount.address,
+                        ),
+                    ) === -1
+                ) {
+                    throw new Error(
+                        'tokensIn must contain referenceAmount token address',
+                    );
+                }
+            }
         }
     }
 }

--- a/src/entities/inputValidator/boosted/inputValidatorBoosted.ts
+++ b/src/entities/inputValidator/boosted/inputValidatorBoosted.ts
@@ -1,3 +1,4 @@
+import { Address } from 'viem';
 import { PoolStateWithUnderlyings } from '@/entities/types';
 import { InputValidatorBase } from '../inputValidatorBase';
 import { AddLiquidityKind } from '@/entities/addLiquidity/types';
@@ -23,11 +24,7 @@ export class InputValidatorBoosted extends InputValidatorBase {
                 .filter(Boolean);
 
             addLiquidityInput.amountsIn.forEach((a) => {
-                if (
-                    !poolTokens.includes(
-                        a.address.toLowerCase() as `0x${string}`,
-                    )
-                ) {
+                if (!poolTokens.includes(a.address.toLowerCase() as Address)) {
                     throw new Error(
                         `Address ${a.address} is not contained in the pool's parent or child tokens.`,
                     );

--- a/src/entities/inputValidator/boosted/inputValidatorBoosted.ts
+++ b/src/entities/inputValidator/boosted/inputValidatorBoosted.ts
@@ -17,8 +17,8 @@ export class InputValidatorBoosted extends InputValidatorBase {
             // List of all tokens that can be added to the pool
             const poolTokens = poolState.tokens
                 .flatMap((token) => [
-                    token.address,
-                    token.underlyingToken?.address,
+                    token.address.toLowerCase(),
+                    token.underlyingToken?.address.toLowerCase(),
                 ])
                 .filter(Boolean);
 

--- a/src/entities/permit2Helper/index.ts
+++ b/src/entities/permit2Helper/index.ts
@@ -8,7 +8,8 @@ import {
 import {
     BALANCER_BATCH_ROUTER,
     BALANCER_BUFFER_ROUTER,
-    BALANCER_COMPOSITE_LIQUIDITY_ROUTER,
+    BALANCER_COMPOSITE_LIQUIDITY_ROUTER_NESTED,
+    BALANCER_COMPOSITE_LIQUIDITY_ROUTER_BOOSTED,
     BALANCER_ROUTER,
     ChainId,
     PERMIT2,
@@ -119,7 +120,8 @@ export class Permit2Helper {
             input.amountsIn.length,
         );
         const maxAmountsIn = input.amountsIn.map((a) => a.amount);
-        const spender = BALANCER_COMPOSITE_LIQUIDITY_ROUTER[input.chainId];
+        const spender =
+            BALANCER_COMPOSITE_LIQUIDITY_ROUTER_NESTED[input.chainId];
         const details: PermitDetails[] = [];
         for (let i = 0; i < input.amountsIn.length; i++) {
             details.push(
@@ -151,7 +153,8 @@ export class Permit2Helper {
             input.amountsIn.length,
         );
         const amounts = getAmountsCall(input);
-        const spender = BALANCER_COMPOSITE_LIQUIDITY_ROUTER[input.chainId];
+        const spender =
+            BALANCER_COMPOSITE_LIQUIDITY_ROUTER_BOOSTED[input.chainId];
         const details: PermitDetails[] = [];
 
         for (let i = 0; i < input.amountsIn.length; i++) {

--- a/src/entities/permitHelper/index.ts
+++ b/src/entities/permitHelper/index.ts
@@ -1,7 +1,8 @@
 import { weightedPoolAbi_V3 } from '@/abi';
 import { Hex } from '@/types';
 import {
-    BALANCER_COMPOSITE_LIQUIDITY_ROUTER,
+    BALANCER_COMPOSITE_LIQUIDITY_ROUTER_NESTED,
+    BALANCER_COMPOSITE_LIQUIDITY_ROUTER_BOOSTED,
     BALANCER_ROUTER,
     ChainId,
     MAX_UINT256,
@@ -80,7 +81,7 @@ export class PermitHelper {
             input.client,
             input.bptAmountIn.token.address,
             input.owner,
-            BALANCER_COMPOSITE_LIQUIDITY_ROUTER[input.chainId],
+            BALANCER_COMPOSITE_LIQUIDITY_ROUTER_NESTED[input.chainId],
             nonce,
             input.bptAmountIn.amount, // maxBptIn
             input.deadline,
@@ -108,7 +109,7 @@ export class PermitHelper {
             input.client,
             input.bptIn.token.address,
             input.owner,
-            BALANCER_COMPOSITE_LIQUIDITY_ROUTER[input.chainId],
+            BALANCER_COMPOSITE_LIQUIDITY_ROUTER_BOOSTED[input.chainId],
             nonce,
             amounts.maxBptAmountIn,
             input.deadline,

--- a/src/entities/priceImpact/addLiquidityNested.ts
+++ b/src/entities/priceImpact/addLiquidityNested.ts
@@ -134,7 +134,7 @@ async function getAddBoostedUnbalancedResult(
         rpcUrl,
         amountsIn,
         kind: AddLiquidityKind.Unbalanced,
-        wrapUnderlying: [true, true],
+        wrapUnderlying: [true, true], // TODO: Handle more elegantly?
     };
 
     const priceImpactAmount = await addLiquidityUnbalancedBoosted(

--- a/src/entities/priceImpact/addLiquidityNested.ts
+++ b/src/entities/priceImpact/addLiquidityNested.ts
@@ -64,14 +64,13 @@ export async function addLiquidityNested(
             });
         }
         let addResult: AddResult;
-        if (isBoostedPool && 'wrapUnderlying' in input && input.wrapUnderlying)
+        if (isBoostedPool)
             addResult = await getAddBoostedUnbalancedResult(
                 addLiquidityBoosted,
                 input.chainId,
                 input.rpcUrl,
                 pool as NestedPoolV3,
                 amountsIn,
-                input.wrapUnderlying,
             );
         else
             addResult = await getAddUnbalancedResult(
@@ -129,14 +128,12 @@ async function getAddBoostedUnbalancedResult(
     rpcUrl: string,
     pool: NestedPoolV3,
     amountsIn: InputAmount[],
-    wrapUnderlying: boolean[],
 ): Promise<AddResult> {
     const addLiquidityInput: AddLiquidityBoostedUnbalancedInput = {
         chainId,
         rpcUrl,
         amountsIn,
         kind: AddLiquidityKind.Unbalanced,
-        wrapUnderlying,
     };
 
     const priceImpactAmount = await addLiquidityUnbalancedBoosted(

--- a/src/entities/priceImpact/addLiquidityNested.ts
+++ b/src/entities/priceImpact/addLiquidityNested.ts
@@ -134,6 +134,7 @@ async function getAddBoostedUnbalancedResult(
         rpcUrl,
         amountsIn,
         kind: AddLiquidityKind.Unbalanced,
+        wrapUnderlying: [true, true],
     };
 
     const priceImpactAmount = await addLiquidityUnbalancedBoosted(

--- a/src/entities/priceImpact/addLiquidityNested.ts
+++ b/src/entities/priceImpact/addLiquidityNested.ts
@@ -64,13 +64,14 @@ export async function addLiquidityNested(
             });
         }
         let addResult: AddResult;
-        if (isBoostedPool)
+        if (isBoostedPool && 'wrapUnderlying' in input && input.wrapUnderlying)
             addResult = await getAddBoostedUnbalancedResult(
                 addLiquidityBoosted,
                 input.chainId,
                 input.rpcUrl,
                 pool as NestedPoolV3,
                 amountsIn,
+                input.wrapUnderlying,
             );
         else
             addResult = await getAddUnbalancedResult(
@@ -128,13 +129,14 @@ async function getAddBoostedUnbalancedResult(
     rpcUrl: string,
     pool: NestedPoolV3,
     amountsIn: InputAmount[],
+    wrapUnderlying: boolean[],
 ): Promise<AddResult> {
     const addLiquidityInput: AddLiquidityBoostedUnbalancedInput = {
         chainId,
         rpcUrl,
         amountsIn,
         kind: AddLiquidityKind.Unbalanced,
-        wrapUnderlying: [true, true], // TODO: Handle more elegantly?
+        wrapUnderlying,
     };
 
     const priceImpactAmount = await addLiquidityUnbalancedBoosted(

--- a/src/entities/priceImpact/addLiquidityUnbalancedBoosted.ts
+++ b/src/entities/priceImpact/addLiquidityUnbalancedBoosted.ts
@@ -66,6 +66,7 @@ export async function addLiquidityUnbalancedBoosted(
         chainId: input.chainId,
         rpcUrl: input.rpcUrl,
         bptIn: bptOut.toInputAmount(),
+        unwrapWrapped: input.wrapUnderlying,
         kind: RemoveLiquidityKind.Proportional,
     };
     const { amountsOut } = await removeLiquidity.query(

--- a/src/entities/priceImpact/addLiquidityUnbalancedBoosted.ts
+++ b/src/entities/priceImpact/addLiquidityUnbalancedBoosted.ts
@@ -66,7 +66,7 @@ export async function addLiquidityUnbalancedBoosted(
         chainId: input.chainId,
         rpcUrl: input.rpcUrl,
         bptIn: bptOut.toInputAmount(),
-        unwrapWrapped: input.wrapUnderlying,
+        tokensOut: poolTokens.map((t) => t.address),
         kind: RemoveLiquidityKind.Proportional,
     };
     const { amountsOut } = await removeLiquidity.query(

--- a/src/entities/removeLiquidityBoosted/doRemoveLiquidityProportionalQuery.ts
+++ b/src/entities/removeLiquidityBoosted/doRemoveLiquidityProportionalQuery.ts
@@ -21,7 +21,7 @@ export const doRemoveLiquidityProportionalQuery = async (
     poolAddress: Address,
     unwrapWrapped: boolean[],
     block?: bigint,
-): Promise<[`0x${string}`[], bigint[]]> => {
+): Promise<[Address[], bigint[]]> => {
     const client = createPublicClient({
         transport: http(rpcUrl),
         chain: CHAINS[chainId],

--- a/src/entities/removeLiquidityBoosted/doRemoveLiquidityProportionalQuery.ts
+++ b/src/entities/removeLiquidityBoosted/doRemoveLiquidityProportionalQuery.ts
@@ -1,7 +1,11 @@
 import { createPublicClient, Hex, http } from 'viem';
-import { BALANCER_COMPOSITE_LIQUIDITY_ROUTER, ChainId, CHAINS } from '@/utils';
+import {
+    BALANCER_COMPOSITE_LIQUIDITY_ROUTER_BOOSTED,
+    ChainId,
+    CHAINS,
+} from '@/utils';
 import { Address } from '@/types';
-import { balancerCompositeLiquidityRouterAbi } from '@/abi';
+import { balancerCompositeLiquidityRouterBoostedAbi } from '@/abi';
 
 export const doRemoveLiquidityProportionalQuery = async (
     rpcUrl: string,
@@ -10,6 +14,7 @@ export const doRemoveLiquidityProportionalQuery = async (
     sender: Address,
     userData: Hex,
     poolAddress: Address,
+    unwrapWrapped: boolean[],
     block?: bigint,
 ): Promise<bigint[]> => {
     const client = createPublicClient({
@@ -17,11 +22,13 @@ export const doRemoveLiquidityProportionalQuery = async (
         chain: CHAINS[chainId],
     });
 
-    const { result: underlyingAmountsOut } = await client.simulateContract({
-        address: BALANCER_COMPOSITE_LIQUIDITY_ROUTER[chainId],
-        abi: balancerCompositeLiquidityRouterAbi,
+    const {
+        result: [, underlyingAmountsOut],
+    } = await client.simulateContract({
+        address: BALANCER_COMPOSITE_LIQUIDITY_ROUTER_BOOSTED[chainId],
+        abi: balancerCompositeLiquidityRouterBoostedAbi,
         functionName: 'queryRemoveLiquidityProportionalFromERC4626Pool',
-        args: [poolAddress, exactBptAmountIn, sender, userData],
+        args: [poolAddress, unwrapWrapped, exactBptAmountIn, sender, userData],
         blockNumber: block,
     });
     // underlying amounts (not pool token amounts)

--- a/src/entities/removeLiquidityBoosted/types.ts
+++ b/src/entities/removeLiquidityBoosted/types.ts
@@ -8,6 +8,7 @@ export type RemoveLiquidityBoostedProportionalInput = {
     chainId: number;
     rpcUrl: string;
     bptIn: InputAmount;
+    unwrapWrapped: boolean[];
     kind: RemoveLiquidityKind.Proportional;
     sender?: Address;
     userData?: Hex;
@@ -17,6 +18,7 @@ export type RemoveLiquidityBoostedQueryOutput = {
     poolType: string;
     poolId: Address;
     removeLiquidityKind: RemoveLiquidityKind.Proportional;
+    unwrapWrapped: boolean[];
     bptIn: TokenAmount;
     amountsOut: TokenAmount[];
     protocolVersion: 3;
@@ -32,6 +34,7 @@ export type RemoveLiquidityBoostedBuildCallInput = {
     removeLiquidityKind: RemoveLiquidityKind.Proportional;
     bptIn: TokenAmount;
     amountsOut: TokenAmount[];
+    unwrapWrapped: boolean[];
     protocolVersion: 3;
     chainId: number;
     slippage: Slippage;

--- a/src/entities/removeLiquidityBoosted/types.ts
+++ b/src/entities/removeLiquidityBoosted/types.ts
@@ -8,7 +8,7 @@ export type RemoveLiquidityBoostedProportionalInput = {
     chainId: number;
     rpcUrl: string;
     bptIn: InputAmount;
-    unwrapWrapped: boolean[];
+    tokensOut: Address[];
     kind: RemoveLiquidityKind.Proportional;
     sender?: Address;
     userData?: Hex;

--- a/src/entities/removeLiquidityNested/index.ts
+++ b/src/entities/removeLiquidityNested/index.ts
@@ -10,7 +10,7 @@ import {
 import { RemoveLiquidityNestedV3 } from './removeLiquidityNestedV3';
 import { validateBuildCallInput } from './removeLiquidityNestedV2/validateInputs';
 import { Address, encodeFunctionData, Hex, zeroAddress } from 'viem';
-import { balancerCompositeLiquidityRouterAbi } from '@/abi';
+import { balancerCompositeLiquidityRouterNestedAbi } from '@/abi';
 
 export class RemoveLiquidityNested {
     async query(
@@ -66,7 +66,7 @@ export class RemoveLiquidityNested {
             [buildCallOutput.callData],
         ] as const;
         const callData = encodeFunctionData({
-            abi: balancerCompositeLiquidityRouterAbi,
+            abi: balancerCompositeLiquidityRouterNestedAbi,
             functionName: 'permitBatchAndCall',
             args,
         });

--- a/src/entities/removeLiquidityNested/removeLiquidityNestedV3/index.ts
+++ b/src/entities/removeLiquidityNested/removeLiquidityNestedV3/index.ts
@@ -13,9 +13,9 @@ import {
     RemoveLiquidityNestedQueryOutputV3,
 } from './types';
 import { RemoveLiquidityNestedBuildCallOutput } from '../types';
-import { BALANCER_COMPOSITE_LIQUIDITY_ROUTER, CHAINS } from '@/utils';
+import { BALANCER_COMPOSITE_LIQUIDITY_ROUTER_NESTED, CHAINS } from '@/utils';
 import {
-    balancerCompositeLiquidityRouterAbi,
+    balancerCompositeLiquidityRouterNestedAbi,
     permit2Abi,
     vaultExtensionAbi_V3,
     vaultV3Abi,
@@ -53,7 +53,7 @@ export class RemoveLiquidityNestedV3 {
             );
 
         return {
-            to: BALANCER_COMPOSITE_LIQUIDITY_ROUTER[input.chainId],
+            to: BALANCER_COMPOSITE_LIQUIDITY_ROUTER_NESTED[input.chainId],
             protocolVersion: 3,
             bptAmountIn: TokenAmount.fromRawAmount(bptToken, input.bptAmountIn),
             chainId: input.chainId,
@@ -79,7 +79,7 @@ export class RemoveLiquidityNestedV3 {
         );
 
         const callData = encodeFunctionData({
-            abi: balancerCompositeLiquidityRouterAbi,
+            abi: balancerCompositeLiquidityRouterNestedAbi,
             functionName: 'removeLiquidityProportionalNestedPool',
             args: [
                 input.parentPool,
@@ -92,7 +92,7 @@ export class RemoveLiquidityNestedV3 {
         });
         return {
             callData,
-            to: BALANCER_COMPOSITE_LIQUIDITY_ROUTER[input.chainId],
+            to: BALANCER_COMPOSITE_LIQUIDITY_ROUTER_NESTED[input.chainId],
             minAmountsOut,
         } as RemoveLiquidityNestedBuildCallOutput;
     }
@@ -112,9 +112,9 @@ export class RemoveLiquidityNestedV3 {
         });
 
         const { result: amountsOut } = await client.simulateContract({
-            address: BALANCER_COMPOSITE_LIQUIDITY_ROUTER[chainId],
+            address: BALANCER_COMPOSITE_LIQUIDITY_ROUTER_NESTED[chainId],
             abi: [
-                ...balancerCompositeLiquidityRouterAbi,
+                ...balancerCompositeLiquidityRouterNestedAbi,
                 ...vaultV3Abi,
                 ...vaultExtensionAbi_V3,
                 ...permit2Abi,

--- a/src/entities/utils/boostedPoolHelpers.ts
+++ b/src/entities/utils/boostedPoolHelpers.ts
@@ -7,9 +7,36 @@ export type MinimalTokenWithIsUnderlyingFlag = MinimalToken & {
 };
 
 /**
- * Builds map of pool tokens (including underlying ) with address as key
- * and token details as values like...
+ * Builds map of pool tokens (including underlying)
+ * with address as key and useful token details as values.
  *
+ * Example output:
+ * {
+ *   "0x8a88124522dbbf1e56352ba3de1d9f78c143751e": {
+ *     index: 0,
+ *     decimals: 6,
+ *     address: "0x8a88124522dbbf1e56352ba3de1d9f78c143751e",
+ *     isUnderlyingToken: false
+ *   },
+ *   "0x94a9d9ac8a22534e3faca9f4e7f2e2cf85d5e4c8": {
+ *     index: 0,
+ *     decimals: 6,
+ *     address: "0x94a9d9ac8a22534e3faca9f4e7f2e2cf85d5e4c8",
+ *     isUnderlyingToken: true
+ *   },
+ *   "0x978206fae13faf5a8d293fb614326b237684b750": {
+ *     index: 1,
+ *     decimals: 6,
+ *     address: "0x978206fae13faf5a8d293fb614326b237684b750",
+ *     isUnderlyingToken: false
+ *   },
+ *   "0xaa8e23fb1079ea71e0a56f48a2aa51851d8433d0": {
+ *     index: 1,
+ *     decimals: 6,
+ *     address: "0xaa8e23fb1079ea71e0a56f48a2aa51851d8433d0",
+ *     isUnderlyingToken: true
+ *   }
+ * }
  */
 export function buildPoolStateTokenMap(
     poolState: PoolStateWithUnderlyings,

--- a/src/entities/utils/boostedPoolHelpers.ts
+++ b/src/entities/utils/boostedPoolHelpers.ts
@@ -1,0 +1,38 @@
+import { MinimalToken } from '@/data/types';
+import { PoolStateWithUnderlyings } from '@/entities/types';
+import { Address } from 'viem';
+
+export type MinimalTokenWithIsUnderlyingFlag = MinimalToken & {
+    isUnderlyingToken: boolean;
+};
+
+/**
+ * Builds map of pool tokens (including underlying ) with address as key
+ * and token details as values like...
+ *
+ */
+export function buildPoolStateTokenMap(
+    poolState: PoolStateWithUnderlyings,
+): Record<Address, MinimalTokenWithIsUnderlyingFlag> {
+    const map: Record<Address, MinimalTokenWithIsUnderlyingFlag> = {};
+
+    poolState.tokens.forEach((t) => {
+        const underlyingToken = t.underlyingToken;
+        map[t.address.toLowerCase()] = {
+            index: t.index,
+            decimals: t.decimals,
+            address: t.address,
+            isUnderlyingToken: false,
+        };
+        if (underlyingToken) {
+            map[underlyingToken.address.toLowerCase()] = {
+                index: underlyingToken.index,
+                decimals: underlyingToken.decimals,
+                address: underlyingToken.address,
+                isUnderlyingToken: true,
+            };
+        }
+    });
+
+    return map;
+}

--- a/src/entities/utils/index.ts
+++ b/src/entities/utils/index.ts
@@ -10,3 +10,4 @@ export * from './parseInitializeArgs';
 export * from './proportionalAmountsHelpers';
 export * from './replaceWrapped';
 export * from './validateNestedPoolState';
+export * from './boostedPoolHelpers';

--- a/src/entities/utils/proportionalAmountsHelpers.ts
+++ b/src/entities/utils/proportionalAmountsHelpers.ts
@@ -146,6 +146,7 @@ export const getBptAmountFromReferenceAmount = async (
 export const getBptAmountFromReferenceAmountBoosted = async (
     input: AddLiquidityBoostedProportionalInput,
     poolStateWithUnderlyings: PoolStateWithUnderlyings,
+    wrapUnderlying: boolean[],
 ): Promise<InputAmount> => {
     let bptAmount: InputAmount;
     if (
@@ -166,7 +167,7 @@ export const getBptAmountFromReferenceAmountBoosted = async (
         ({ bptAmount } = calculateProportionalAmountsBoosted(
             poolStateWithUnderlyingBalances,
             input.referenceAmount,
-            input.wrapUnderlying,
+            wrapUnderlying,
         ));
     }
     return bptAmount;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -254,13 +254,23 @@ export const BALANCER_BATCH_ROUTER: Record<number, Address> = {
     [ChainId.BASE]: '0x85a80afee867aDf27B50BdB7b76DA70f1E853062',
 };
 
-export const BALANCER_COMPOSITE_LIQUIDITY_ROUTER: Record<number, Address> = {
+export const BALANCER_COMPOSITE_LIQUIDITY_ROUTER_NESTED: Record<
+    number,
+    Address
+> = {
     [ChainId.SEPOLIA]: '0xc6674C0c7694E9b990eAc939E74F8cc3DD39B4b0',
     [ChainId.MAINNET]: '0x1CD776897ef4f647bf8241Ec69549e4A9cb1D608',
     [ChainId.GNOSIS_CHAIN]: '0xC1A64500E035D9159C8826E982dFb802003227f0',
     [ChainId.SONIC]: '0xcf21664262774eBB2C2b559e13b47F6cA10F3E65',
     [ChainId.ARBITRUM_ONE]: '0x1311Fbc9F60359639174c1e7cC2032DbDb5Cc4d1',
     [ChainId.BASE]: '0xf23b4DB826DbA14c0e857029dfF076b1c0264843',
+};
+
+export const BALANCER_COMPOSITE_LIQUIDITY_ROUTER_BOOSTED: Record<
+    number,
+    Address
+> = {
+    [ChainId.SEPOLIA]: '0x6A20a4b6DcFF78e6D21BF0dbFfD58C96644DB9cb',
 };
 
 export const BALANCER_BUFFER_ROUTER: Record<number, Address> = {

--- a/test/anvil/anvil-global-setup.ts
+++ b/test/anvil/anvil-global-setup.ts
@@ -66,7 +66,7 @@ export const ANVIL_NETWORKS: Record<NetworksWithFork, NetworkSetup> = {
         rpcEnv: 'SEPOLIA_RPC_URL',
         fallBackRpc: 'https://sepolia.gateway.tenderly.co',
         port: ANVIL_PORTS.SEPOLIA,
-        forkBlockNumber: 7245070n,
+        forkBlockNumber: 7562540n,
     },
     OPTIMISM: {
         rpcEnv: 'OPTIMISM_RPC_URL',

--- a/test/lib/utils/addLiquidityBoostedHelper.ts
+++ b/test/lib/utils/addLiquidityBoostedHelper.ts
@@ -11,7 +11,7 @@ import {
     TokenAmount,
 } from '@/entities';
 import {
-    BALANCER_COMPOSITE_LIQUIDITY_ROUTER,
+    BALANCER_COMPOSITE_LIQUIDITY_ROUTER_BOOSTED,
     ChainId,
     NATIVE_ASSETS,
     PERMIT2,
@@ -38,6 +38,7 @@ export async function GetBoostedBpt(
         decimals: number;
         slot: number;
     }[],
+    wrapUnderlying: boolean[],
 ): Promise<bigint> {
     await setTokenBalances(
         client,
@@ -49,6 +50,7 @@ export async function GetBoostedBpt(
 
     const addLiquidityInput: AddLiquidityBoostedUnbalancedInput = {
         amountsIn,
+        wrapUnderlying,
         chainId,
         rpcUrl,
         kind: AddLiquidityKind.Unbalanced,
@@ -69,7 +71,7 @@ export async function GetBoostedBpt(
             client,
             testAddress,
             amount.address,
-            BALANCER_COMPOSITE_LIQUIDITY_ROUTER[chainId],
+            BALANCER_COMPOSITE_LIQUIDITY_ROUTER_BOOSTED[chainId],
         );
     }
 
@@ -114,7 +116,7 @@ export async function GetBoostedBpt(
             client,
             testAddress,
             amount.address,
-            BALANCER_COMPOSITE_LIQUIDITY_ROUTER[chainId],
+            BALANCER_COMPOSITE_LIQUIDITY_ROUTER_BOOSTED[chainId],
             0n,
         );
     }
@@ -232,7 +234,7 @@ export const assertAddLiquidityBoostedUnbalanced = (
 
     expect(protocolVersion).toEqual(3);
     expect(bptOut.amount > 0n).to.be.true;
-    expect(to).to.eq(BALANCER_COMPOSITE_LIQUIDITY_ROUTER[chainId]);
+    expect(to).to.eq(BALANCER_COMPOSITE_LIQUIDITY_ROUTER_BOOSTED[chainId]);
     expect(transactionReceipt.status).to.eq('success');
 
     // add one extra index for native token balance
@@ -279,7 +281,7 @@ export const assertAddLiquidityBoostedProportional = (
 
     expect(protocolVersion).toEqual(3);
     expect(bptOut.amount > 0n).to.be.true;
-    expect(to).to.eq(BALANCER_COMPOSITE_LIQUIDITY_ROUTER[chainId]);
+    expect(to).to.eq(BALANCER_COMPOSITE_LIQUIDITY_ROUTER_BOOSTED[chainId]);
     expect(transactionReceipt.status).to.eq('success');
 
     // add one extra index for native token balance

--- a/test/lib/utils/addLiquidityBoostedHelper.ts
+++ b/test/lib/utils/addLiquidityBoostedHelper.ts
@@ -38,7 +38,6 @@ export async function GetBoostedBpt(
         decimals: number;
         slot: number;
     }[],
-    wrapUnderlying: boolean[],
 ): Promise<bigint> {
     await setTokenBalances(
         client,
@@ -50,7 +49,6 @@ export async function GetBoostedBpt(
 
     const addLiquidityInput: AddLiquidityBoostedUnbalancedInput = {
         amountsIn,
-        wrapUnderlying,
         chainId,
         rpcUrl,
         kind: AddLiquidityKind.Unbalanced,

--- a/test/lib/utils/helper.ts
+++ b/test/lib/utils/helper.ts
@@ -25,7 +25,7 @@ import {
     PERMIT2,
     BALANCER_ROUTER,
     BALANCER_BATCH_ROUTER,
-    BALANCER_COMPOSITE_LIQUIDITY_ROUTER,
+    BALANCER_COMPOSITE_LIQUIDITY_ROUTER_NESTED,
     PublicWalletClient,
     BALANCER_BUFFER_ROUTER,
 } from '@/utils';
@@ -129,7 +129,7 @@ export const approveToken = async (
                     client,
                     accountAddress,
                     tokenAddress,
-                    BALANCER_COMPOSITE_LIQUIDITY_ROUTER[chainId],
+                    BALANCER_COMPOSITE_LIQUIDITY_ROUTER_NESTED[chainId],
                     amount,
                     deadline,
                 );
@@ -331,9 +331,9 @@ export async function sendTransactionGetBalances(
     // TODO - Leave this in as useful as basis for manual debug
     // await client.simulateContract({
     //     address:
-    //         BALANCER_COMPOSITE_LIQUIDITY_ROUTER[client.chain?.id as number],
+    //         BALANCER_COMPOSITE_LIQUIDITY_ROUTER_NESTED[client.chain?.id as number],
     //     abi: [
-    //         ...balancerCompositeLiquidityRouterAbi,
+    //         ...balancerCompositeLiquidityRouterNestedAbi,
     //         ...vaultV3Abi,
     //         ...vaultExtensionAbi_V3,
     //         ...permit2Abi,

--- a/test/lib/utils/removeLiquidityNestedHelper.ts
+++ b/test/lib/utils/removeLiquidityNestedHelper.ts
@@ -14,7 +14,7 @@ import {
     TokenAmount,
 } from '@/entities';
 import {
-    BALANCER_COMPOSITE_LIQUIDITY_ROUTER,
+    BALANCER_COMPOSITE_LIQUIDITY_ROUTER_NESTED,
     ChainId,
     NATIVE_ASSETS,
     PERMIT2,
@@ -71,7 +71,7 @@ export async function GetNestedBpt(
             client,
             testAddress,
             amount.address,
-            BALANCER_COMPOSITE_LIQUIDITY_ROUTER[chainId],
+            BALANCER_COMPOSITE_LIQUIDITY_ROUTER_NESTED[chainId],
         );
     }
 
@@ -116,7 +116,7 @@ export async function GetNestedBpt(
             client,
             testAddress,
             amount.address,
-            BALANCER_COMPOSITE_LIQUIDITY_ROUTER[chainId],
+            BALANCER_COMPOSITE_LIQUIDITY_ROUTER_NESTED[chainId],
             0n,
         );
     }
@@ -280,7 +280,7 @@ export const assertRemoveLiquidityNested = (
     expect(expectedMinAmountsOut).to.deep.eq(
         minAmountsOut.map((a) => a.amount),
     );
-    expect(to).to.eq(BALANCER_COMPOSITE_LIQUIDITY_ROUTER[chainId]);
+    expect(to).to.eq(BALANCER_COMPOSITE_LIQUIDITY_ROUTER_NESTED[chainId]);
 
     expect(transactionReceipt.status).to.eq('success');
 

--- a/test/lib/utils/types.ts
+++ b/test/lib/utils/types.ts
@@ -13,11 +13,12 @@ import {
     RemoveLiquidity,
     Slippage,
     RemoveLiquidityRecoveryInput,
+    AddLiquidityBoostedV3,
 } from '@/.';
 
 export type AddLiquidityTxInput = {
     client: PublicWalletClient & TestActions;
-    addLiquidity: AddLiquidity;
+    addLiquidity: AddLiquidity | AddLiquidityBoostedV3;
     addLiquidityInput: AddLiquidityInput;
     slippage: Slippage;
     poolState: PoolState;

--- a/test/v3/addLiquidityBoosted/addLiquidityBoosted.integration.test.ts
+++ b/test/v3/addLiquidityBoosted/addLiquidityBoosted.integration.test.ts
@@ -126,6 +126,33 @@ describe('Boosted AddLiquidity', () => {
         snapshot = await client.snapshot();
     });
 
+    test('query returns correct token addresses', async () => {
+        const referenceAmount = {
+            rawAmount: 481201n,
+            decimals: 6,
+            address: USDC.address,
+        };
+        const wrapUnderlying = [true, false];
+
+        const addLiquidityBoostedInput: AddLiquidityBoostedProportionalInput = {
+            chainId,
+            rpcUrl,
+            referenceAmount,
+            wrapUnderlying,
+            kind: AddLiquidityKind.Proportional,
+        };
+
+        const addLiquidityQueryOutput = await addLiquidityBoosted.query(
+            addLiquidityBoostedInput,
+            boostedPool_USDC_USDT,
+        );
+
+        const amountsIn = addLiquidityQueryOutput.amountsIn;
+
+        expect(amountsIn[0].token.address).to.eq(usdcToken.address);
+        expect(amountsIn[1].token.address).to.eq(stataUSDT.address);
+    });
+
     describe('permit 2 direct approval', () => {
         beforeEach(async () => {
             // Here we approve the Vault to spend tokens on the users behalf via Permit2
@@ -378,34 +405,6 @@ describe('Boosted AddLiquidity', () => {
                     wethIsEth,
                 );
             });
-        });
-
-        test('query returns correct tokens', async () => {
-            const referenceAmount = {
-                rawAmount: 481201n,
-                decimals: 6,
-                address: USDC.address,
-            };
-            const wrapUnderlying = [true, false];
-
-            const addLiquidityBoostedInput: AddLiquidityBoostedProportionalInput =
-                {
-                    chainId,
-                    rpcUrl,
-                    referenceAmount,
-                    wrapUnderlying,
-                    kind: AddLiquidityKind.Proportional,
-                };
-
-            const addLiquidityQueryOutput = await addLiquidityBoosted.query(
-                addLiquidityBoostedInput,
-                boostedPool_USDC_USDT,
-            );
-
-            const amountsIn = addLiquidityQueryOutput.amountsIn;
-
-            expect(amountsIn[0].token.address).to.eq(usdcToken.address);
-            expect(amountsIn[1].token.address).to.eq(stataUSDT.address);
         });
     });
 

--- a/test/v3/addLiquidityBoosted/addLiquidityBoosted.integration.test.ts
+++ b/test/v3/addLiquidityBoosted/addLiquidityBoosted.integration.test.ts
@@ -69,6 +69,7 @@ describe('Boosted AddLiquidity', () => {
     let testAddress: Address;
     const addLiquidityBoosted = new AddLiquidityBoostedV3();
 
+    // for unbalanced inputs
     const amountsInForSingleWrap = [
         TokenAmount.fromHumanAmount(usdcToken, '1'),
         TokenAmount.fromHumanAmount(stataUsdtToken, '2'),
@@ -77,7 +78,6 @@ describe('Boosted AddLiquidity', () => {
         rawAmount: a.amount,
         decimals: a.token.decimals,
     }));
-
     const amountsInForDoubleWrap = [
         TokenAmount.fromHumanAmount(usdcToken, '1'),
         TokenAmount.fromHumanAmount(usdtToken, '1'),
@@ -87,6 +87,7 @@ describe('Boosted AddLiquidity', () => {
         decimals: a.token.decimals,
     }));
 
+    // for proportional inputs
     const tokensInForSingleWrap = [USDC.address, stataUSDT.address];
     const tokensInForDoubleWrap = [USDC.address, USDT.address];
 

--- a/test/v3/addLiquidityBoosted/addLiquidityBoosted.integration.test.ts
+++ b/test/v3/addLiquidityBoosted/addLiquidityBoosted.integration.test.ts
@@ -40,8 +40,6 @@ import {
 import { ANVIL_NETWORKS, startFork } from '../../anvil/anvil-global-setup';
 import { boostedPool_USDC_USDT } from 'test/mockData/boostedPool';
 
-// const protocolVersion = 3;
-
 const chainId = ChainId.SEPOLIA;
 const USDC = TOKENS[chainId].USDC_AAVE;
 const USDT = TOKENS[chainId].USDT_AAVE;
@@ -55,11 +53,7 @@ describe('Boosted AddLiquidity', () => {
     const addLiquidityBoosted = new AddLiquidityBoostedV3();
 
     beforeAll(async () => {
-        ({ rpcUrl } = await startFork(
-            ANVIL_NETWORKS[ChainId[chainId]],
-            undefined,
-            7562540n, // block after new composite liquidity router deployed
-        ));
+        ({ rpcUrl } = await startFork(ANVIL_NETWORKS[ChainId[chainId]]));
 
         client = createTestClient({
             mode: 'anvil',

--- a/test/v3/addLiquidityBoosted/addLiquidityBoosted.integration.test.ts
+++ b/test/v3/addLiquidityBoosted/addLiquidityBoosted.integration.test.ts
@@ -87,6 +87,9 @@ describe('Boosted AddLiquidity', () => {
         decimals: a.token.decimals,
     }));
 
+    const tokensInForSingleWrap = [USDC.address, stataUSDT.address];
+    const tokensInForDoubleWrap = [USDC.address, USDT.address];
+
     beforeAll(async () => {
         ({ rpcUrl } = await startFork(ANVIL_NETWORKS[ChainId[chainId]]));
 
@@ -147,13 +150,11 @@ describe('Boosted AddLiquidity', () => {
 
     describe('query', () => {
         test('unbalanced returns correct tokens', async () => {
-            const wrapUnderlying = [true, false];
             const addLiquidityBoostedInput: AddLiquidityBoostedUnbalancedInput =
                 {
                     chainId,
                     rpcUrl,
                     amountsIn: amountsInForSingleWrap,
-                    wrapUnderlying,
                     kind: AddLiquidityKind.Unbalanced,
                 };
 
@@ -169,7 +170,6 @@ describe('Boosted AddLiquidity', () => {
         });
 
         test('proportional returns correct tokens', async () => {
-            const wrapUnderlying = [true, false];
             const referenceAmount = {
                 rawAmount: 481201n,
                 decimals: 6,
@@ -181,7 +181,7 @@ describe('Boosted AddLiquidity', () => {
                     chainId,
                     rpcUrl,
                     referenceAmount,
-                    wrapUnderlying,
+                    tokensIn: tokensInForSingleWrap,
                     kind: AddLiquidityKind.Proportional,
                 };
 
@@ -220,14 +220,12 @@ describe('Boosted AddLiquidity', () => {
         });
         describe('unbalanced', () => {
             test('with both underlying tokens wrapped', async () => {
-                const wrapUnderlying = [true, true];
                 const wethIsEth = false;
                 const addLiquidityBoostedInput: AddLiquidityBoostedUnbalancedInput =
                     {
                         chainId,
                         rpcUrl,
                         amountsIn: amountsInForDoubleWrap,
-                        wrapUnderlying,
                         kind: AddLiquidityKind.Unbalanced,
                     };
 
@@ -260,14 +258,12 @@ describe('Boosted AddLiquidity', () => {
             });
 
             test('with only one underlying token wrapped', async () => {
-                const wrapUnderlying = [true, false];
                 const wethIsEth = false;
                 const addLiquidityBoostedInput: AddLiquidityBoostedUnbalancedInput =
                     {
                         chainId,
                         rpcUrl,
                         amountsIn: amountsInForSingleWrap,
-                        wrapUnderlying,
                         kind: AddLiquidityKind.Unbalanced,
                     };
 
@@ -306,7 +302,6 @@ describe('Boosted AddLiquidity', () => {
                     decimals: 18,
                     address: boostedPool_USDC_USDT.address,
                 };
-                const wrapUnderlying = [true, true];
                 const wethIsEth = false;
 
                 const addLiquidityBoostedInput: AddLiquidityBoostedProportionalInput =
@@ -314,7 +309,7 @@ describe('Boosted AddLiquidity', () => {
                         chainId,
                         rpcUrl,
                         referenceAmount,
-                        wrapUnderlying,
+                        tokensIn: tokensInForDoubleWrap,
                         kind: AddLiquidityKind.Proportional,
                     };
 
@@ -351,7 +346,6 @@ describe('Boosted AddLiquidity', () => {
                     decimals: 6,
                     address: USDC.address,
                 };
-                const wrapUnderlying = [true, true];
                 const wethIsEth = false;
 
                 const addLiquidityBoostedInput: AddLiquidityBoostedProportionalInput =
@@ -359,9 +353,10 @@ describe('Boosted AddLiquidity', () => {
                         chainId,
                         rpcUrl,
                         referenceAmount,
-                        wrapUnderlying,
+                        tokensIn: tokensInForDoubleWrap,
                         kind: AddLiquidityKind.Proportional,
                     };
+
                 const txInput: AddLiquidityBoostedTxInput = {
                     client,
                     addLiquidityBoosted,
@@ -396,7 +391,6 @@ describe('Boosted AddLiquidity', () => {
                     decimals: 6,
                     address: USDC.address,
                 };
-                const wrapUnderlying = [true, false];
                 const wethIsEth = false;
 
                 const addLiquidityBoostedInput: AddLiquidityBoostedProportionalInput =
@@ -404,7 +398,7 @@ describe('Boosted AddLiquidity', () => {
                         chainId,
                         rpcUrl,
                         referenceAmount,
-                        wrapUnderlying,
+                        tokensIn: tokensInForSingleWrap,
                         kind: AddLiquidityKind.Proportional,
                     };
                 const txInput: AddLiquidityBoostedTxInput = {
@@ -444,7 +438,6 @@ describe('Boosted AddLiquidity', () => {
                     chainId,
                     rpcUrl,
                     amountsIn: amountsInForDoubleWrap,
-                    wrapUnderlying: [true, true],
                     kind: AddLiquidityKind.Unbalanced,
                 };
 
@@ -515,7 +508,7 @@ describe('Boosted AddLiquidity', () => {
                             decimals: 18,
                             address: boostedPool_USDC_USDT.address,
                         },
-                        wrapUnderlying: [true, true],
+                        tokensIn: tokensInForDoubleWrap,
                         kind: AddLiquidityKind.Proportional,
                     };
 

--- a/test/v3/addLiquidityBoosted/addLiquidityBoosted.integration.test.ts
+++ b/test/v3/addLiquidityBoosted/addLiquidityBoosted.integration.test.ts
@@ -107,7 +107,7 @@ describe('Boosted AddLiquidity', () => {
         await setTokenBalances(
             client,
             testAddress,
-            [USDT.address, USDC.address] as Address[],
+            [USDT.address, USDC.address],
             [USDT.slot, USDC.slot] as number[],
             [
                 parseUnits('1000', USDT.decimals),
@@ -135,7 +135,7 @@ describe('Boosted AddLiquidity', () => {
         await approveSpenderOnTokens(
             client,
             testAddress,
-            [USDT.address, USDC.address, stataUSDT.address] as Address[],
+            [USDT.address, USDC.address, stataUSDT.address],
             PERMIT2[chainId],
         );
 
@@ -508,8 +508,8 @@ describe('Boosted AddLiquidity', () => {
                     await sendTransactionGetBalances(
                         [
                             addLiquidityQueryOutput.bptOut.token.address,
-                            USDC.address as `0x${string}`,
-                            USDT.address as `0x${string}`,
+                            USDC.address,
+                            USDT.address,
                         ],
                         client,
                         testAddress,
@@ -570,7 +570,7 @@ describe('Boosted AddLiquidity', () => {
                     });
 
                 const addLiquidityBuildCallOutput =
-                    await addLiquidityBoosted.buildCallWithPermit2(
+                    addLiquidityBoosted.buildCallWithPermit2(
                         addLiquidityBuildInput,
                         permit2,
                     );
@@ -579,8 +579,8 @@ describe('Boosted AddLiquidity', () => {
                     await sendTransactionGetBalances(
                         [
                             addLiquidityQueryOutput.bptOut.token.address,
-                            USDC.address as `0x${string}`,
-                            USDT.address as `0x${string}`,
+                            USDC.address,
+                            USDT.address,
                         ],
                         client,
                         testAddress,
@@ -618,16 +618,8 @@ describe('Boosted AddLiquidity', () => {
                 // make sure to pass Tokens in correct order. Same as poolTokens but as underlyings instead
                 assertTokenMatch(
                     [
-                        new Token(
-                            111555111,
-                            USDC.address as Address,
-                            USDC.decimals,
-                        ),
-                        new Token(
-                            111555111,
-                            USDT.address as Address,
-                            USDT.decimals,
-                        ),
+                        new Token(111555111, USDC.address, USDC.decimals),
+                        new Token(111555111, USDT.address, USDT.decimals),
                     ],
                     addLiquidityBuildCallOutput.maxAmountsIn.map(
                         (a) => a.token,

--- a/test/v3/addLiquidityBoosted/addLiquidityBoosted.integration.test.ts
+++ b/test/v3/addLiquidityBoosted/addLiquidityBoosted.integration.test.ts
@@ -219,6 +219,44 @@ describe('Boosted AddLiquidity', () => {
             }
         });
         describe('unbalanced', () => {
+            test('with only one token', async () => {
+                const wethIsEth = false;
+                const addLiquidityBoostedInput: AddLiquidityBoostedUnbalancedInput =
+                    {
+                        chainId,
+                        rpcUrl,
+                        amountsIn: [amountsInForDoubleWrap[0]],
+                        kind: AddLiquidityKind.Unbalanced,
+                    };
+
+                const txInput: AddLiquidityBoostedTxInput = {
+                    client,
+                    addLiquidityBoosted,
+                    addLiquidityBoostedInput,
+                    testAddress,
+                    poolStateWithUnderlyings: boostedPool_USDC_USDT,
+                    slippage: Slippage.fromPercentage('1'),
+                    wethIsEth,
+                };
+
+                const {
+                    addLiquidityBoostedQueryOutput,
+                    addLiquidityBuildCallOutput,
+                    tokenAmountsForBalanceCheck,
+                    txOutput,
+                } = await doAddLiquidityBoosted(txInput);
+
+                assertAddLiquidityBoostedUnbalanced(
+                    {
+                        addLiquidityBoostedQueryOutput,
+                        addLiquidityBuildCallOutput,
+                        tokenAmountsForBalanceCheck,
+                        txOutput,
+                    },
+                    wethIsEth,
+                );
+            });
+
             test('with both underlying tokens wrapped', async () => {
                 const wethIsEth = false;
                 const addLiquidityBoostedInput: AddLiquidityBoostedUnbalancedInput =
@@ -295,6 +333,7 @@ describe('Boosted AddLiquidity', () => {
                 );
             });
         });
+
         describe('proportional', () => {
             test('with bpt as reference token', async () => {
                 const referenceAmount = {

--- a/test/v3/addLiquidityBoosted/addLiquidityPartialBoosted.integration.test.ts
+++ b/test/v3/addLiquidityBoosted/addLiquidityPartialBoosted.integration.test.ts
@@ -124,7 +124,47 @@ describe('V3 add liquidity partial boosted', () => {
             };
         });
 
-        test('with tokens', async () => {
+        test('with only one token', async () => {
+            const wethIsEth = false;
+
+            const txInput: AddLiquidityBoostedTxInput = {
+                client,
+                addLiquidityBoosted,
+                addLiquidityBoostedInput: {
+                    ...addLiquidityBoostedInput,
+                    amountsIn: [
+                        {
+                            address: amountsIn[1].token.address,
+                            rawAmount: amountsIn[1].amount,
+                            decimals: amountsIn[1].token.decimals,
+                        },
+                    ],
+                },
+                testAddress,
+                poolStateWithUnderlyings: partialBoostedPool_WETH_stataUSDT,
+                slippage: Slippage.fromPercentage('1'),
+                wethIsEth,
+            };
+
+            const {
+                addLiquidityBoostedQueryOutput,
+                addLiquidityBuildCallOutput,
+                tokenAmountsForBalanceCheck,
+                txOutput,
+            } = await doAddLiquidityBoosted(txInput);
+
+            assertAddLiquidityBoostedUnbalanced(
+                {
+                    addLiquidityBoostedQueryOutput,
+                    addLiquidityBuildCallOutput,
+                    tokenAmountsForBalanceCheck,
+                    txOutput,
+                },
+                wethIsEth,
+            );
+        });
+
+        test('with two tokens', async () => {
             const wethIsEth = false;
 
             const txInput: AddLiquidityBoostedTxInput = {

--- a/test/v3/addLiquidityBoosted/addLiquidityPartialBoosted.integration.test.ts
+++ b/test/v3/addLiquidityBoosted/addLiquidityPartialBoosted.integration.test.ts
@@ -13,7 +13,7 @@ import {
 } from 'viem';
 import {
     Address,
-    BALANCER_COMPOSITE_LIQUIDITY_ROUTER,
+    BALANCER_COMPOSITE_LIQUIDITY_ROUTER_BOOSTED,
     CHAINS,
     ChainId,
     PERMIT2,
@@ -57,10 +57,15 @@ describe('V3 add liquidity partial boosted', () => {
         TokenAmount.fromHumanAmount(usdtToken, '1'),
         TokenAmount.fromHumanAmount(wethToken, '0.02'),
     ];
+    const wrapUnderlying = [false, true]; // order must match on-chain state for pool tokens
 
     beforeAll(async () => {
         // setup chain and test client
-        ({ rpcUrl } = await startFork(ANVIL_NETWORKS.SEPOLIA));
+        ({ rpcUrl } = await startFork(
+            ANVIL_NETWORKS[ChainId[chainId]],
+            undefined,
+            7562550n, // block after new composite liquidity router deployed
+        ));
 
         client = createTestClient({
             mode: 'anvil',
@@ -94,7 +99,7 @@ describe('V3 add liquidity partial boosted', () => {
                 client,
                 testAddress,
                 token.underlyingToken?.address ?? token.address,
-                BALANCER_COMPOSITE_LIQUIDITY_ROUTER[chainId],
+                BALANCER_COMPOSITE_LIQUIDITY_ROUTER_BOOSTED[chainId],
             );
         }
 
@@ -118,6 +123,7 @@ describe('V3 add liquidity partial boosted', () => {
                     rawAmount: a.amount,
                     decimals: a.token.decimals,
                 })),
+                wrapUnderlying,
                 chainId,
                 rpcUrl,
                 kind: AddLiquidityKind.Unbalanced,
@@ -198,6 +204,7 @@ describe('V3 add liquidity partial boosted', () => {
                     rawAmount: referenceTokenAmount.amount,
                     decimals: referenceTokenAmount.token.decimals,
                 },
+                wrapUnderlying,
                 chainId,
                 rpcUrl,
                 kind: AddLiquidityKind.Proportional,

--- a/test/v3/addLiquidityBoosted/addLiquidityPartialBoosted.integration.test.ts
+++ b/test/v3/addLiquidityBoosted/addLiquidityPartialBoosted.integration.test.ts
@@ -61,11 +61,7 @@ describe('V3 add liquidity partial boosted', () => {
 
     beforeAll(async () => {
         // setup chain and test client
-        ({ rpcUrl } = await startFork(
-            ANVIL_NETWORKS[ChainId[chainId]],
-            undefined,
-            7562550n, // block after new composite liquidity router deployed
-        ));
+        ({ rpcUrl } = await startFork(ANVIL_NETWORKS[ChainId[chainId]]));
 
         client = createTestClient({
             mode: 'anvil',

--- a/test/v3/addLiquidityBoosted/addLiquidityPartialBoosted.integration.test.ts
+++ b/test/v3/addLiquidityBoosted/addLiquidityPartialBoosted.integration.test.ts
@@ -57,7 +57,6 @@ describe('V3 add liquidity partial boosted', () => {
         TokenAmount.fromHumanAmount(usdtToken, '1'),
         TokenAmount.fromHumanAmount(wethToken, '0.02'),
     ];
-    const wrapUnderlying = [false, true]; // order must match on-chain state for pool tokens
 
     beforeAll(async () => {
         // setup chain and test client
@@ -119,7 +118,6 @@ describe('V3 add liquidity partial boosted', () => {
                     rawAmount: a.amount,
                     decimals: a.token.decimals,
                 })),
-                wrapUnderlying,
                 chainId,
                 rpcUrl,
                 kind: AddLiquidityKind.Unbalanced,
@@ -200,16 +198,15 @@ describe('V3 add liquidity partial boosted', () => {
                     rawAmount: referenceTokenAmount.amount,
                     decimals: referenceTokenAmount.token.decimals,
                 },
-                wrapUnderlying,
                 chainId,
                 rpcUrl,
                 kind: AddLiquidityKind.Proportional,
+                tokensIn: [USDT.address, WETH.address],
             };
         });
 
         test('with tokens', async () => {
             const wethIsEth = false;
-
             const txInput: AddLiquidityBoostedTxInput = {
                 client,
                 addLiquidityBoosted,

--- a/test/v3/addLiquidityBuffer/addLiquidityBuffer.integration.test.ts
+++ b/test/v3/addLiquidityBuffer/addLiquidityBuffer.integration.test.ts
@@ -140,10 +140,7 @@ describe('Buffer AddLiquidity', () => {
 
             const { transactionReceipt, balanceDeltas } =
                 await sendTransactionGetBalances(
-                    [
-                        stataUSDC.address as `0x${string}`,
-                        USDC.address as `0x${string}`,
-                    ],
+                    [stataUSDC.address, USDC.address],
                     client,
                     testAddress,
                     addLiquidityBufferBuildCallOutput.to,

--- a/test/v3/addLiquidityNested/addLiquidityNestedV3.integration.test.ts
+++ b/test/v3/addLiquidityNested/addLiquidityNestedV3.integration.test.ts
@@ -14,7 +14,7 @@ import {
 } from 'viem';
 import {
     Address,
-    BALANCER_COMPOSITE_LIQUIDITY_ROUTER,
+    BALANCER_COMPOSITE_LIQUIDITY_ROUTER_NESTED,
     CHAINS,
     ChainId,
     PERMIT2,
@@ -158,7 +158,7 @@ describe('V3 add liquidity nested test, with Permit2 direct approval', () => {
                     client,
                     testAddress,
                     amount.address,
-                    BALANCER_COMPOSITE_LIQUIDITY_ROUTER[chainId],
+                    BALANCER_COMPOSITE_LIQUIDITY_ROUTER_NESTED[chainId],
                 );
             }
 
@@ -177,7 +177,7 @@ describe('V3 add liquidity nested test, with Permit2 direct approval', () => {
             );
             expect(addLiquidityBuildCallOutput.value === 0n).to.be.true;
             expect(addLiquidityBuildCallOutput.to).to.eq(
-                BALANCER_COMPOSITE_LIQUIDITY_ROUTER[chainId],
+                BALANCER_COMPOSITE_LIQUIDITY_ROUTER_NESTED[chainId],
             );
 
             // send add liquidity transaction and check balance changes
@@ -244,7 +244,7 @@ describe('V3 add liquidity nested test, with Permit2 direct approval', () => {
                     client,
                     testAddress,
                     amount.address,
-                    BALANCER_COMPOSITE_LIQUIDITY_ROUTER[chainId],
+                    BALANCER_COMPOSITE_LIQUIDITY_ROUTER_NESTED[chainId],
                 );
             }
 
@@ -267,7 +267,7 @@ describe('V3 add liquidity nested test, with Permit2 direct approval', () => {
                     addLiquidityInput.amountsIn[0].rawAmount,
             ).to.be.true;
             expect(addLiquidityBuildCallOutput.to).to.eq(
-                BALANCER_COMPOSITE_LIQUIDITY_ROUTER[chainId],
+                BALANCER_COMPOSITE_LIQUIDITY_ROUTER_NESTED[chainId],
             );
 
             // send add liquidity transaction and check balance changes

--- a/test/v3/addLiquidityNested/addLiquidityNestedV3Signature.integration.test.ts
+++ b/test/v3/addLiquidityNested/addLiquidityNestedV3Signature.integration.test.ts
@@ -23,7 +23,7 @@ import {
     AddLiquidityNestedInput,
     AddLiquidityNestedQueryOutputV3,
     Permit2Helper,
-    BALANCER_COMPOSITE_LIQUIDITY_ROUTER,
+    BALANCER_COMPOSITE_LIQUIDITY_ROUTER_NESTED,
 } from '@/index';
 import { ANVIL_NETWORKS, startFork } from 'test/anvil/anvil-global-setup';
 import {
@@ -129,7 +129,7 @@ describe('V3 add liquidity nested test, with Permit2 signature', () => {
             );
         expect(addLiquidityBuildCallOutput.value === 0n).to.be.true;
         expect(addLiquidityBuildCallOutput.to).to.eq(
-            BALANCER_COMPOSITE_LIQUIDITY_ROUTER[chainId],
+            BALANCER_COMPOSITE_LIQUIDITY_ROUTER_NESTED[chainId],
         );
 
         // send add liquidity transaction and check balance changes

--- a/test/v3/priceImpact/priceImpact.V3.integration.test.ts
+++ b/test/v3/priceImpact/priceImpact.V3.integration.test.ts
@@ -32,8 +32,13 @@ const WETH = TOKENS[chainId].WETH;
 describe('PriceImpact V3', () => {
     let rpcUrl: string;
     beforeAll(async () => {
-        ({ rpcUrl } = await startFork(ANVIL_NETWORKS.SEPOLIA));
+        ({ rpcUrl } = await startFork(
+            ANVIL_NETWORKS[ChainId[chainId]],
+            undefined,
+            7562540n, // block after new composite liquidity router deployed
+        ));
     });
+
     describe('Full Boosted Pool Boosted Pool AddLiquidity', () => {
         test('Close to proportional', async () => {
             const addLiquidityInput: AddLiquidityBoostedUnbalancedInput = {
@@ -51,6 +56,7 @@ describe('PriceImpact V3', () => {
                         address: USDT.address as Address,
                     },
                 ],
+                wrapUnderlying: [true, true],
                 kind: AddLiquidityKind.Unbalanced,
                 userData: '0x',
             };
@@ -59,7 +65,7 @@ describe('PriceImpact V3', () => {
                     addLiquidityInput,
                     boostedPool_USDC_USDT,
                 );
-            const priceImpactSpot = PriceImpactAmount.fromDecimal('0.000042');
+            const priceImpactSpot = PriceImpactAmount.fromDecimal('0.000605');
             expect(priceImpactABA.decimal).eq(priceImpactSpot.decimal);
         });
 
@@ -80,6 +86,7 @@ describe('PriceImpact V3', () => {
                     },
                 ],
                 kind: AddLiquidityKind.Unbalanced,
+                wrapUnderlying: [true, true],
                 userData: '0x',
             };
             const priceImpactABA =
@@ -88,7 +95,7 @@ describe('PriceImpact V3', () => {
                     boostedPool_USDC_USDT,
                 );
             const priceImpactSpot =
-                PriceImpactAmount.fromDecimal('0.0005511004');
+                PriceImpactAmount.fromDecimal('0.00183097705');
             expect(priceImpactABA.decimal).eq(priceImpactSpot.decimal);
         });
 
@@ -104,6 +111,7 @@ describe('PriceImpact V3', () => {
                     },
                 ],
                 kind: AddLiquidityKind.Unbalanced,
+                wrapUnderlying: [true, true],
                 userData: '0x',
             };
             const priceImpactABA =
@@ -111,7 +119,7 @@ describe('PriceImpact V3', () => {
                     addLiquidityInput,
                     boostedPool_USDC_USDT,
                 );
-            const priceImpactSpot = PriceImpactAmount.fromDecimal('0.000492');
+            const priceImpactSpot = PriceImpactAmount.fromDecimal('0.000211');
             expect(priceImpactABA.decimal).eq(priceImpactSpot.decimal);
         });
     });
@@ -134,6 +142,7 @@ describe('PriceImpact V3', () => {
                     },
                 ],
                 kind: AddLiquidityKind.Unbalanced,
+                wrapUnderlying: [false, true],
                 userData: '0x',
             };
             const priceImpactABA =
@@ -141,7 +150,7 @@ describe('PriceImpact V3', () => {
                     addLiquidityInput,
                     partialBoostedPool_USDT_stataDAI,
                 );
-            const priceImpactSpot = PriceImpactAmount.fromDecimal('0.0000045');
+            const priceImpactSpot = PriceImpactAmount.fromDecimal('0.0008225');
             expect(priceImpactABA.decimal).eq(priceImpactSpot.decimal);
         });
 
@@ -162,6 +171,7 @@ describe('PriceImpact V3', () => {
                     },
                 ],
                 kind: AddLiquidityKind.Unbalanced,
+                wrapUnderlying: [false, true],
                 userData: '0x',
             };
             const priceImpactABA =
@@ -169,8 +179,7 @@ describe('PriceImpact V3', () => {
                     addLiquidityInput,
                     partialBoostedPool_USDT_stataDAI,
                 );
-            const priceImpactSpot =
-                PriceImpactAmount.fromDecimal('0.000396375');
+            const priceImpactSpot = PriceImpactAmount.fromDecimal('0.00171675');
             expect(priceImpactABA.decimal).eq(priceImpactSpot.decimal);
         });
     });
@@ -198,7 +207,7 @@ describe('PriceImpact V3', () => {
                 nestedWithBoostedPool,
             );
             const priceImpactSpot = PriceImpactAmount.fromDecimal(
-                '0.005213821423105922',
+                '0.004208136163133692',
             );
             expect(priceImpactABA.decimal).eq(priceImpactSpot.decimal);
         });

--- a/test/v3/priceImpact/priceImpact.V3.integration.test.ts
+++ b/test/v3/priceImpact/priceImpact.V3.integration.test.ts
@@ -52,7 +52,6 @@ describe('PriceImpact V3', () => {
                         address: USDT.address as Address,
                     },
                 ],
-                wrapUnderlying: [true, true],
                 kind: AddLiquidityKind.Unbalanced,
                 userData: '0x',
             };
@@ -82,7 +81,6 @@ describe('PriceImpact V3', () => {
                     },
                 ],
                 kind: AddLiquidityKind.Unbalanced,
-                wrapUnderlying: [true, true],
                 userData: '0x',
             };
             const priceImpactABA =
@@ -107,7 +105,6 @@ describe('PriceImpact V3', () => {
                     },
                 ],
                 kind: AddLiquidityKind.Unbalanced,
-                wrapUnderlying: [true, true],
                 userData: '0x',
             };
             const priceImpactABA =
@@ -138,7 +135,6 @@ describe('PriceImpact V3', () => {
                     },
                 ],
                 kind: AddLiquidityKind.Unbalanced,
-                wrapUnderlying: [false, true],
                 userData: '0x',
             };
             const priceImpactABA =
@@ -167,7 +163,6 @@ describe('PriceImpact V3', () => {
                     },
                 ],
                 kind: AddLiquidityKind.Unbalanced,
-                wrapUnderlying: [false, true],
                 userData: '0x',
             };
             const priceImpactABA =
@@ -195,7 +190,6 @@ describe('PriceImpact V3', () => {
                         decimals: USDC.decimals,
                     },
                 ],
-                wrapUnderlying: [false, true],
                 chainId,
                 rpcUrl,
             };

--- a/test/v3/priceImpact/priceImpact.V3.integration.test.ts
+++ b/test/v3/priceImpact/priceImpact.V3.integration.test.ts
@@ -199,6 +199,7 @@ describe('PriceImpact V3', () => {
                         decimals: USDC.decimals,
                     },
                 ],
+                wrapUnderlying: [false, true],
                 chainId,
                 rpcUrl,
             };
@@ -207,7 +208,7 @@ describe('PriceImpact V3', () => {
                 nestedWithBoostedPool,
             );
             const priceImpactSpot = PriceImpactAmount.fromDecimal(
-                '0.004208136163133692',
+                '0.10540652060304274',
             );
             expect(priceImpactABA.decimal).eq(priceImpactSpot.decimal);
         });

--- a/test/v3/priceImpact/priceImpact.V3.integration.test.ts
+++ b/test/v3/priceImpact/priceImpact.V3.integration.test.ts
@@ -32,11 +32,7 @@ const WETH = TOKENS[chainId].WETH;
 describe('PriceImpact V3', () => {
     let rpcUrl: string;
     beforeAll(async () => {
-        ({ rpcUrl } = await startFork(
-            ANVIL_NETWORKS[ChainId[chainId]],
-            undefined,
-            7562540n, // block after new composite liquidity router deployed
-        ));
+        ({ rpcUrl } = await startFork(ANVIL_NETWORKS[ChainId[chainId]]));
     });
 
     describe('Full Boosted Pool Boosted Pool AddLiquidity', () => {

--- a/test/v3/priceImpact/priceImpact.V3.integration.test.ts
+++ b/test/v3/priceImpact/priceImpact.V3.integration.test.ts
@@ -112,7 +112,7 @@ describe('PriceImpact V3', () => {
                     addLiquidityInput,
                     boostedPool_USDC_USDT,
                 );
-            const priceImpactSpot = PriceImpactAmount.fromDecimal('0.000211');
+            const priceImpactSpot = PriceImpactAmount.fromDecimal('0.000208');
             expect(priceImpactABA.decimal).eq(priceImpactSpot.decimal);
         });
     });
@@ -198,7 +198,7 @@ describe('PriceImpact V3', () => {
                 nestedWithBoostedPool,
             );
             const priceImpactSpot = PriceImpactAmount.fromDecimal(
-                '0.10540652060304274',
+                '0.004206886163133692',
             );
             expect(priceImpactABA.decimal).eq(priceImpactSpot.decimal);
         });

--- a/test/v3/priceImpact/priceImpactErrors.V3.integration.test.ts
+++ b/test/v3/priceImpact/priceImpactErrors.V3.integration.test.ts
@@ -38,6 +38,7 @@ describe('PriceImpact Errors V3', () => {
                     address: USDC.address as Address,
                 },
             ],
+            wrapUnderlying: [true, true],
             kind: AddLiquidityKind.Unbalanced,
             userData: '0x',
         };

--- a/test/v3/removeLiquidityBoosted/removeLiquidityBoosted.integration.test.ts
+++ b/test/v3/removeLiquidityBoosted/removeLiquidityBoosted.integration.test.ts
@@ -199,11 +199,7 @@ describe('remove liquidity boosted proportional', () => {
 
             const { transactionReceipt, balanceDeltas } =
                 await sendTransactionGetBalances(
-                    [
-                        boostedPool_USDC_USDT.address,
-                        USDC.address as `0x${string}`,
-                        USDT.address as `0x${string}`,
-                    ],
+                    [boostedPool_USDC_USDT.address, USDC.address, USDT.address],
                     client,
                     testAddress,
                     removeLiquidityBuildCallOutput.to,
@@ -293,8 +289,8 @@ describe('remove liquidity boosted proportional', () => {
                 await sendTransactionGetBalances(
                     [
                         boostedPool_USDC_USDT.address,
-                        USDC.address as `0x${string}`,
-                        stataUSDT.address as `0x${string}`,
+                        USDC.address,
+                        stataUSDT.address,
                     ],
                     client,
                     testAddress,
@@ -397,11 +393,7 @@ describe('remove liquidity boosted proportional', () => {
 
             const { transactionReceipt, balanceDeltas } =
                 await sendTransactionGetBalances(
-                    [
-                        boostedPool_USDC_USDT.address,
-                        USDC.address as `0x${string}`,
-                        USDT.address as `0x${string}`,
-                    ],
+                    [boostedPool_USDC_USDT.address, USDC.address, USDT.address],
                     client,
                     testAddress,
                     removeLiquidityBuildCallOutput.to,

--- a/test/v3/removeLiquidityBoosted/removeLiquidityBoosted.integration.test.ts
+++ b/test/v3/removeLiquidityBoosted/removeLiquidityBoosted.integration.test.ts
@@ -56,11 +56,7 @@ describe('remove liquidity test', () => {
     let testAddress: Address;
 
     beforeAll(async () => {
-        ({ rpcUrl } = await startFork(
-            ANVIL_NETWORKS[ChainId[chainId]],
-            undefined,
-            7562540n, // block after new composite liquidity router deployed
-        ));
+        ({ rpcUrl } = await startFork(ANVIL_NETWORKS[ChainId[chainId]]));
 
         client = createTestClient({
             mode: 'anvil',

--- a/test/v3/removeLiquidityBoosted/removeLiquidityBoosted.integration.test.ts
+++ b/test/v3/removeLiquidityBoosted/removeLiquidityBoosted.integration.test.ts
@@ -116,7 +116,7 @@ describe('remove liquidity boosted proportional', () => {
                 address: boostedPool_USDC_USDT.address,
             },
             kind: AddLiquidityKind.Proportional,
-            wrapUnderlying: [true, true],
+            tokensIn: [USDC.address, USDT.address],
         };
 
         await doAddLiquidity({

--- a/test/v3/removeLiquidityBoosted/removeLiquidityBoosted.integration.test.ts
+++ b/test/v3/removeLiquidityBoosted/removeLiquidityBoosted.integration.test.ts
@@ -102,7 +102,6 @@ describe('remove liquidity test', () => {
         });
         snapshot = await client.snapshot();
 
-        // Approve the Vault to spend Tokens on the users behalf via Permit2
         for (const token of boostedPool_USDC_USDT.tokens) {
             await approveSpenderOnPermit2(
                 client,
@@ -126,7 +125,7 @@ describe('remove liquidity test', () => {
 
         await doAddLiquidity({
             client,
-            addLiquidity: new AddLiquidityBoostedV3(), // TODO: debug linter type complaint
+            addLiquidity: new AddLiquidityBoostedV3(),
             addLiquidityInput,
             slippage: Slippage.fromPercentage('1'),
             poolState: boostedPool_USDC_USDT,

--- a/test/v3/removeLiquidityBoosted/removeLiquidityBoosted.integration.test.ts
+++ b/test/v3/removeLiquidityBoosted/removeLiquidityBoosted.integration.test.ts
@@ -140,7 +140,7 @@ describe('remove liquidity boosted proportional', () => {
                 decimals: 18,
                 address: boostedPool_USDC_USDT.address,
             },
-            unwrapWrapped: [true, false],
+            tokensOut: [USDC.address, stataUSDT.address],
             kind: RemoveLiquidityKind.Proportional,
         };
 
@@ -179,7 +179,7 @@ describe('remove liquidity boosted proportional', () => {
                         decimals: 18,
                         address: boostedPool_USDC_USDT.address,
                     },
-                    unwrapWrapped: [true, true],
+                    tokensOut: [USDC.address, USDT.address],
                     kind: RemoveLiquidityKind.Proportional,
                 };
 
@@ -271,7 +271,7 @@ describe('remove liquidity boosted proportional', () => {
                         decimals: 18,
                         address: boostedPool_USDC_USDT.address,
                     },
-                    unwrapWrapped: [true, false],
+                    tokensOut: [USDC.address, stataUSDT.address],
                     kind: RemoveLiquidityKind.Proportional,
                 };
 
@@ -364,7 +364,7 @@ describe('remove liquidity boosted proportional', () => {
                         decimals: 18,
                         address: boostedPool_USDC_USDT.address,
                     },
-                    unwrapWrapped: [true, true],
+                    tokensOut: [USDC.address, USDT.address],
                     kind: RemoveLiquidityKind.Proportional,
                     sender: testAddress,
                     userData: '0x123',

--- a/test/v3/removeLiquidityBoosted/removeLiquidityPartialBoosted.integration.test.ts
+++ b/test/v3/removeLiquidityBoosted/removeLiquidityPartialBoosted.integration.test.ts
@@ -64,11 +64,7 @@ describe('V3 remove liquidity partial boosted', () => {
     let removeLiquidityInput: RemoveLiquidityBoostedProportionalInput;
 
     beforeAll(async () => {
-        ({ rpcUrl } = await startFork(
-            ANVIL_NETWORKS[ChainId[chainId]],
-            undefined,
-            7562540n, // block after new composite liquidity router deployed
-        ));
+        ({ rpcUrl } = await startFork(ANVIL_NETWORKS[ChainId[chainId]]));
 
         client = createTestClient({
             mode: 'anvil',

--- a/test/v3/removeLiquidityBoosted/removeLiquidityPartialBoosted.integration.test.ts
+++ b/test/v3/removeLiquidityBoosted/removeLiquidityPartialBoosted.integration.test.ts
@@ -51,7 +51,6 @@ const parentBptToken = new Token(
 // These are the underlying tokens
 const usdtToken = new Token(chainId, USDT.address, USDT.decimals);
 const wethToken = new Token(chainId, WETH.address, WETH.decimals);
-const unwrapWrapped = [false, true]; // unwrapWrapped must match order of on chain state for pool tokens
 
 describe('V3 remove liquidity partial boosted', () => {
     let rpcUrl: string;
@@ -99,7 +98,6 @@ describe('V3 remove liquidity partial boosted', () => {
                     slot: WETH.slot as number,
                 },
             ],
-            unwrapWrapped,
         );
 
         removeLiquidityInput = {
@@ -110,7 +108,7 @@ describe('V3 remove liquidity partial boosted', () => {
                 decimals: 18,
                 rawAmount: bptAmount,
             },
-            unwrapWrapped,
+            tokensOut: [USDT.address, WETH.address],
             kind: RemoveLiquidityKind.Proportional,
         };
 

--- a/test/v3/removeLiquidityNested/removeLiquidityNestedV3.integration.test.ts
+++ b/test/v3/removeLiquidityNested/removeLiquidityNestedV3.integration.test.ts
@@ -20,7 +20,7 @@ import {
     Token,
     RemoveLiquidityNestedInput,
     RemoveLiquidityNested,
-    BALANCER_COMPOSITE_LIQUIDITY_ROUTER,
+    BALANCER_COMPOSITE_LIQUIDITY_ROUTER_NESTED,
     Slippage,
 } from 'src';
 
@@ -105,7 +105,7 @@ describe('V3 remove liquidity nested test, with Permit direct approval', () => {
             client,
             testAddress,
             parentBptToken.address,
-            BALANCER_COMPOSITE_LIQUIDITY_ROUTER[chainId],
+            BALANCER_COMPOSITE_LIQUIDITY_ROUTER_NESTED[chainId],
         );
 
         snapshot = await client.snapshot();

--- a/test/v3/removeLiquidityNested/removeLiquidityNestedV3Signature.integration.test.ts
+++ b/test/v3/removeLiquidityNested/removeLiquidityNestedV3Signature.integration.test.ts
@@ -19,7 +19,7 @@ import {
     Token,
     RemoveLiquidityNestedInput,
     RemoveLiquidityNested,
-    BALANCER_COMPOSITE_LIQUIDITY_ROUTER,
+    BALANCER_COMPOSITE_LIQUIDITY_ROUTER_NESTED,
     Slippage,
     PermitHelper,
     RemoveLiquidityNestedCallInputV3,
@@ -130,7 +130,7 @@ describe('V3 remove liquidity nested test, with Permit signature', () => {
             addLiquidityBuildCallOutput.minAmountsOut.map((a) => a.amount),
         );
         expect(addLiquidityBuildCallOutput.to).to.eq(
-            BALANCER_COMPOSITE_LIQUIDITY_ROUTER[chainId],
+            BALANCER_COMPOSITE_LIQUIDITY_ROUTER_NESTED[chainId],
         );
 
         // send remove liquidity transaction and check balance changes

--- a/test/v3/utils/getPoolStateWithBalancesV3.integration.test.ts
+++ b/test/v3/utils/getPoolStateWithBalancesV3.integration.test.ts
@@ -52,16 +52,16 @@ describe('add liquidity test', () => {
                         address: USDC.address,
                         decimals: USDC.decimals,
                         index: 0,
-                        balance: '4982.377088',
+                        balance: '6916.384366',
                     },
                     {
                         address: DAI.address,
                         decimals: DAI.decimals,
                         index: 1,
-                        balance: '4412.573626596067233661',
+                        balance: '6240.659067374271172646',
                     },
                 ],
-                totalShares: '4685.71985547775593574',
+                totalShares: '6565.147517543863649467',
             };
 
             expect(poolStateWithBalances).to.deep.eq(mockData);


### PR DESCRIPTION
Closes #555 

### Summary
- Temporarily splitting composite router into boosted and nested versions
  - See why [here](https://balancerecosystem.slack.com/archives/C08AG424F09/p1737697686330499)
- New composite router allows for passing array of booleans that determine if token should be wrapped / unwrapped

### Update 1
- For proportional boosted queries, using the new `tokensIn` and `tokensOut` that are returned by composite router 

### Update 2
- Major refactor of implementation to infer `wrapUnderlying` and `unwrapWrapped` so user only has to worry about which tokens they want to add / remove