### PR TITLE
Add underlying tokens to poolState query

### DIFF
--- a/test/v2/data/balancerApi.test.ts
+++ b/test/v2/data/balancerApi.test.ts
@@ -38,7 +38,7 @@ describe(
 describe(
     'BalancerApi Provider for boosted pools',
     () => {
-        test.only('boosted pool has underlying token data', async () => {
+        test('boosted pool has underlying token data', async () => {
             const chainId = ChainId.MAINNET;
             // wstEth/WETH Boosted Pool
             const poolId = '0xc4ce391d82d164c166df9c8336ddf84206b2f812';

--- a/test/v2/data/balancerApi.test.ts
+++ b/test/v2/data/balancerApi.test.ts
@@ -5,6 +5,7 @@ import {
     NestedPoolState,
     PoolState,
     API_ENDPOINT,
+    PoolStateWithUnderlyings,
 } from '../../../src';
 
 // Placeholder test to help validate the impact of API updates
@@ -27,6 +28,49 @@ describe(
             expect(poolStateInput.tokens[1].address).toEqual(
                 poolStateInput.address,
             );
+        });
+    },
+    {
+        timeout: 60000,
+    },
+);
+
+describe(
+    'BalancerApi Provider for boosted pools',
+    () => {
+        test.only('boosted pool has underlying token data', async () => {
+            const chainId = ChainId.MAINNET;
+            // wstEth/WETH Boosted Pool
+            const poolId = '0xc4ce391d82d164c166df9c8336ddf84206b2f812';
+
+            // API is used to fetch relevant pool data
+            const balancerApi = new BalancerApi(API_ENDPOINT, chainId);
+            const poolStateInput: PoolStateWithUnderlyings =
+                await balancerApi.pools.fetchPoolState(poolId);
+
+            expect(poolStateInput.tokens.length).toEqual(2);
+            expect(poolStateInput.tokens).toEqual([
+                {
+                    index: 0,
+                    address: '0x0fe906e030a44ef24ca8c7dc7b7c53a6c4f00ce9',
+                    decimals: 18,
+                    underlyingToken: {
+                        address: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+                        decimals: 18,
+                        index: 0,
+                    },
+                },
+                {
+                    index: 1,
+                    address: '0x775f661b0bd1739349b9a2a3ef60be277c5d2d29',
+                    decimals: 18,
+                    underlyingToken: {
+                        address: '0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0',
+                        decimals: 18,
+                        index: 1,
+                    },
+                },
+            ]);
         });
     },
     {


### PR DESCRIPTION
Presently, I think user has to fetch the data from our API on their own if they want to use an underlying token to add liquidity to a boosted pool

( The boosted tests are all using hard coded poolState )

If no underlying token, this change just adds  `"underlyingToken": null` to `poolState.tokens[i]`

This approach would enable the same helper to be used for boosted and non boosted