### PR TITLE
fix: TokenAmount.toSignificant with very small amounts

### DIFF
--- a/.changeset/plenty-peaches-occur.md
+++ b/.changeset/plenty-peaches-occur.md
@@ -1,0 +1,5 @@
+---
+"@balancer/sdk": patch
+---
+
+Fix TokenAmount.toSignificant with very small amounts

--- a/src/entities/tokenAmount.test.ts
+++ b/src/entities/tokenAmount.test.ts
@@ -1,0 +1,50 @@
+import { ChainId, NATIVE_ASSETS, TokenAmount } from '@balancer/sdk';
+import { parseUnits } from 'viem';
+import _Decimal from 'decimal.js-light';
+
+const weth = NATIVE_ASSETS[ChainId.MAINNET];
+
+it('fromRawAmount', () => {
+    const rawAmount = parseUnits('1.23456789123456789', weth.decimals);
+    const tokenAmount = TokenAmount.fromRawAmount(weth, rawAmount);
+
+    expect(tokenAmount.amount).toEqual(rawAmount);
+    expect(tokenAmount.scalar).toEqual(1n);
+    expect(tokenAmount.token).toEqual(weth);
+});
+
+it('toInputAmount', () => {
+    const rawAmount = parseUnits('3.123456789123456789', weth.decimals);
+    const tokenAmount = TokenAmount.fromRawAmount(weth, rawAmount);
+    const inputAmount = tokenAmount.toInputAmount();
+
+    expect(inputAmount.address).toBe(weth.address);
+    expect(inputAmount.decimals).toBe(weth.decimals);
+    expect(inputAmount.rawAmount).toBe(rawAmount);
+});
+
+describe('toSignificant', () => {
+    it('should format amounts ', () => {
+        const rawAmount = parseUnits('2.123456789123456789', weth.decimals);
+        const tokenAmount = TokenAmount.fromRawAmount(weth, rawAmount);
+
+        expect(tokenAmount.toSignificant(weth.decimals)).toEqual(
+            '2.123456789123456789',
+        );
+    });
+
+    it('should format small amounts', () => {
+        const smallRawAmount = parseUnits(
+            '0.000000312457062375',
+            weth.decimals,
+        );
+        const smallTokenAmount = TokenAmount.fromRawAmount(
+            weth,
+            smallRawAmount,
+        );
+
+        expect(smallTokenAmount.toSignificant(weth.decimals)).toEqual(
+            '0.000000312457062375',
+        );
+    });
+});

--- a/src/entities/tokenAmount.ts
+++ b/src/entities/tokenAmount.ts
@@ -84,7 +84,7 @@ export class TokenAmount {
         return new _Decimal(this.amount.toString())
             .div(new _Decimal(this.decimalScale.toString()))
             .toDecimalPlaces(significantDigits)
-            .toString();
+            .toFixed();
     }
 
     public toInputAmount(): InputAmount {


### PR DESCRIPTION
Closes https://github.com/balancer/b-sdk/issues/596

Using   .toDecimalPlaces(significantDigits).**toString**();

was returning exponential notation when using very small numbers. Replacing `toString` by `toFixed` fixes the issue

