### PR TITLE
Error Handling - Input Validation

### DIFF
--- a/.changeset/big-pens-joke.md
+++ b/.changeset/big-pens-joke.md
@@ -1,0 +1,5 @@
+---
+"@balancer/sdk": minor
+---
+
+Refactor input validation errors as SDKError

--- a/.changeset/poor-adults-deny.md
+++ b/.changeset/poor-adults-deny.md
@@ -1,5 +1,0 @@
----
-"@balancer/sdk": patch
----
-
-Update GyroECLP factory addresses and ABI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @balancer/sdk
 
+## 2.5.1
+
+### Patch Changes
+
+- 3763ca1: Update GyroECLP factory addresses and ABI
+
 ## 2.5.0
 
 ### Minor Changes

--- a/examples/addLiquidity/addLiquidityCustom.ts
+++ b/examples/addLiquidity/addLiquidityCustom.ts
@@ -108,6 +108,7 @@ const addLiquidity = async ({
         slippage,
         chainId,
         wethIsEth: false,
+        userData: '0x',
     });
 
     console.log('\nWith slippage applied:');

--- a/examples/addLiquidity/addLiquidityProportional.ts
+++ b/examples/addLiquidity/addLiquidityProportional.ts
@@ -103,6 +103,7 @@ const addLiquidityProportional = async ({
         slippage,
         chainId,
         wethIsEth: false,
+        userData: '0x',
     });
 
     console.log('\nWith slippage applied:');

--- a/examples/addLiquidity/addLiquidityUnbalanced.ts
+++ b/examples/addLiquidity/addLiquidityUnbalanced.ts
@@ -113,6 +113,7 @@ export const addLiquidityExample = async ({
         slippage,
         chainId,
         wethIsEth: false,
+        userData: '0x',
     });
 
     console.log('\nWith slippage applied:');

--- a/examples/addLiquidity/addLiquidityWithPermit2Signature.ts
+++ b/examples/addLiquidity/addLiquidityWithPermit2Signature.ts
@@ -14,9 +14,10 @@ import {
     walletActions,
 } from 'viem';
 import {
+    AddLiquidity,
     AddLiquidityInput,
     AddLiquidityKind,
-    AddLiquidity,
+    AddLiquidityV3BuildCallInput,
     BalancerApi,
     ChainId,
     PriceImpact,
@@ -136,11 +137,12 @@ const addLiquidityWithPermit2Signature = async ({
     console.log(`BPT Out: ${queryOutput.bptOut.amount.toString()}`);
 
     // Add liquidity build call input with slippage applied to BPT amount from query output
-    const addLiquidityBuildCallInput = {
+    const addLiquidityBuildCallInput: AddLiquidityV3BuildCallInput = {
         ...queryOutput,
         slippage,
         chainId,
         wethIsEth: false,
+        userData: '0x',
     };
 
     // Sign permit2 approvals

--- a/examples/removeLiquidity/removeLiquidityWithPermitSignature.ts
+++ b/examples/removeLiquidity/removeLiquidityWithPermitSignature.ts
@@ -26,6 +26,7 @@ import {
     RemoveLiquidity,
     RemoveLiquidityInput,
     RemoveLiquidityKind,
+    RemoveLiquidityV3BuildCallInput,
     Slippage,
     TEST_API_ENDPOINT,
 } from '../../src';
@@ -149,10 +150,11 @@ const removeLiquidityWithPermitSignature = async ({
     });
 
     // Remove liquidity build call input with slippage applied to amountOut from query output
-    const removeLiquidityBuildCallInput = {
+    const removeLiquidityBuildCallInput: RemoveLiquidityV3BuildCallInput = {
         ...queryOutput,
         slippage,
         chainId,
+        userData: '0x',
     };
 
     // Sign permit approvals

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "publishConfig": {
         "access": "public"
     },
-    "version": "2.5.0",
+    "version": "2.5.1",
     "main": "dist/index.js",
     "module": "dist/index.mjs",
     "types": "dist/index.d.ts",

--- a/src/data/providers/balancer-api/modules/buffer-state/index.ts
+++ b/src/data/providers/balancer-api/modules/buffer-state/index.ts
@@ -2,6 +2,7 @@ import { BalancerApiClient } from '../../client';
 import { API_CHAIN_NAMES } from '../../../../../utils/constants';
 import { BufferState } from '@/entities';
 import { Address } from 'viem';
+import { inputValidationError } from '@/utils';
 
 export class Buffers {
     readonly bufferStateQuery = `
@@ -36,8 +37,9 @@ export class Buffers {
             underlyingTokenAddress: Address;
         };
         if (!wrappedToken.isErc4626) {
-            throw new Error(
-                `Wrapped token address provided is not an ERC4626: ${wrappedTokenAddress}`,
+            throw inputValidationError(
+                'Fetch Buffer State',
+                `wrappedTokenAddress ${wrappedTokenAddress} provided is not an ERC4626`,
             );
         }
         const bufferState: BufferState = {

--- a/src/entities/addLiquidity/addLiquidityCowAmm/index.ts
+++ b/src/entities/addLiquidity/addLiquidityCowAmm/index.ts
@@ -3,7 +3,11 @@ import { cowAmmPoolAbi } from '@/abi/cowAmmPool';
 import { Token } from '@/entities/token';
 import { TokenAmount } from '@/entities/tokenAmount';
 import { PoolState } from '@/entities/types';
-import { buildCallWithPermit2ProtocolVersionError } from '@/utils';
+import {
+    addLiquidityProportionalOnlyError,
+    addLiquidityNativeAssetError,
+    buildCallWithPermit2ProtocolVersionError,
+} from '@/utils';
 
 import { getAmountsCall } from '../helpers';
 import {
@@ -77,14 +81,13 @@ export class AddLiquidityCowAmm implements AddLiquidityBase {
         input: AddLiquidityBaseBuildCallInput,
     ): AddLiquidityBuildCallOutput {
         if (input.addLiquidityKind !== AddLiquidityKind.Proportional) {
-            throw new Error(
-                `Error: Add Liquidity ${input.addLiquidityKind} is not supported. Cow AMM pools support Add Liquidity Proportional only.`,
+            throw addLiquidityProportionalOnlyError(
+                input.addLiquidityKind,
+                'Cow AMM',
             );
         }
         if (input.wethIsEth) {
-            throw new Error(
-                'Cow AMM pools do not support adding liquidity with ETH.',
-            );
+            throw addLiquidityNativeAssetError('Cow AMM');
         }
 
         const amounts = getAmountsCall(input);

--- a/src/entities/addLiquidity/addLiquidityCowAmm/index.ts
+++ b/src/entities/addLiquidity/addLiquidityCowAmm/index.ts
@@ -109,6 +109,6 @@ export class AddLiquidityCowAmm implements AddLiquidityBase {
     }
 
     public buildCallWithPermit2(): AddLiquidityBuildCallOutput {
-        throw buildCallWithPermit2ProtocolVersionError;
+        throw buildCallWithPermit2ProtocolVersionError();
     }
 }

--- a/src/entities/addLiquidity/addLiquidityCowAmm/index.ts
+++ b/src/entities/addLiquidity/addLiquidityCowAmm/index.ts
@@ -3,11 +3,7 @@ import { cowAmmPoolAbi } from '@/abi/cowAmmPool';
 import { Token } from '@/entities/token';
 import { TokenAmount } from '@/entities/tokenAmount';
 import { PoolState } from '@/entities/types';
-import {
-    addLiquidityProportionalOnlyError,
-    addLiquidityNativeAssetError,
-    buildCallWithPermit2ProtocolVersionError,
-} from '@/utils';
+import { poolTypeError, protocolVersionError } from '@/utils';
 
 import { getAmountsCall } from '../helpers';
 import {
@@ -81,13 +77,18 @@ export class AddLiquidityCowAmm implements AddLiquidityBase {
         input: AddLiquidityBaseBuildCallInput,
     ): AddLiquidityBuildCallOutput {
         if (input.addLiquidityKind !== AddLiquidityKind.Proportional) {
-            throw addLiquidityProportionalOnlyError(
-                input.addLiquidityKind,
-                'Cow AMM',
+            throw poolTypeError(
+                'Add Liquidity',
+                input.poolType,
+                'Use Add Liquidity Proportional instead.',
             );
         }
         if (input.wethIsEth) {
-            throw addLiquidityNativeAssetError('Cow AMM');
+            throw poolTypeError(
+                'Add Liquidity with native asset (e.g. ETH)',
+                input.poolType,
+                'Use wrapped native asset instead (e.g. WETH).',
+            );
         }
 
         const amounts = getAmountsCall(input);
@@ -111,7 +112,13 @@ export class AddLiquidityCowAmm implements AddLiquidityBase {
         };
     }
 
-    public buildCallWithPermit2(): AddLiquidityBuildCallOutput {
-        throw buildCallWithPermit2ProtocolVersionError();
+    public buildCallWithPermit2(
+        input: AddLiquidityBaseBuildCallInput,
+    ): AddLiquidityBuildCallOutput {
+        throw protocolVersionError(
+            'buildCallWithPermit2',
+            input.protocolVersion,
+            'buildCallWithPermit2 is supported on Balancer v3 only.',
+        );
     }
 }

--- a/src/entities/addLiquidity/addLiquidityV2/composableStable/addLiquidityComposableStable.ts
+++ b/src/entities/addLiquidity/addLiquidityV2/composableStable/addLiquidityComposableStable.ts
@@ -121,6 +121,6 @@ export class AddLiquidityComposableStable implements AddLiquidityBase {
     }
 
     public buildCallWithPermit2(): AddLiquidityBuildCallOutput {
-        throw buildCallWithPermit2ProtocolVersionError;
+        throw buildCallWithPermit2ProtocolVersionError();
     }
 }

--- a/src/entities/addLiquidity/addLiquidityV2/composableStable/addLiquidityComposableStable.ts
+++ b/src/entities/addLiquidity/addLiquidityV2/composableStable/addLiquidityComposableStable.ts
@@ -1,11 +1,7 @@
 import { encodeFunctionData } from 'viem';
 import { Token } from '@/entities/token';
 import { TokenAmount } from '@/entities/tokenAmount';
-import {
-    buildCallWithPermit2ProtocolVersionError,
-    VAULT_V2,
-    ZERO_ADDRESS,
-} from '@/utils';
+import { protocolVersionError, VAULT_V2, ZERO_ADDRESS } from '@/utils';
 import { vaultV2Abi } from '@/abi';
 import {
     AddLiquidityBase,
@@ -120,7 +116,13 @@ export class AddLiquidityComposableStable implements AddLiquidityBase {
         };
     }
 
-    public buildCallWithPermit2(): AddLiquidityBuildCallOutput {
-        throw buildCallWithPermit2ProtocolVersionError();
+    public buildCallWithPermit2(
+        input: AddLiquidityV2ComposableStableBuildCallInput,
+    ): AddLiquidityBuildCallOutput {
+        throw protocolVersionError(
+            'buildCallWithPermit2',
+            input.protocolVersion,
+            'buildCallWithPermit2 is supported on Balancer v3 only.',
+        );
     }
 }

--- a/src/entities/addLiquidity/addLiquidityV2/index.ts
+++ b/src/entities/addLiquidity/addLiquidityV2/index.ts
@@ -1,4 +1,4 @@
-import { buildCallWithPermit2ProtocolVersionError, SDKError } from '@/utils';
+import { protocolVersionError, SDKError } from '@/utils';
 import {
     AddLiquidityBase,
     AddLiquidityBuildCallOutput,
@@ -56,7 +56,13 @@ export class AddLiquidityV2 implements AddLiquidityBase {
         return this.getAddLiquidity(input.poolType).buildCall(input);
     }
 
-    public buildCallWithPermit2(): AddLiquidityBuildCallOutput {
-        throw buildCallWithPermit2ProtocolVersionError();
+    public buildCallWithPermit2(
+        input: AddLiquidityV2BuildCallInput,
+    ): AddLiquidityBuildCallOutput {
+        throw protocolVersionError(
+            'buildCallWithPermit2',
+            input.protocolVersion,
+            'buildCallWithPermit2 is supported on Balancer v3 only.',
+        );
     }
 }

--- a/src/entities/addLiquidity/addLiquidityV2/index.ts
+++ b/src/entities/addLiquidity/addLiquidityV2/index.ts
@@ -1,4 +1,4 @@
-import { buildCallWithPermit2ProtocolVersionError } from '@/utils';
+import { buildCallWithPermit2ProtocolVersionError, SDKError } from '@/utils';
 import {
     AddLiquidityBase,
     AddLiquidityBuildCallOutput,
@@ -34,7 +34,11 @@ export class AddLiquidityV2 implements AddLiquidityBase {
 
     public getAddLiquidity(poolType: string): AddLiquidityBase {
         if (!this.addLiquidityTypes[poolType]) {
-            throw new Error(`Unsupported pool type ${poolType}`);
+            throw new SDKError(
+                'Input Validation',
+                'Add Liquidity',
+                `Unsupported pool type ${poolType}`,
+            );
         }
         return this.addLiquidityTypes[poolType];
     }

--- a/src/entities/addLiquidity/addLiquidityV2/index.ts
+++ b/src/entities/addLiquidity/addLiquidityV2/index.ts
@@ -53,6 +53,6 @@ export class AddLiquidityV2 implements AddLiquidityBase {
     }
 
     public buildCallWithPermit2(): AddLiquidityBuildCallOutput {
-        throw buildCallWithPermit2ProtocolVersionError;
+        throw buildCallWithPermit2ProtocolVersionError();
     }
 }

--- a/src/entities/addLiquidity/addLiquidityV2/stable/addLiquidityStable.ts
+++ b/src/entities/addLiquidity/addLiquidityV2/stable/addLiquidityStable.ts
@@ -2,11 +2,7 @@ import { encodeFunctionData } from 'viem';
 import { Token } from '@/entities/token';
 import { TokenAmount } from '@/entities/tokenAmount';
 import { StableEncoder } from '@/entities/encoders/stable';
-import {
-    buildCallWithPermit2ProtocolVersionError,
-    VAULT_V2,
-    ZERO_ADDRESS,
-} from '@/utils';
+import { protocolVersionError, VAULT_V2, ZERO_ADDRESS } from '@/utils';
 import { vaultV2Abi } from '@/abi';
 import {
     AddLiquidityBase,
@@ -112,7 +108,13 @@ export class AddLiquidityStable implements AddLiquidityBase {
         };
     }
 
-    public buildCallWithPermit2(): AddLiquidityBuildCallOutput {
-        throw buildCallWithPermit2ProtocolVersionError();
+    public buildCallWithPermit2(
+        input: AddLiquidityV2BaseBuildCallInput,
+    ): AddLiquidityBuildCallOutput {
+        throw protocolVersionError(
+            'buildCallWithPermit2',
+            input.protocolVersion,
+            'buildCallWithPermit2 is supported on Balancer v3 only.',
+        );
     }
 }

--- a/src/entities/addLiquidity/addLiquidityV2/stable/addLiquidityStable.ts
+++ b/src/entities/addLiquidity/addLiquidityV2/stable/addLiquidityStable.ts
@@ -113,6 +113,6 @@ export class AddLiquidityStable implements AddLiquidityBase {
     }
 
     public buildCallWithPermit2(): AddLiquidityBuildCallOutput {
-        throw buildCallWithPermit2ProtocolVersionError;
+        throw buildCallWithPermit2ProtocolVersionError();
     }
 }

--- a/src/entities/addLiquidity/addLiquidityV2/weighted/addLiquidityWeighted.ts
+++ b/src/entities/addLiquidity/addLiquidityV2/weighted/addLiquidityWeighted.ts
@@ -2,11 +2,7 @@ import { encodeFunctionData } from 'viem';
 import { Token } from '@/entities/token';
 import { TokenAmount } from '@/entities/tokenAmount';
 import { WeightedEncoder } from '@/entities/encoders/weighted';
-import {
-    buildCallWithPermit2ProtocolVersionError,
-    VAULT_V2,
-    ZERO_ADDRESS,
-} from '@/utils';
+import { protocolVersionError, VAULT_V2, ZERO_ADDRESS } from '@/utils';
 import { vaultV2Abi } from '@/abi';
 import {
     AddLiquidityBase,
@@ -114,7 +110,13 @@ export class AddLiquidityWeighted implements AddLiquidityBase {
         };
     }
 
-    public buildCallWithPermit2(): AddLiquidityBuildCallOutput {
-        throw buildCallWithPermit2ProtocolVersionError();
+    public buildCallWithPermit2(
+        input: AddLiquidityV2BaseBuildCallInput,
+    ): AddLiquidityBuildCallOutput {
+        throw protocolVersionError(
+            'buildCallWithPermit2',
+            input.protocolVersion,
+            'buildCallWithPermit2 is supported on Balancer v3 only.',
+        );
     }
 }

--- a/src/entities/addLiquidity/addLiquidityV2/weighted/addLiquidityWeighted.ts
+++ b/src/entities/addLiquidity/addLiquidityV2/weighted/addLiquidityWeighted.ts
@@ -115,6 +115,6 @@ export class AddLiquidityWeighted implements AddLiquidityBase {
     }
 
     public buildCallWithPermit2(): AddLiquidityBuildCallOutput {
-        throw buildCallWithPermit2ProtocolVersionError;
+        throw buildCallWithPermit2ProtocolVersionError();
     }
 }

--- a/src/entities/addLiquidity/addLiquidityV3/index.ts
+++ b/src/entities/addLiquidity/addLiquidityV3/index.ts
@@ -1,5 +1,6 @@
 import { encodeFunctionData, zeroAddress } from 'viem';
 import { balancerRouterAbiExtended } from '@/abi';
+import { Permit2 } from '@/entities/permit2Helper';
 import { Token } from '@/entities/token';
 import { TokenAmount } from '@/entities/tokenAmount';
 import { PoolState } from '@/entities/types';
@@ -7,12 +8,10 @@ import {
     getAmounts,
     getBptAmountFromReferenceAmount,
     getSortedTokens,
+    getValue,
 } from '@/entities/utils';
 import { Hex } from '@/types';
-import {
-    BALANCER_ROUTER,
-    addLiquiditySingleTokenShouldHaveTokenInIndexError,
-} from '@/utils';
+import { BALANCER_ROUTER, addLiquidityMissingTokenInIndexError } from '@/utils';
 
 import { getAmountsCall } from '../helpers';
 import {
@@ -26,8 +25,6 @@ import {
 import { doAddLiquidityUnbalancedQuery } from './doAddLiquidityUnbalancedQuery';
 import { doAddLiquiditySingleTokenQuery } from './doAddLiquiditySingleTokenQuery';
 import { doAddLiquidityProportionalQuery } from './doAddLiquidityProportionalQuery';
-import { getValue } from '@/entities/utils/getValue';
-import { Permit2 } from '@/entities/permit2Helper';
 
 export class AddLiquidityV3 implements AddLiquidityBase {
     async query(
@@ -174,7 +171,7 @@ export class AddLiquidityV3 implements AddLiquidityBase {
                 {
                     // just a sanity check as this is already checked in InputValidator
                     if (input.tokenInIndex === undefined) {
-                        throw addLiquiditySingleTokenShouldHaveTokenInIndexError;
+                        throw addLiquidityMissingTokenInIndexError();
                     }
                     callData = encodeFunctionData({
                         abi: balancerRouterAbiExtended,

--- a/src/entities/addLiquidity/addLiquidityV3/index.ts
+++ b/src/entities/addLiquidity/addLiquidityV3/index.ts
@@ -11,7 +11,7 @@ import {
     getValue,
 } from '@/entities/utils';
 import { Hex } from '@/types';
-import { BALANCER_ROUTER, addLiquidityMissingTokenInIndexError } from '@/utils';
+import { BALANCER_ROUTER, missingParameterError } from '@/utils';
 
 import { getAmountsCall } from '../helpers';
 import {
@@ -171,7 +171,11 @@ export class AddLiquidityV3 implements AddLiquidityBase {
                 {
                     // just a sanity check as this is already checked in InputValidator
                     if (input.tokenInIndex === undefined) {
-                        throw addLiquidityMissingTokenInIndexError();
+                        throw missingParameterError(
+                            'Add Liquidity SingleToken',
+                            'tokenInIndex',
+                            input.protocolVersion,
+                        );
                     }
                     callData = encodeFunctionData({
                         abi: balancerRouterAbiExtended,

--- a/src/entities/addLiquidity/addLiquidityV3/index.ts
+++ b/src/entities/addLiquidity/addLiquidityV3/index.ts
@@ -16,11 +16,11 @@ import { BALANCER_ROUTER, missingParameterError } from '@/utils';
 import { getAmountsCall } from '../helpers';
 import {
     AddLiquidityBase,
-    AddLiquidityBaseBuildCallInput,
     AddLiquidityBaseQueryOutput,
     AddLiquidityBuildCallOutput,
     AddLiquidityInput,
     AddLiquidityKind,
+    AddLiquidityV3BuildCallInput,
 } from '../types';
 import { doAddLiquidityUnbalancedQuery } from './doAddLiquidityUnbalancedQuery';
 import { doAddLiquiditySingleTokenQuery } from './doAddLiquiditySingleTokenQuery';
@@ -132,7 +132,7 @@ export class AddLiquidityV3 implements AddLiquidityBase {
     }
 
     buildCall(
-        input: AddLiquidityBaseBuildCallInput & { userData: Hex },
+        input: AddLiquidityV3BuildCallInput,
     ): AddLiquidityBuildCallOutput {
         const amounts = getAmountsCall(input);
         let callData: Hex;
@@ -208,7 +208,7 @@ export class AddLiquidityV3 implements AddLiquidityBase {
     }
 
     public buildCallWithPermit2(
-        input: AddLiquidityBaseBuildCallInput & { userData: Hex },
+        input: AddLiquidityV3BuildCallInput,
         permit2: Permit2,
     ): AddLiquidityBuildCallOutput {
         const buildCallOutput = this.buildCall(input);

--- a/src/entities/addLiquidity/types.ts
+++ b/src/entities/addLiquidity/types.ts
@@ -64,8 +64,12 @@ export type AddLiquidityBaseBuildCallInput = {
     wethIsEth?: boolean;
 } & AddLiquidityBaseQueryOutput;
 
+export type AddLiquidityV3BuildCallInput = AddLiquidityBaseBuildCallInput & {
+    userData: Hex;
+};
+
 export type AddLiquidityBuildCallInput =
-    | AddLiquidityBaseBuildCallInput
+    | AddLiquidityV3BuildCallInput
     | AddLiquidityV2BuildCallInput;
 
 export interface AddLiquidityBase {

--- a/src/entities/addLiquidityBoosted/index.ts
+++ b/src/entities/addLiquidityBoosted/index.ts
@@ -20,7 +20,10 @@ import {
 import { doAddLiquidityUnbalancedQuery } from './doAddLiquidityUnbalancedQuery';
 import { doAddLiquidityProportionalQuery } from './doAddLiquidityPropotionalQuery';
 import { Token } from '../token';
-import { BALANCER_COMPOSITE_LIQUIDITY_ROUTER_BOOSTED } from '@/utils';
+import {
+    BALANCER_COMPOSITE_LIQUIDITY_ROUTER_BOOSTED,
+    protocolVersionError,
+} from '@/utils';
 import {
     balancerCompositeLiquidityRouterBoostedAbiExtended,
     balancerRouterAbiExtended,
@@ -65,13 +68,10 @@ export class AddLiquidityBoostedV3 {
                 // Use amountsIn provided by use to infer if token should be wrapped
                 const tokensIn: MinimalTokenWithIsUnderlyingFlag[] =
                     input.amountsIn.map((amountIn) => {
-                        const amountInAddress = amountIn.address.toLowerCase();
+                        const amountInAddress =
+                            amountIn.address.toLowerCase() as Address;
+                        // input validation already verifies that token is in poolState
                         const token = poolStateTokenMap[amountInAddress];
-                        if (!token) {
-                            throw new Error(
-                                `Token not found in poolState: ${amountInAddress}`,
-                            );
-                        }
                         return token;
                     });
 
@@ -128,9 +128,6 @@ export class AddLiquidityBoostedV3 {
                 input.tokensIn.forEach((t) => {
                     const tokenIn =
                         poolStateTokenMap[t.toLowerCase() as Address];
-                    if (!tokenIn) {
-                        throw new Error(`Invalid token address: ${t}`);
-                    }
                     wrapUnderlying[tokenIn.index] = tokenIn.isUnderlyingToken;
                 });
 
@@ -223,7 +220,10 @@ export class AddLiquidityBoostedV3 {
                 break;
             }
             case AddLiquidityKind.SingleToken: {
-                throw new Error('SingleToken not supported');
+                throw protocolVersionError(
+                    'Add Liquidity Boosted Single Token',
+                    input.protocolVersion,
+                );
             }
         }
 

--- a/src/entities/addLiquidityNested/addLiquidityNestedV2/encodeCalls.ts
+++ b/src/entities/addLiquidityNested/addLiquidityNestedV2/encodeCalls.ts
@@ -7,6 +7,7 @@ import { replaceWrapped } from '@/entities/utils';
 import { AddLiquidityNestedCallAttributes } from './types';
 import { WeightedEncoder } from '@/entities/encoders';
 import { PoolType } from '@/types';
+import { poolTypeError } from '@/utils';
 
 export const encodeCalls = (
     callsAttributes: AddLiquidityNestedCallAttributes[],
@@ -90,6 +91,6 @@ const getUserData = (
                 minBptOut,
             );
         default:
-            throw new Error(`Unsupported pool type: ${poolType}`);
+            throw poolTypeError('Add Liquidity Nested', poolType);
     }
 };

--- a/src/entities/addLiquidityNested/addLiquidityNestedV2/validateInputs.ts
+++ b/src/entities/addLiquidityNested/addLiquidityNestedV2/validateInputs.ts
@@ -1,4 +1,5 @@
-import { NATIVE_ASSETS } from '../../../utils';
+import { inputValidationError, NATIVE_ASSETS } from '@/utils';
+
 import { Token } from '../../token';
 import { TokenAmount } from '../../tokenAmount';
 import { NestedPoolState } from '../../types';
@@ -17,8 +18,9 @@ export const validateQueryInput = (
             t.isSameAddress(amountIn.address),
         );
         if (tokenIn === undefined) {
-            throw new Error(
-                `Adding liquidity with ${amountIn.address} requires it to exist within mainTokens`,
+            throw inputValidationError(
+                'Add Liquidity Nested',
+                `Adding liquidity with amountIn address ${amountIn.address} requires it to exist within mainTokens`,
             );
         }
         return TokenAmount.fromRawAmount(tokenIn, amountIn.rawAmount);
@@ -36,7 +38,8 @@ export const validateBuildCallInput = (
                 a.token.isUnderlyingEqual(NATIVE_ASSETS[chainId]),
             )
         ) {
-            throw new Error(
+            throw inputValidationError(
+                'Add Liquidity Nested',
                 'Adding liquidity with native asset requires wrapped native asset to exist within amountsIn',
             );
         }

--- a/src/entities/addLiquidityNested/index.ts
+++ b/src/entities/addLiquidityNested/index.ts
@@ -12,6 +12,7 @@ import { Permit2 } from '../permit2Helper';
 import { AddLiquidityNestedCallInputV3 } from './addLiquidityNestedV3/types';
 import { Slippage } from '../slippage';
 import { Address, Hex } from 'viem';
+import { protocolVersionError } from '@/utils/errors';
 
 export class AddLiquidityNested {
     async query(
@@ -22,8 +23,9 @@ export class AddLiquidityNested {
         validateNestedPoolState(nestedPoolState);
         switch (nestedPoolState.protocolVersion) {
             case 1: {
-                throw new Error(
-                    'AddLiquidityNested not supported for ProtocolVersion 1.',
+                throw protocolVersionError(
+                    'AddLiquidityNested',
+                    nestedPoolState.protocolVersion,
                 );
             }
             case 2: {

--- a/src/entities/createPool/createPoolV2/index.ts
+++ b/src/entities/createPool/createPoolV2/index.ts
@@ -1,4 +1,6 @@
 import { PoolType } from '@/types';
+import { poolTypeProtocolVersionError } from '@/utils';
+
 import { CreatePoolComposableStableV2 } from './composableStable/createPoolComposableStable';
 import {
     CreatePoolBase,
@@ -19,7 +21,7 @@ export class CreatePoolV2 implements CreatePoolBase {
 
     private getCreatePool(poolType: string): CreatePoolBase {
         if (!this.createPoolTypes[poolType]) {
-            throw new Error('Unsupported pool type: ${poolType}');
+            throw poolTypeProtocolVersionError('Create Pool', poolType, 2);
         }
         return this.createPoolTypes[poolType];
     }

--- a/src/entities/createPool/createPoolV3/index.ts
+++ b/src/entities/createPool/createPoolV3/index.ts
@@ -1,4 +1,6 @@
 import { PoolType } from '@/types';
+import { poolTypeProtocolVersionError } from '@/utils';
+
 import {
     CreatePoolBase,
     CreatePoolBuildCallOutput,
@@ -8,6 +10,7 @@ import { CreatePoolWeightedV3 } from './weighted/createPoolWeighted';
 import { CreatePoolStableV3 } from './stable/createPoolStable';
 import { CreatePoolStableSurge } from './stableSurge/createStableSurge';
 import { CreatePoolGyroECLP } from './gyroECLP/createPoolGyroECLP';
+
 export class CreatePoolV3 implements CreatePoolBase {
     private readonly createPoolTypes: Record<string, CreatePoolBase> = {};
 
@@ -22,7 +25,7 @@ export class CreatePoolV3 implements CreatePoolBase {
 
     private getCreatePool(poolType: string): CreatePoolBase {
         if (!this.createPoolTypes[poolType]) {
-            throw new Error('Unsupported pool type: ${poolType}');
+            throw poolTypeProtocolVersionError('Create Pool', poolType, 3);
         }
         return this.createPoolTypes[poolType];
     }

--- a/src/entities/encoders/composableStable.ts
+++ b/src/entities/encoders/composableStable.ts
@@ -8,7 +8,7 @@ import {
 } from '../types';
 import { RemoveLiquidityKind } from '../removeLiquidity/types';
 import {
-    addLiquidityMissingTokenInIndexError,
+    missingParameterError,
     removeLiquidityMissingTokenOutIndexError,
 } from '@/utils/errors';
 import { encodeRemoveLiquidityRecovery } from './base';
@@ -62,7 +62,11 @@ export class ComposableStableEncoder {
             case AddLiquidityKind.SingleToken: {
                 // just a sanity check as this is already checked in InputValidator
                 if (amounts.tokenInIndex === undefined) {
-                    throw addLiquidityMissingTokenInIndexError();
+                    throw missingParameterError(
+                        'Add Liquidity SingleToken',
+                        'tokenInIndex',
+                        2,
+                    );
                 }
                 return ComposableStableEncoder.addLiquiditySingleToken(
                     amounts.minimumBpt,

--- a/src/entities/encoders/composableStable.ts
+++ b/src/entities/encoders/composableStable.ts
@@ -7,10 +7,7 @@ import {
     RemoveLiquidityAmounts,
 } from '../types';
 import { RemoveLiquidityKind } from '../removeLiquidity/types';
-import {
-    missingParameterError,
-    removeLiquidityMissingTokenOutIndexError,
-} from '@/utils/errors';
+import { missingParameterError } from '@/utils/errors';
 import { encodeRemoveLiquidityRecovery } from './base';
 
 export enum ComposableStablePoolJoinKind {
@@ -100,7 +97,11 @@ export class ComposableStableEncoder {
                 );
             case RemoveLiquidityKind.SingleTokenExactIn:
                 if (amounts.tokenOutIndex === undefined)
-                    throw removeLiquidityMissingTokenOutIndexError();
+                    throw missingParameterError(
+                        'Remove Liquidity SingleTokenExactIn',
+                        'tokenOutIndex',
+                        2,
+                    );
 
                 return ComposableStableEncoder.removeLiquiditySingleTokenExactIn(
                     amounts.maxBptAmountIn,

--- a/src/entities/encoders/composableStable.ts
+++ b/src/entities/encoders/composableStable.ts
@@ -8,8 +8,8 @@ import {
 } from '../types';
 import { RemoveLiquidityKind } from '../removeLiquidity/types';
 import {
-    addLiquiditySingleTokenShouldHaveTokenInIndexError,
-    removeLiquiditySingleTokenExactInShouldHaveTokenOutIndexError,
+    addLiquidityMissingTokenInIndexError,
+    removeLiquidityMissingTokenOutIndexError,
 } from '@/utils/errors';
 import { encodeRemoveLiquidityRecovery } from './base';
 
@@ -62,7 +62,7 @@ export class ComposableStableEncoder {
             case AddLiquidityKind.SingleToken: {
                 // just a sanity check as this is already checked in InputValidator
                 if (amounts.tokenInIndex === undefined) {
-                    throw addLiquiditySingleTokenShouldHaveTokenInIndexError;
+                    throw addLiquidityMissingTokenInIndexError();
                 }
                 return ComposableStableEncoder.addLiquiditySingleToken(
                     amounts.minimumBpt,
@@ -96,7 +96,7 @@ export class ComposableStableEncoder {
                 );
             case RemoveLiquidityKind.SingleTokenExactIn:
                 if (amounts.tokenOutIndex === undefined)
-                    throw removeLiquiditySingleTokenExactInShouldHaveTokenOutIndexError;
+                    throw removeLiquidityMissingTokenOutIndexError();
 
                 return ComposableStableEncoder.removeLiquiditySingleTokenExactIn(
                     amounts.maxBptAmountIn,

--- a/src/entities/encoders/stable.ts
+++ b/src/entities/encoders/stable.ts
@@ -8,8 +8,8 @@ import {
 } from '../types';
 import { RemoveLiquidityKind } from '../removeLiquidity/types';
 import {
-    addLiquiditySingleTokenShouldHaveTokenInIndexError,
-    removeLiquiditySingleTokenExactInShouldHaveTokenOutIndexError,
+    addLiquidityMissingTokenInIndexError,
+    removeLiquidityMissingTokenOutIndexError,
 } from '@/utils/errors';
 import { encodeRemoveLiquidityRecovery } from './base';
 
@@ -61,7 +61,7 @@ export class StableEncoder {
             case AddLiquidityKind.SingleToken: {
                 // just a sanity check as this is already checked in InputValidator
                 if (amounts.tokenInIndex === undefined) {
-                    throw addLiquiditySingleTokenShouldHaveTokenInIndexError;
+                    throw addLiquidityMissingTokenInIndexError();
                 }
                 return StableEncoder.addLiquiditySingleToken(
                     amounts.minimumBpt,
@@ -92,7 +92,7 @@ export class StableEncoder {
                 );
             case RemoveLiquidityKind.SingleTokenExactIn:
                 if (amounts.tokenOutIndex === undefined)
-                    throw removeLiquiditySingleTokenExactInShouldHaveTokenOutIndexError;
+                    throw removeLiquidityMissingTokenOutIndexError();
 
                 return StableEncoder.removeLiquiditySingleTokenExactIn(
                     amounts.maxBptAmountIn,

--- a/src/entities/encoders/stable.ts
+++ b/src/entities/encoders/stable.ts
@@ -9,6 +9,7 @@ import {
 import { RemoveLiquidityKind } from '../removeLiquidity/types';
 import {
     addLiquidityMissingTokenInIndexError,
+    poolTypeProtocolVersionError,
     removeLiquidityMissingTokenOutIndexError,
 } from '@/utils/errors';
 import { encodeRemoveLiquidityRecovery } from './base';
@@ -69,7 +70,11 @@ export class StableEncoder {
                 );
             }
             default:
-                throw new Error(`AddLiquidityKind not supported: ${kind}`);
+                throw poolTypeProtocolVersionError(
+                    `Add Liquidity ${kind}`,
+                    'Stable',
+                    2,
+                );
         }
     };
 

--- a/src/entities/encoders/stable.ts
+++ b/src/entities/encoders/stable.ts
@@ -10,7 +10,6 @@ import { RemoveLiquidityKind } from '../removeLiquidity/types';
 import {
     missingParameterError,
     poolTypeProtocolVersionError,
-    removeLiquidityMissingTokenOutIndexError,
 } from '@/utils/errors';
 import { encodeRemoveLiquidityRecovery } from './base';
 
@@ -101,7 +100,11 @@ export class StableEncoder {
                 );
             case RemoveLiquidityKind.SingleTokenExactIn:
                 if (amounts.tokenOutIndex === undefined)
-                    throw removeLiquidityMissingTokenOutIndexError();
+                    throw missingParameterError(
+                        'Remove Liquidity SingleTokenExactIn',
+                        'tokenOutIndex',
+                        2,
+                    );
 
                 return StableEncoder.removeLiquiditySingleTokenExactIn(
                     amounts.maxBptAmountIn,

--- a/src/entities/encoders/stable.ts
+++ b/src/entities/encoders/stable.ts
@@ -8,7 +8,7 @@ import {
 } from '../types';
 import { RemoveLiquidityKind } from '../removeLiquidity/types';
 import {
-    addLiquidityMissingTokenInIndexError,
+    missingParameterError,
     poolTypeProtocolVersionError,
     removeLiquidityMissingTokenOutIndexError,
 } from '@/utils/errors';
@@ -62,7 +62,11 @@ export class StableEncoder {
             case AddLiquidityKind.SingleToken: {
                 // just a sanity check as this is already checked in InputValidator
                 if (amounts.tokenInIndex === undefined) {
-                    throw addLiquidityMissingTokenInIndexError();
+                    throw missingParameterError(
+                        'Add Liquidity SingleToken',
+                        'tokenInIndex',
+                        2,
+                    );
                 }
                 return StableEncoder.addLiquiditySingleToken(
                     amounts.minimumBpt,

--- a/src/entities/encoders/weighted.ts
+++ b/src/entities/encoders/weighted.ts
@@ -7,10 +7,7 @@ import {
     RemoveLiquidityAmounts,
 } from '../types';
 import { RemoveLiquidityKind } from '../removeLiquidity/types';
-import {
-    missingParameterError,
-    removeLiquidityMissingTokenOutIndexError,
-} from '@/utils/errors';
+import { missingParameterError } from '@/utils/errors';
 import { encodeRemoveLiquidityRecovery } from './base';
 
 export enum WeightedPoolJoinKind {
@@ -101,7 +98,11 @@ export class WeightedEncoder {
                 );
             case RemoveLiquidityKind.SingleTokenExactIn:
                 if (amounts.tokenOutIndex === undefined)
-                    throw removeLiquidityMissingTokenOutIndexError();
+                    throw missingParameterError(
+                        'Remove Liquidity SingleTokenExactIn',
+                        'tokenOutIndex',
+                        2,
+                    );
 
                 return WeightedEncoder.removeLiquiditySingleTokenExactIn(
                     amounts.maxBptAmountIn,

--- a/src/entities/encoders/weighted.ts
+++ b/src/entities/encoders/weighted.ts
@@ -8,8 +8,8 @@ import {
 } from '../types';
 import { RemoveLiquidityKind } from '../removeLiquidity/types';
 import {
-    addLiquiditySingleTokenShouldHaveTokenInIndexError,
-    removeLiquiditySingleTokenExactInShouldHaveTokenOutIndexError,
+    addLiquidityMissingTokenInIndexError,
+    removeLiquidityMissingTokenOutIndexError,
 } from '@/utils/errors';
 import { encodeRemoveLiquidityRecovery } from './base';
 
@@ -63,7 +63,7 @@ export class WeightedEncoder {
             case AddLiquidityKind.SingleToken: {
                 // just a sanity check as this is already checked in InputValidator
                 if (amounts.tokenInIndex === undefined) {
-                    throw addLiquiditySingleTokenShouldHaveTokenInIndexError;
+                    throw addLiquidityMissingTokenInIndexError();
                 }
                 return WeightedEncoder.addLiquiditySingleToken(
                     amounts.minimumBpt,
@@ -97,7 +97,7 @@ export class WeightedEncoder {
                 );
             case RemoveLiquidityKind.SingleTokenExactIn:
                 if (amounts.tokenOutIndex === undefined)
-                    throw removeLiquiditySingleTokenExactInShouldHaveTokenOutIndexError;
+                    throw removeLiquidityMissingTokenOutIndexError();
 
                 return WeightedEncoder.removeLiquiditySingleTokenExactIn(
                     amounts.maxBptAmountIn,

--- a/src/entities/encoders/weighted.ts
+++ b/src/entities/encoders/weighted.ts
@@ -8,7 +8,7 @@ import {
 } from '../types';
 import { RemoveLiquidityKind } from '../removeLiquidity/types';
 import {
-    addLiquidityMissingTokenInIndexError,
+    missingParameterError,
     removeLiquidityMissingTokenOutIndexError,
 } from '@/utils/errors';
 import { encodeRemoveLiquidityRecovery } from './base';
@@ -63,7 +63,11 @@ export class WeightedEncoder {
             case AddLiquidityKind.SingleToken: {
                 // just a sanity check as this is already checked in InputValidator
                 if (amounts.tokenInIndex === undefined) {
-                    throw addLiquidityMissingTokenInIndexError();
+                    throw missingParameterError(
+                        'Add Liquidity SingleToken',
+                        'tokenInIndex',
+                        2,
+                    );
                 }
                 return WeightedEncoder.addLiquiditySingleToken(
                     amounts.minimumBpt,

--- a/src/entities/initPool/initPoolV2/index.ts
+++ b/src/entities/initPool/initPoolV2/index.ts
@@ -1,5 +1,6 @@
 import { PoolState } from '@/entities/types';
 import { PoolType } from '@/types';
+import { poolTypeProtocolVersionError } from '@/utils';
 
 import { InitPoolComposableStable } from './composableStable/initPoolComposableStable';
 import {
@@ -24,7 +25,7 @@ export class InitPoolV2 implements InitPoolBase {
 
     getInitPool(poolType: string): InitPoolBase {
         if (!this.initPoolTypes[poolType]) {
-            throw new Error('Unsupported pool type: ${poolType}');
+            throw poolTypeProtocolVersionError('Init Pool', poolType, 2);
         }
         return this.initPoolTypes[poolType];
     }

--- a/src/entities/inputValidator/boosted/inputValidatorBoosted.ts
+++ b/src/entities/inputValidator/boosted/inputValidatorBoosted.ts
@@ -3,7 +3,11 @@ import { PoolStateWithUnderlyings } from '@/entities/types';
 import { InputValidatorBase } from '../inputValidatorBase';
 import { AddLiquidityKind } from '@/entities/addLiquidity/types';
 import { AddLiquidityBoostedInput } from '@/entities/addLiquidityBoosted/types';
-import { isSameAddress, protocolVersionError } from '@/utils';
+import {
+    inputValidationError,
+    isSameAddress,
+    protocolVersionError,
+} from '@/utils';
 
 export class InputValidatorBoosted extends InputValidatorBase {
     validateAddLiquidityBoosted(
@@ -29,8 +33,9 @@ export class InputValidatorBoosted extends InputValidatorBase {
 
             addLiquidityInput.amountsIn.forEach((a) => {
                 if (!poolTokens.includes(a.address.toLowerCase() as Address)) {
-                    throw new Error(
-                        `Address ${a.address} is not contained in the pool's parent or child tokens.`,
+                    throw inputValidationError(
+                        'Add Liquidity Boosted',
+                        `amountIn address ${a.address} should exist in poolState tokens`,
                     );
                 }
             });
@@ -52,8 +57,9 @@ export class InputValidatorBoosted extends InputValidatorBase {
                         ),
                     ) === -1
                 ) {
-                    throw new Error(
-                        'tokensIn must contain referenceAmount token address',
+                    throw inputValidationError(
+                        'Add Liquidity Boosted',
+                        `referenceAmount address ${addLiquidityInput.referenceAmount.address} should exist in tokensIn`,
                     );
                 }
             }

--- a/src/entities/inputValidator/boosted/inputValidatorBoosted.ts
+++ b/src/entities/inputValidator/boosted/inputValidatorBoosted.ts
@@ -3,7 +3,7 @@ import { PoolStateWithUnderlyings } from '@/entities/types';
 import { InputValidatorBase } from '../inputValidatorBase';
 import { AddLiquidityKind } from '@/entities/addLiquidity/types';
 import { AddLiquidityBoostedInput } from '@/entities/addLiquidityBoosted/types';
-import { isSameAddress } from '@/utils';
+import { isSameAddress, protocolVersionError } from '@/utils';
 
 export class InputValidatorBoosted extends InputValidatorBase {
     validateAddLiquidityBoosted(
@@ -12,7 +12,10 @@ export class InputValidatorBoosted extends InputValidatorBase {
     ): void {
         //check if poolState.protocolVersion is 3
         if (poolState.protocolVersion !== 3) {
-            throw new Error('protocol version must be 3');
+            throw protocolVersionError(
+                'Add Liquidity Boosted',
+                poolState.protocolVersion,
+            );
         }
 
         if (addLiquidityInput.kind === AddLiquidityKind.Unbalanced) {

--- a/src/entities/inputValidator/composableStable/inputValidatorComposableStable.ts
+++ b/src/entities/inputValidator/composableStable/inputValidatorComposableStable.ts
@@ -1,3 +1,4 @@
+import { inputValidationError } from '@/utils';
 import { AddLiquidityInput } from '../../addLiquidity/types';
 import { CreatePoolV2ComposableStableInput } from '../../createPool/types';
 import {
@@ -14,7 +15,7 @@ export class InputValidatorComposableStable extends InputValidatorBase {
         poolState: PoolState,
     ): void {
         super.validateAddLiquidity(addLiquidityInput, poolState);
-        validatePoolHasBpt(poolState);
+        validatePoolHasBpt('Add Liquidity', poolState);
     }
 
     validateRemoveLiquidity(
@@ -22,7 +23,7 @@ export class InputValidatorComposableStable extends InputValidatorBase {
         poolState: PoolState,
     ): void {
         super.validateRemoveLiquidity(input, poolState);
-        validatePoolHasBpt(poolState);
+        validatePoolHasBpt('Remove Liquidity', poolState);
     }
 
     validateRemoveLiquidityRecovery(
@@ -30,22 +31,27 @@ export class InputValidatorComposableStable extends InputValidatorBase {
         poolStateWithBalances: PoolStateWithBalances,
     ): void {
         super.validateRemoveLiquidityRecovery(input, poolStateWithBalances);
-        validatePoolHasBpt(poolStateWithBalances);
+        validatePoolHasBpt('Remove Liquidity Recovery', poolStateWithBalances);
     }
 
     validateCreatePool(input: CreatePoolV2ComposableStableInput): void {
         super.validateCreatePool(input);
         if (input.tokens.length > 5) {
-            throw new Error(
-                'Composable stable pools can have a maximum of 5 tokens',
+            throw inputValidationError(
+                'Create Pool',
+                'Composable stable pools can have a maximum of 5 tokens on Balancer v2',
             );
         }
         if (input.amplificationParameter <= BigInt(0)) {
-            throw new Error('Amplification parameter must be greater than 0');
+            throw inputValidationError(
+                'Create Pool',
+                'Amplification parameter must be greater than 0 on Balancer v2',
+            );
         }
         if (input.amplificationParameter > BigInt(5000)) {
-            throw new Error(
-                'Amplification parameter must be equal or lower than 5000',
+            throw inputValidationError(
+                'Create Pool',
+                'Amplification parameter must be equal or lower than 5000 on Balancer v2',
             );
         }
         return;

--- a/src/entities/inputValidator/cowAmm/inputValidatorCowAmm.ts
+++ b/src/entities/inputValidator/cowAmm/inputValidatorCowAmm.ts
@@ -9,11 +9,7 @@ import {
     validateTokensAddLiquidity,
     validateTokensRemoveLiquidity,
 } from '../utils/validateTokens';
-import {
-    addLiquidityProportionalOnlyError,
-    poolTypeError,
-    protocolVersionError,
-} from '@/utils';
+import { poolTypeError, protocolVersionError } from '@/utils';
 
 export class InputValidatorCowAmm extends InputValidatorBase {
     validateInitPool(): void {
@@ -25,9 +21,10 @@ export class InputValidatorCowAmm extends InputValidatorBase {
         poolState: PoolState,
     ): void {
         if (addLiquidityInput.kind !== AddLiquidityKind.Proportional) {
-            throw addLiquidityProportionalOnlyError(
-                addLiquidityInput.kind,
+            throw poolTypeError(
+                `Add Liquidity ${addLiquidityInput.kind}`,
                 poolState.type,
+                'Use Add Liquidity Proportional',
             );
         }
         validateTokensAddLiquidity(addLiquidityInput, poolState);

--- a/src/entities/inputValidator/cowAmm/inputValidatorCowAmm.ts
+++ b/src/entities/inputValidator/cowAmm/inputValidatorCowAmm.ts
@@ -11,8 +11,8 @@ import {
 } from '../utils/validateTokens';
 import {
     addLiquidityProportionalOnlyError,
+    poolTypeError,
     protocolVersionError,
-    removeLiquidityProportionalOnlyError,
 } from '@/utils';
 
 export class InputValidatorCowAmm extends InputValidatorBase {
@@ -38,9 +38,10 @@ export class InputValidatorCowAmm extends InputValidatorBase {
         poolState: PoolState,
     ): void {
         if (removeLiquidityInput.kind !== RemoveLiquidityKind.Proportional) {
-            throw removeLiquidityProportionalOnlyError(
-                removeLiquidityInput.kind,
+            throw poolTypeError(
+                `Remove Liquidity ${removeLiquidityInput.kind}`,
                 poolState.type,
+                'Use Remove Liquidity Proportional',
             );
         }
         validateTokensRemoveLiquidity(removeLiquidityInput, poolState);

--- a/src/entities/inputValidator/cowAmm/inputValidatorCowAmm.ts
+++ b/src/entities/inputValidator/cowAmm/inputValidatorCowAmm.ts
@@ -1,6 +1,4 @@
-import { InitPoolInput } from '@/entities/initPool';
 import { AddLiquidityInput, AddLiquidityKind } from '../../addLiquidity/types';
-import { CreatePoolInput } from '../../createPool/types';
 import {
     RemoveLiquidityInput,
     RemoveLiquidityKind,
@@ -13,13 +11,13 @@ import {
 } from '../utils/validateTokens';
 import {
     addLiquidityProportionalOnlyError,
+    protocolVersionError,
     removeLiquidityProportionalOnlyError,
 } from '@/utils';
 
 export class InputValidatorCowAmm extends InputValidatorBase {
-    // biome-ignore lint/correctness/noUnusedVariables: <explanation>
-    validateInitPool(initPoolInput: InitPoolInput, poolState: PoolState): void {
-        throw new Error('Method not implemented.');
+    validateInitPool(): void {
+        throw protocolVersionError('Init Pool', 1);
     }
 
     validateAddLiquidity(
@@ -48,8 +46,7 @@ export class InputValidatorCowAmm extends InputValidatorBase {
         validateTokensRemoveLiquidity(removeLiquidityInput, poolState);
     }
 
-    validateCreatePool(input: CreatePoolInput): void {
-        console.log(input);
-        throw new Error('Method not implemented.');
+    validateCreatePool(): void {
+        throw protocolVersionError('Create Pool', 1);
     }
 }

--- a/src/entities/inputValidator/gyro/inputValidatorGyro.ts
+++ b/src/entities/inputValidator/gyro/inputValidatorGyro.ts
@@ -9,11 +9,7 @@ import {
     validateTokensAddLiquidity,
     validateTokensRemoveLiquidity,
 } from '../utils/validateTokens';
-import {
-    addLiquidityProportionalOnlyError,
-    inputValidationError,
-    poolTypeError,
-} from '@/utils';
+import { inputValidationError, poolTypeError } from '@/utils';
 import { CreatePoolGyroECLPInput } from '@/entities/createPool';
 import { GyroECLPMath } from '@balancer-labs/balancer-maths';
 
@@ -39,9 +35,10 @@ export class InputValidatorGyro extends InputValidatorBase {
         poolState: PoolState,
     ): void {
         if (addLiquidityInput.kind !== AddLiquidityKind.Proportional) {
-            throw addLiquidityProportionalOnlyError(
-                addLiquidityInput.kind,
+            throw poolTypeError(
+                `Add Liquidity ${addLiquidityInput.kind}`,
                 poolState.type,
+                'Use Add Liquidity Proportional',
             );
         }
         validateTokensAddLiquidity(addLiquidityInput, poolState);

--- a/src/entities/inputValidator/gyro/inputValidatorGyro.ts
+++ b/src/entities/inputValidator/gyro/inputValidatorGyro.ts
@@ -11,6 +11,7 @@ import {
 } from '../utils/validateTokens';
 import {
     addLiquidityProportionalOnlyError,
+    inputValidationError,
     removeLiquidityProportionalOnlyError,
 } from '@/utils';
 import { CreatePoolGyroECLPInput } from '@/entities/createPool';
@@ -21,7 +22,10 @@ export class InputValidatorGyro extends InputValidatorBase {
         super.validateCreatePool(input);
 
         if (input.tokens.length !== 2) {
-            throw new Error('GyroECLP pools on v3 support only two tokens');
+            throw inputValidationError(
+                'Create Pool',
+                'GyroECLP pools support only two tokens on Balancer v3',
+            );
         }
 
         const { eclpParams, derivedEclpParams } = input;

--- a/src/entities/inputValidator/gyro/inputValidatorGyro.ts
+++ b/src/entities/inputValidator/gyro/inputValidatorGyro.ts
@@ -12,7 +12,6 @@ import {
 import { inputValidationError, poolTypeError } from '@/utils';
 import { CreatePoolGyroECLPInput } from '@/entities/createPool';
 import { GyroECLPMath } from '@balancer-labs/balancer-maths';
-
 export class InputValidatorGyro extends InputValidatorBase {
     validateCreatePool(input: CreatePoolGyroECLPInput) {
         super.validateCreatePool(input);
@@ -26,10 +25,26 @@ export class InputValidatorGyro extends InputValidatorBase {
 
         const { eclpParams, derivedEclpParams } = input;
 
-        GyroECLPMath.validateParams(eclpParams);
-        GyroECLPMath.validateDerivedParams(eclpParams, derivedEclpParams);
-    }
+        try {
+            GyroECLPMath.validateParams(eclpParams);
+        } catch (err) {
+            throw inputValidationError(
+                'Create Pool',
+                'Invalid base ECLP parameters',
+                (err as Error).message,
+            );
+        }
 
+        try {
+            GyroECLPMath.validateDerivedParams(eclpParams, derivedEclpParams);
+        } catch (err) {
+            throw inputValidationError(
+                'Create Pool',
+                'Invalid derived ECLP parameters',
+                (err as Error).message,
+            );
+        }
+    }
     validateAddLiquidity(
         addLiquidityInput: AddLiquidityInput,
         poolState: PoolState,

--- a/src/entities/inputValidator/gyro/inputValidatorGyro.ts
+++ b/src/entities/inputValidator/gyro/inputValidatorGyro.ts
@@ -12,7 +12,7 @@ import {
 import {
     addLiquidityProportionalOnlyError,
     inputValidationError,
-    removeLiquidityProportionalOnlyError,
+    poolTypeError,
 } from '@/utils';
 import { CreatePoolGyroECLPInput } from '@/entities/createPool';
 import { GyroECLPMath } from '@balancer-labs/balancer-maths';
@@ -52,9 +52,10 @@ export class InputValidatorGyro extends InputValidatorBase {
         poolState: PoolState,
     ): void {
         if (removeLiquidityInput.kind !== RemoveLiquidityKind.Proportional) {
-            throw removeLiquidityProportionalOnlyError(
-                removeLiquidityInput.kind,
+            throw poolTypeError(
+                `Remove Liquidity ${removeLiquidityInput.kind}`,
                 poolState.type,
+                'Use Remove Liquidity Proportional',
             );
         }
         validateTokensRemoveLiquidity(removeLiquidityInput, poolState);

--- a/src/entities/inputValidator/inputValidator.ts
+++ b/src/entities/inputValidator/inputValidator.ts
@@ -114,7 +114,7 @@ export class InputValidator {
         protocolVersion: number;
     }): void {
         if (input.protocolVersion !== 3) {
-            throw buildCallWithPermit2ProtocolVersionError;
+            throw buildCallWithPermit2ProtocolVersionError();
         }
     }
 }

--- a/src/entities/inputValidator/inputValidator.ts
+++ b/src/entities/inputValidator/inputValidator.ts
@@ -14,7 +14,11 @@ import { InputValidatorStable } from './stable/inputValidatorStable';
 import { InputValidatorBase } from './inputValidatorBase';
 import { InputValidatorWeighted } from './weighted/inputValidatorWeighted';
 import { InputValidatorBoosted } from './boosted/inputValidatorBoosted';
-import { ChainId, buildCallWithPermit2ProtocolVersionError } from '@/utils';
+import {
+    ChainId,
+    SDKError,
+    buildCallWithPermit2ProtocolVersionError,
+} from '@/utils';
 import { AddLiquidityBoostedInput } from '../addLiquidityBoosted/types';
 
 export class InputValidator {
@@ -95,10 +99,6 @@ export class InputValidator {
         addLiquidityInput: AddLiquidityBoostedInput,
         poolState: PoolStateWithUnderlyings,
     ): void {
-        if (poolState.type !== PoolType.Boosted)
-            throw new Error(
-                `validateAddLiquidityBoosted on non boosted pool: ${poolState.address}:${poolState.type}`,
-            );
         this.validateChain(addLiquidityInput.chainId);
         (
             this.validators[PoolType.Boosted] as InputValidatorBoosted
@@ -107,7 +107,11 @@ export class InputValidator {
 
     private validateChain(chainId: number): void {
         if (chainId in ChainId) return;
-        throw new Error(`Unsupported ChainId: ${chainId}`);
+        throw new SDKError(
+            'Input Validation',
+            'Any',
+            `Unsupported chainId: ${chainId}`,
+        );
     }
 
     static validateBuildCallWithPermit2(input: {

--- a/src/entities/inputValidator/inputValidator.ts
+++ b/src/entities/inputValidator/inputValidator.ts
@@ -14,11 +14,7 @@ import { InputValidatorStable } from './stable/inputValidatorStable';
 import { InputValidatorBase } from './inputValidatorBase';
 import { InputValidatorWeighted } from './weighted/inputValidatorWeighted';
 import { InputValidatorBoosted } from './boosted/inputValidatorBoosted';
-import {
-    ChainId,
-    SDKError,
-    buildCallWithPermit2ProtocolVersionError,
-} from '@/utils';
+import { ChainId, protocolVersionError, SDKError } from '@/utils';
 import { AddLiquidityBoostedInput } from '../addLiquidityBoosted/types';
 
 export class InputValidator {
@@ -118,7 +114,11 @@ export class InputValidator {
         protocolVersion: number;
     }): void {
         if (input.protocolVersion !== 3) {
-            throw buildCallWithPermit2ProtocolVersionError();
+            throw protocolVersionError(
+                'buildCallWithPermit2',
+                input.protocolVersion,
+                'buildCallWithPermit2 is supported on Balancer v3 only.',
+            );
         }
     }
 }

--- a/src/entities/inputValidator/inputValidatorBase.ts
+++ b/src/entities/inputValidator/inputValidatorBase.ts
@@ -20,6 +20,7 @@ import { isSameAddress, NATIVE_ASSETS, inputValidationError } from '@/utils';
 export class InputValidatorBase {
     validateInitPool(initPoolInput: InitPoolInput, poolState: PoolState): void {
         areTokensInArray(
+            'Init Pool',
             initPoolInput.amountsIn.map((a) => a.address),
             poolState.tokens.map((t) => t.address),
         );

--- a/src/entities/inputValidator/inputValidatorBase.ts
+++ b/src/entities/inputValidator/inputValidatorBase.ts
@@ -15,7 +15,7 @@ import { TokenType } from '@/types';
 import { zeroAddress } from 'viem';
 import { AddLiquidityInput } from '@/entities/addLiquidity/types';
 import { areTokensInArray } from '@/entities/utils/areTokensInArray';
-import { isSameAddress, NATIVE_ASSETS } from '@/utils';
+import { isSameAddress, NATIVE_ASSETS, inputValidationError } from '@/utils';
 
 export class InputValidatorBase {
     validateInitPool(initPoolInput: InitPoolInput, poolState: PoolState): void {
@@ -36,7 +36,8 @@ export class InputValidatorBase {
                     tokenType !== TokenType.STANDARD &&
                     rateProvider === zeroAddress
                 ) {
-                    throw new Error(
+                    throw inputValidationError(
+                        'Create Pool',
                         'Only TokenType.STANDARD is allowed to have zeroAddress rateProvider',
                     );
                 }
@@ -75,7 +76,8 @@ export class InputValidatorBase {
                     ),
                 );
             if (!inputContainsWrappedNativeAsset) {
-                throw new Error(
+                throw inputValidationError(
+                    'Init Pool',
                     'wethIsEth requires wrapped native asset as input',
                 );
             }

--- a/src/entities/inputValidator/stable/inputValidatorStable.ts
+++ b/src/entities/inputValidator/stable/inputValidatorStable.ts
@@ -3,7 +3,7 @@ import {
     AddLiquidityKind,
 } from '@/entities/addLiquidity/types';
 import { PoolState } from '@/entities/types';
-import { addLiquidityProportionalNotSupportedOnPoolTypeError } from '@/utils';
+import { addLiquidityPoolTypeError } from '@/utils';
 import { InputValidatorBase } from '../inputValidatorBase';
 import { validateTokensAddLiquidity } from '../utils/validateTokens';
 import { CreatePoolV3StableInput } from '@/entities/createPool';
@@ -41,7 +41,8 @@ export class InputValidatorStable extends InputValidatorBase {
             poolState.protocolVersion === 2 &&
             addLiquidityInput.kind === AddLiquidityKind.Proportional
         ) {
-            throw addLiquidityProportionalNotSupportedOnPoolTypeError(
+            throw addLiquidityPoolTypeError(
+                addLiquidityInput.kind,
                 poolState.type,
             );
         }

--- a/src/entities/inputValidator/stable/inputValidatorStable.ts
+++ b/src/entities/inputValidator/stable/inputValidatorStable.ts
@@ -3,7 +3,7 @@ import {
     AddLiquidityKind,
 } from '@/entities/addLiquidity/types';
 import { PoolState } from '@/entities/types';
-import { addLiquidityPoolTypeError, inputValidationError } from '@/utils';
+import { inputValidationError, poolTypeError } from '@/utils';
 import { InputValidatorBase } from '../inputValidatorBase';
 import { validateTokensAddLiquidity } from '../utils/validateTokens';
 import { CreatePoolV3StableInput } from '@/entities/createPool';
@@ -43,8 +43,8 @@ export class InputValidatorStable extends InputValidatorBase {
             poolState.protocolVersion === 2 &&
             addLiquidityInput.kind === AddLiquidityKind.Proportional
         ) {
-            throw addLiquidityPoolTypeError(
-                addLiquidityInput.kind,
+            throw poolTypeError(
+                `Add Liquidity ${addLiquidityInput.kind}`,
                 poolState.type,
             );
         }

--- a/src/entities/inputValidator/stable/inputValidatorStable.ts
+++ b/src/entities/inputValidator/stable/inputValidatorStable.ts
@@ -3,7 +3,7 @@ import {
     AddLiquidityKind,
 } from '@/entities/addLiquidity/types';
 import { PoolState } from '@/entities/types';
-import { addLiquidityPoolTypeError } from '@/utils';
+import { addLiquidityPoolTypeError, inputValidationError } from '@/utils';
 import { InputValidatorBase } from '../inputValidatorBase';
 import { validateTokensAddLiquidity } from '../utils/validateTokens';
 import { CreatePoolV3StableInput } from '@/entities/createPool';
@@ -16,19 +16,21 @@ export class InputValidatorStable extends InputValidatorBase {
         super.validateCreatePool(input);
 
         if (input.tokens.length > MAX_TOKENS) {
-            throw new Error(
-                `Stable pools can only have a maximum of ${MAX_TOKENS} tokens`,
+            throw inputValidationError(
+                'Create Pool',
+                `Stable pools can only have a maximum of ${MAX_TOKENS} tokens on Balancer v3`,
             );
         }
-
         if (input.amplificationParameter < MIN_AMP) {
-            throw new Error(
-                `Amplification parameter below minimum of ${MIN_AMP}`,
+            throw inputValidationError(
+                'Create Pool',
+                `Amplification parameter below minimum of ${MIN_AMP} on Balancer v3`,
             );
         }
         if (input.amplificationParameter > MAX_AMP) {
-            throw new Error(
-                `Amplification parameter above maximum of ${MAX_AMP}`,
+            throw inputValidationError(
+                'Create Pool',
+                `Amplification parameter above maximum of ${MAX_AMP} on Balancer v3`,
             );
         }
     }

--- a/src/entities/inputValidator/utils/validateTokens.ts
+++ b/src/entities/inputValidator/utils/validateTokens.ts
@@ -15,18 +15,21 @@ export const validateTokensAddLiquidity = (
     switch (addLiquidityInput.kind) {
         case AddLiquidityKind.Unbalanced:
             areTokensInArray(
+                'Add Liquidity Unbalanced',
                 addLiquidityInput.amountsIn.map((a) => a.address),
                 poolState.tokens.map((t) => t.address),
             );
             break;
         case AddLiquidityKind.SingleToken:
             areTokensInArray(
+                'Add Liquidity Single Token',
                 [addLiquidityInput.tokenIn],
                 poolState.tokens.map((t) => t.address),
             );
             break;
         case AddLiquidityKind.Proportional:
             areTokensInArray(
+                'Add Liquidity Proportional',
                 [addLiquidityInput.referenceAmount.address],
                 [poolState.address, ...poolState.tokens.map((t) => t.address)], // reference amount can be any pool token or pool BPT
             );
@@ -43,24 +46,28 @@ export const validateTokensRemoveLiquidity = (
     switch (removeLiquidityInput.kind) {
         case RemoveLiquidityKind.Unbalanced:
             areTokensInArray(
+                'Remove Liquidity Unbalanced',
                 removeLiquidityInput.amountsOut.map((a) => a.address),
                 poolState.tokens.map((t) => t.address),
             );
             break;
         case RemoveLiquidityKind.SingleTokenExactOut:
             areTokensInArray(
+                'Remove Liquidity Single Token Exact Out',
                 [removeLiquidityInput.amountOut.address],
                 poolState.tokens.map((t) => t.address),
             );
             break;
         case RemoveLiquidityKind.SingleTokenExactIn:
             areTokensInArray(
+                'Remove Liquidity Single Token Exact In',
                 [removeLiquidityInput.tokenOut],
                 poolState.tokens.map((t) => t.address),
             );
             break;
         case RemoveLiquidityKind.Proportional:
             areTokensInArray(
+                'Remove Liquidity Proportional',
                 [removeLiquidityInput.bptIn.address],
                 [poolState.address],
             );
@@ -73,6 +80,7 @@ export const validateTokensRemoveLiquidityRecovery = (
     poolState: PoolState,
 ) => {
     areTokensInArray(
+        'Remove Liquidity Recovery',
         [removeLiquidityRecoveryInput.bptIn.address],
         [poolState.address],
     );

--- a/src/entities/inputValidator/utils/validateTokens.ts
+++ b/src/entities/inputValidator/utils/validateTokens.ts
@@ -6,6 +6,7 @@ import {
 } from '../../removeLiquidity/types';
 import { PoolState } from '../../types';
 import { areTokensInArray } from '../../utils/areTokensInArray';
+import { inputValidationError } from '@/utils';
 
 export const validateTokensAddLiquidity = (
     addLiquidityInput: AddLiquidityInput,
@@ -77,12 +78,13 @@ export const validateTokensRemoveLiquidityRecovery = (
     );
 };
 
-export const validatePoolHasBpt = (poolState: PoolState) => {
+export const validatePoolHasBpt = (action: string, poolState: PoolState) => {
     const { tokens, address } = poolState;
     const bptIndex = tokens.findIndex((t) => t.address === address);
     if (bptIndex < 0) {
-        throw new Error(
-            'INPUT_ERROR: Pool State should have BPT token included',
+        throw inputValidationError(
+            action,
+            'poolState should have BPT token included for Composable Stable pools',
         );
     }
 };
@@ -90,9 +92,12 @@ export const validatePoolHasBpt = (poolState: PoolState) => {
 export const validateCreatePoolTokens = (tokens: { address: string }[]) => {
     const tokenAddresses = tokens.map((t) => t.address);
     if (tokenAddresses.length !== new Set(tokenAddresses).size) {
-        throw new Error('Duplicate token addresses');
+        throw inputValidationError('Create Pool', 'Duplicate token addresses');
     }
     if (tokens.length < 2) {
-        throw new Error('Minimum of 2 tokens required');
+        throw inputValidationError(
+            'Create Pool',
+            'Minimum of 2 tokens required',
+        );
     }
 };

--- a/src/entities/inputValidator/weighted/inputValidatorWeighted.ts
+++ b/src/entities/inputValidator/weighted/inputValidatorWeighted.ts
@@ -3,6 +3,7 @@ import {
     CreatePoolV3WeightedInput,
 } from '../../createPool/types';
 import { InputValidatorBase } from '../inputValidatorBase';
+import { inputValidationError } from '@/utils';
 
 export class InputValidatorWeighted extends InputValidatorBase {
     validateCreatePool(
@@ -10,17 +11,23 @@ export class InputValidatorWeighted extends InputValidatorBase {
     ) {
         super.validateCreatePool(input);
         if (input.tokens.length > 8) {
-            throw new Error('Weighted pools can have a maximum of 8 tokens');
+            throw inputValidationError(
+                'Create Pool',
+                'Weighted pools can have a maximum of 8 tokens',
+            );
         }
         const weightsSum = input.tokens.reduce(
             (acc, { weight }) => acc + weight,
             0n,
         );
         if (weightsSum !== BigInt(1e18)) {
-            throw new Error('Weights must sum to 1e18');
+            throw inputValidationError(
+                'Create Pool',
+                'Weights must sum to 1e18',
+            );
         }
         if (input.tokens.find(({ weight }) => weight === 0n)) {
-            throw new Error('Weight cannot be 0');
+            throw inputValidationError('Create Pool', 'Weight cannot be 0');
         }
     }
 }

--- a/src/entities/permit2Helper/index.ts
+++ b/src/entities/permit2Helper/index.ts
@@ -14,6 +14,7 @@ import {
     ChainId,
     PERMIT2,
     PublicWalletClient,
+    inputValidationError,
 } from '@/utils';
 import {
     MaxAllowanceExpiration,
@@ -373,9 +374,15 @@ const validateNoncesAndExpirations = (
     expectedLength: number,
 ) => {
     if (nonces && nonces.length !== expectedLength) {
-        throw new Error("Nonces length doesn't match expected length");
+        throw inputValidationError(
+            'Permit2 Signature',
+            "Nonces length doesn't match amountsIn length",
+        );
     }
     if (expirations && expirations.length !== expectedLength) {
-        throw new Error("Expirations length doesn't match expected length");
+        throw inputValidationError(
+            'Permit2 Signature',
+            "Expirations length doesn't match amountsIn length",
+        );
     }
 };

--- a/src/entities/removeLiquidity/helper.ts
+++ b/src/entities/removeLiquidity/helper.ts
@@ -1,7 +1,4 @@
-import {
-    MAX_UINT256,
-    removeLiquiditySingleTokenExactInShouldHaveTokenOutIndexError,
-} from '@/utils';
+import { MAX_UINT256, removeLiquidityMissingTokenOutIndexError } from '@/utils';
 import { Token } from '../token';
 import { RemoveLiquidityAmounts } from '../types';
 import { getAmounts } from '../utils';
@@ -67,7 +64,7 @@ export const getAmountsCall = (
             };
         case RemoveLiquidityKind.SingleTokenExactIn:
             if (input.tokenOutIndex === undefined) {
-                throw removeLiquiditySingleTokenExactInShouldHaveTokenOutIndexError;
+                throw removeLiquidityMissingTokenOutIndexError();
             }
             return {
                 minAmountsOut: input.amountsOut.map((a) =>

--- a/src/entities/removeLiquidity/helper.ts
+++ b/src/entities/removeLiquidity/helper.ts
@@ -1,4 +1,4 @@
-import { MAX_UINT256, removeLiquidityMissingTokenOutIndexError } from '@/utils';
+import { MAX_UINT256, missingParameterError } from '@/utils';
 import { Token } from '../token';
 import { RemoveLiquidityAmounts } from '../types';
 import { getAmounts } from '../utils';
@@ -64,7 +64,11 @@ export const getAmountsCall = (
             };
         case RemoveLiquidityKind.SingleTokenExactIn:
             if (input.tokenOutIndex === undefined) {
-                throw removeLiquidityMissingTokenOutIndexError();
+                throw missingParameterError(
+                    'Remove Liquidity SingleTokenExactIn',
+                    'tokenOutIndex',
+                    input.protocolVersion,
+                );
             }
             return {
                 minAmountsOut: input.amountsOut.map((a) =>

--- a/src/entities/removeLiquidity/removeLiquidityCowAmm/index.ts
+++ b/src/entities/removeLiquidity/removeLiquidityCowAmm/index.ts
@@ -95,6 +95,6 @@ export class RemoveLiquidityCowAmm implements RemoveLiquidityBase {
     }
 
     buildCallWithPermit(): RemoveLiquidityBuildCallOutput {
-        throw buildCallWithPermit2ProtocolVersionError;
+        throw buildCallWithPermit2ProtocolVersionError();
     }
 }

--- a/src/entities/removeLiquidity/removeLiquidityCowAmm/index.ts
+++ b/src/entities/removeLiquidity/removeLiquidityCowAmm/index.ts
@@ -17,7 +17,7 @@ import {
 } from '../types';
 import { encodeFunctionData } from 'viem';
 import { cowAmmPoolAbi } from '@/abi/cowAmmPool';
-import { buildCallWithPermit2ProtocolVersionError } from '@/utils';
+import { poolTypeError, protocolVersionError } from '@/utils';
 
 export class RemoveLiquidityCowAmm implements RemoveLiquidityBase {
     public async query(
@@ -67,8 +67,10 @@ export class RemoveLiquidityCowAmm implements RemoveLiquidityBase {
         input: RemoveLiquidityBaseBuildCallInput,
     ): RemoveLiquidityBuildCallOutput {
         if (input.removeLiquidityKind !== RemoveLiquidityKind.Proportional) {
-            throw new Error(
-                `Error: Remove Liquidity ${input.removeLiquidityKind} is not supported. Cow AMM pools support Remove Liquidity Proportional only.`,
+            throw poolTypeError(
+                'Remove Liquidity',
+                input.poolType,
+                'Use Remove Liquidity Proportional instead.',
             );
         }
 
@@ -94,7 +96,13 @@ export class RemoveLiquidityCowAmm implements RemoveLiquidityBase {
         };
     }
 
-    buildCallWithPermit(): RemoveLiquidityBuildCallOutput {
-        throw buildCallWithPermit2ProtocolVersionError();
+    buildCallWithPermit(
+        input: RemoveLiquidityBaseBuildCallInput,
+    ): RemoveLiquidityBuildCallOutput {
+        throw protocolVersionError(
+            'buildCallWithPermit',
+            input.protocolVersion,
+            'buildCallWithPermit is supported on Balancer v3 only.',
+        );
     }
 }

--- a/src/entities/removeLiquidity/removeLiquidityV2/composableStable/removeLiquidityComposableStable.ts
+++ b/src/entities/removeLiquidity/removeLiquidityV2/composableStable/removeLiquidityComposableStable.ts
@@ -1,7 +1,11 @@
 import { encodeFunctionData } from 'viem';
 import { Token } from '../../../token';
 import { TokenAmount } from '../../../tokenAmount';
-import { VAULT_V2, ZERO_ADDRESS } from '../../../../utils/';
+import {
+    protocolVersionError,
+    VAULT_V2,
+    ZERO_ADDRESS,
+} from '../../../../utils/';
 import { vaultV2Abi } from '../../../../abi';
 import { parseRemoveLiquidityArgs } from '../../../utils/parseRemoveLiquidityArgs';
 import {
@@ -181,7 +185,13 @@ export class RemoveLiquidityComposableStable implements RemoveLiquidityBase {
         };
     }
 
-    buildCallWithPermit(): RemoveLiquidityBuildCallOutput {
-        throw new Error('buildCallWithPermit is not supported on v2');
+    buildCallWithPermit(
+        input: RemoveLiquidityV2ComposableStableBuildCallInput,
+    ): RemoveLiquidityBuildCallOutput {
+        throw protocolVersionError(
+            'buildCallWithPermit',
+            input.protocolVersion,
+            'buildCallWithPermit is supported on Balancer v3 only.',
+        );
     }
 }

--- a/src/entities/removeLiquidity/removeLiquidityV2/index.ts
+++ b/src/entities/removeLiquidity/removeLiquidityV2/index.ts
@@ -6,11 +6,13 @@ import {
     RemoveLiquidityConfig,
     RemoveLiquidityInput,
     RemoveLiquidityQueryOutput,
+    RemoveLiquidityBaseBuildCallInput,
 } from '@/entities';
 import { RemoveLiquidityWeighted } from './weighted/removeLiquidityWeighted';
 import { RemoveLiquidityComposableStable } from './composableStable/removeLiquidityComposableStable';
 import { PoolType } from '@/types';
 import { RemoveLiquidityStable } from './stable/removeLiquidityStable';
+import { poolTypeError, protocolVersionError } from '@/utils';
 
 export class RemoveLiquidityV2 implements RemoveLiquidityBase {
     private readonly removeLiquidityTypes: Record<string, RemoveLiquidityBase> =
@@ -34,7 +36,7 @@ export class RemoveLiquidityV2 implements RemoveLiquidityBase {
 
     public getRemoveLiquidity(poolType: string): RemoveLiquidityBase {
         if (!this.removeLiquidityTypes[poolType]) {
-            throw new Error(`Unsupported pool type ${poolType}`);
+            throw poolTypeError('Remove Liquidity', poolType);
         }
 
         return this.removeLiquidityTypes[poolType];
@@ -53,7 +55,13 @@ export class RemoveLiquidityV2 implements RemoveLiquidityBase {
         return this.getRemoveLiquidity(input.poolType).buildCall(input);
     }
 
-    buildCallWithPermit(): RemoveLiquidityBuildCallOutput {
-        throw new Error('buildCallWithPermit is not supported on v2');
+    buildCallWithPermit(
+        input: RemoveLiquidityBaseBuildCallInput,
+    ): RemoveLiquidityBuildCallOutput {
+        throw protocolVersionError(
+            'buildCallWithPermit',
+            input.protocolVersion,
+            'buildCallWithPermit is supported on Balancer v3 only.',
+        );
     }
 }

--- a/src/entities/removeLiquidity/removeLiquidityV2/stable/removeLiquidityStable.ts
+++ b/src/entities/removeLiquidity/removeLiquidityV2/stable/removeLiquidityStable.ts
@@ -2,7 +2,11 @@ import { encodeFunctionData } from 'viem';
 import { Token } from '../../../token';
 import { TokenAmount } from '../../../tokenAmount';
 import { StableEncoder } from '../../../encoders/stable';
-import { VAULT_V2, ZERO_ADDRESS } from '../../../../utils';
+import {
+    protocolVersionError,
+    VAULT_V2,
+    ZERO_ADDRESS,
+} from '../../../../utils';
 import { vaultV2Abi } from '../../../../abi';
 import { parseRemoveLiquidityArgs } from '../../../utils/parseRemoveLiquidityArgs';
 import {
@@ -159,7 +163,13 @@ export class RemoveLiquidityStable implements RemoveLiquidityBase {
         };
     }
 
-    buildCallWithPermit(): RemoveLiquidityBuildCallOutput {
-        throw new Error('buildCallWithPermit is not supported on v2');
+    buildCallWithPermit(
+        input: RemoveLiquidityV2BaseBuildCallInput,
+    ): RemoveLiquidityBuildCallOutput {
+        throw protocolVersionError(
+            'buildCallWithPermit',
+            input.protocolVersion,
+            'buildCallWithPermit is supported on Balancer v3 only.',
+        );
     }
 }

--- a/src/entities/removeLiquidity/removeLiquidityV2/weighted/removeLiquidityWeighted.ts
+++ b/src/entities/removeLiquidity/removeLiquidityV2/weighted/removeLiquidityWeighted.ts
@@ -2,7 +2,7 @@ import { encodeFunctionData } from 'viem';
 import { Token } from '../../../token';
 import { TokenAmount } from '../../../tokenAmount';
 import { WeightedEncoder } from '../../../encoders/weighted';
-import { VAULT_V2, ZERO_ADDRESS } from '@/utils';
+import { protocolVersionError, VAULT_V2, ZERO_ADDRESS } from '@/utils';
 import { vaultV2Abi } from '../../../../abi';
 import { parseRemoveLiquidityArgs } from '../../../utils/parseRemoveLiquidityArgs';
 import {
@@ -158,7 +158,13 @@ export class RemoveLiquidityWeighted implements RemoveLiquidityBase {
         };
     }
 
-    buildCallWithPermit(): RemoveLiquidityBuildCallOutput {
-        throw new Error('buildCallWithPermit is not supported on v2');
+    buildCallWithPermit(
+        input: RemoveLiquidityV2BaseBuildCallInput,
+    ): RemoveLiquidityBuildCallOutput {
+        throw protocolVersionError(
+            'buildCallWithPermit',
+            input.protocolVersion,
+            'buildCallWithPermit is supported on Balancer v3 only.',
+        );
     }
 }

--- a/src/entities/removeLiquidity/removeLiquidityV3/encodeRemoveLiquidityProportional.ts
+++ b/src/entities/removeLiquidity/removeLiquidityV3/encodeRemoveLiquidityProportional.ts
@@ -1,9 +1,9 @@
-import { encodeFunctionData, Hex } from 'viem';
-import { RemoveLiquidityBaseBuildCallInput } from '../types';
+import { encodeFunctionData } from 'viem';
+import { RemoveLiquidityV3BuildCallInput } from '../types';
 import { balancerRouterAbiExtended } from '@/abi';
 
 export const encodeRemoveLiquidityProportional = (
-    input: RemoveLiquidityBaseBuildCallInput & { userData: Hex },
+    input: RemoveLiquidityV3BuildCallInput,
     minAmountsOut: bigint[],
 ) => {
     return encodeFunctionData({

--- a/src/entities/removeLiquidity/removeLiquidityV3/encodeRemoveLiquiditySingleTokenExactIn.ts
+++ b/src/entities/removeLiquidity/removeLiquidityV3/encodeRemoveLiquiditySingleTokenExactIn.ts
@@ -1,15 +1,18 @@
-import { encodeFunctionData, Hex } from 'viem';
-import { RemoveLiquidityBaseBuildCallInput } from '../types';
+import { encodeFunctionData } from 'viem';
+import { RemoveLiquidityV3BuildCallInput } from '../types';
 import { balancerRouterAbiExtended } from '@/abi';
+import { missingParameterError } from '@/utils';
 
 export const encodeRemoveLiquiditySingleTokenExactIn = (
-    input: RemoveLiquidityBaseBuildCallInput & { userData: Hex },
+    input: RemoveLiquidityV3BuildCallInput,
     minAmountsOut: bigint[],
 ) => {
-    // just a sanity check as this is already checked in InputValidator
+    // TODO: move this check to an input validator
     if (input.tokenOutIndex === undefined) {
-        throw new Error(
-            'RemoveLiquidityKind.SingleTokenExactOut should have tokenOutIndex',
+        throw missingParameterError(
+            'RemoveLiquidity SingleTokenExactIn',
+            'tokenOutIndex',
+            input.protocolVersion,
         );
     }
     return encodeFunctionData({

--- a/src/entities/removeLiquidity/removeLiquidityV3/encodeRemoveLiquiditySingleTokenExactOut.ts
+++ b/src/entities/removeLiquidity/removeLiquidityV3/encodeRemoveLiquiditySingleTokenExactOut.ts
@@ -2,10 +2,10 @@ import { encodeFunctionData } from 'viem';
 import { balancerRouterAbiExtended } from '@/abi';
 import { Hex } from '@/types';
 import { missingParameterError } from '@/utils';
-import { RemoveLiquidityBaseBuildCallInput } from '../types';
+import { RemoveLiquidityV3BuildCallInput } from '../types';
 
 export const encodeRemoveLiquiditySingleTokenExactOut = (
-    input: RemoveLiquidityBaseBuildCallInput & { userData: Hex },
+    input: RemoveLiquidityV3BuildCallInput,
     maxBptAmountIn: bigint,
 ): Hex => {
     // just a sanity check as this is already checked in InputValidator

--- a/src/entities/removeLiquidity/removeLiquidityV3/encodeRemoveLiquiditySingleTokenExactOut.ts
+++ b/src/entities/removeLiquidity/removeLiquidityV3/encodeRemoveLiquiditySingleTokenExactOut.ts
@@ -1,8 +1,8 @@
-import { removeLiquidityMissingTokenOutIndexError } from '@/utils';
-import { RemoveLiquidityBaseBuildCallInput } from '../types';
 import { encodeFunctionData } from 'viem';
 import { balancerRouterAbiExtended } from '@/abi';
 import { Hex } from '@/types';
+import { missingParameterError } from '@/utils';
+import { RemoveLiquidityBaseBuildCallInput } from '../types';
 
 export const encodeRemoveLiquiditySingleTokenExactOut = (
     input: RemoveLiquidityBaseBuildCallInput & { userData: Hex },
@@ -10,7 +10,11 @@ export const encodeRemoveLiquiditySingleTokenExactOut = (
 ): Hex => {
     // just a sanity check as this is already checked in InputValidator
     if (input.tokenOutIndex === undefined) {
-        throw removeLiquidityMissingTokenOutIndexError();
+        throw missingParameterError(
+            'Remove Liquidity SingleTokenExactOut',
+            'tokenOutIndex',
+            input.protocolVersion,
+        );
     }
     return encodeFunctionData({
         abi: balancerRouterAbiExtended,

--- a/src/entities/removeLiquidity/removeLiquidityV3/encodeRemoveLiquiditySingleTokenExactOut.ts
+++ b/src/entities/removeLiquidity/removeLiquidityV3/encodeRemoveLiquiditySingleTokenExactOut.ts
@@ -1,4 +1,4 @@
-import { removeLiquiditySingleTokenExactInShouldHaveTokenOutIndexError } from '@/utils';
+import { removeLiquidityMissingTokenOutIndexError } from '@/utils';
 import { RemoveLiquidityBaseBuildCallInput } from '../types';
 import { encodeFunctionData } from 'viem';
 import { balancerRouterAbiExtended } from '@/abi';
@@ -10,7 +10,7 @@ export const encodeRemoveLiquiditySingleTokenExactOut = (
 ): Hex => {
     // just a sanity check as this is already checked in InputValidator
     if (input.tokenOutIndex === undefined) {
-        throw removeLiquiditySingleTokenExactInShouldHaveTokenOutIndexError;
+        throw removeLiquidityMissingTokenOutIndexError();
     }
     return encodeFunctionData({
         abi: balancerRouterAbiExtended,

--- a/src/entities/removeLiquidity/removeLiquidityV3/index.ts
+++ b/src/entities/removeLiquidity/removeLiquidityV3/index.ts
@@ -5,7 +5,7 @@ import { getSortedTokens } from '@/entities/utils';
 import { Hex } from '@/types';
 import {
     BALANCER_ROUTER,
-    removeLiquidityUnbalancedNotSupportedOnV3,
+    removeLiquidityUnbalancedProtocolVersionError,
 } from '@/utils';
 
 import { getAmountsCall, getAmountsQuery } from '../helper';
@@ -43,7 +43,7 @@ export class RemoveLiquidityV3 implements RemoveLiquidityBase {
 
         switch (input.kind) {
             case RemoveLiquidityKind.Unbalanced:
-                throw removeLiquidityUnbalancedNotSupportedOnV3;
+                throw removeLiquidityUnbalancedProtocolVersionError();
             case RemoveLiquidityKind.SingleTokenExactOut:
                 {
                     maxBptAmountIn =
@@ -134,7 +134,7 @@ export class RemoveLiquidityV3 implements RemoveLiquidityBase {
         let callData: Hex;
         switch (input.removeLiquidityKind) {
             case RemoveLiquidityKind.Unbalanced:
-                throw removeLiquidityUnbalancedNotSupportedOnV3;
+                throw removeLiquidityUnbalancedProtocolVersionError();
             case RemoveLiquidityKind.SingleTokenExactOut:
                 {
                     callData = encodeRemoveLiquiditySingleTokenExactOut(

--- a/src/entities/removeLiquidity/removeLiquidityV3/index.ts
+++ b/src/entities/removeLiquidity/removeLiquidityV3/index.ts
@@ -3,10 +3,7 @@ import { TokenAmount } from '@/entities/tokenAmount';
 import { PoolState } from '@/entities/types';
 import { getSortedTokens } from '@/entities/utils';
 import { Hex } from '@/types';
-import {
-    BALANCER_ROUTER,
-    removeLiquidityUnbalancedProtocolVersionError,
-} from '@/utils';
+import { BALANCER_ROUTER, protocolVersionError } from '@/utils';
 
 import { getAmountsCall, getAmountsQuery } from '../helper';
 import {
@@ -43,7 +40,10 @@ export class RemoveLiquidityV3 implements RemoveLiquidityBase {
 
         switch (input.kind) {
             case RemoveLiquidityKind.Unbalanced:
-                throw removeLiquidityUnbalancedProtocolVersionError();
+                throw protocolVersionError(
+                    'Remove Liquidity Unbalanced',
+                    poolState.protocolVersion,
+                );
             case RemoveLiquidityKind.SingleTokenExactOut:
                 {
                     maxBptAmountIn =
@@ -134,7 +134,10 @@ export class RemoveLiquidityV3 implements RemoveLiquidityBase {
         let callData: Hex;
         switch (input.removeLiquidityKind) {
             case RemoveLiquidityKind.Unbalanced:
-                throw removeLiquidityUnbalancedProtocolVersionError();
+                throw protocolVersionError(
+                    'Remove Liquidity Unbalanced',
+                    input.protocolVersion,
+                );
             case RemoveLiquidityKind.SingleTokenExactOut:
                 {
                     callData = encodeRemoveLiquiditySingleTokenExactOut(

--- a/src/entities/removeLiquidity/removeLiquidityV3/index.ts
+++ b/src/entities/removeLiquidity/removeLiquidityV3/index.ts
@@ -8,11 +8,11 @@ import { BALANCER_ROUTER, protocolVersionError } from '@/utils';
 import { getAmountsCall, getAmountsQuery } from '../helper';
 import {
     RemoveLiquidityBase,
-    RemoveLiquidityBaseBuildCallInput,
     RemoveLiquidityBaseQueryOutput,
     RemoveLiquidityBuildCallOutput,
     RemoveLiquidityInput,
     RemoveLiquidityKind,
+    RemoveLiquidityV3BuildCallInput,
 } from '../types';
 import { doRemoveLiquiditySingleTokenExactOutQuery } from './doRemoveLiquiditySingleTokenExactOutQuery';
 import { doRemoveLiquiditySingleTokenExactInQuery } from './doRemoveLiquiditySingleTokenExactInQuery';
@@ -127,7 +127,7 @@ export class RemoveLiquidityV3 implements RemoveLiquidityBase {
     }
 
     public buildCall(
-        input: RemoveLiquidityBaseBuildCallInput & { userData: Hex },
+        input: RemoveLiquidityV3BuildCallInput,
     ): RemoveLiquidityBuildCallOutput {
         const amounts = getAmountsCall(input);
 
@@ -187,7 +187,7 @@ export class RemoveLiquidityV3 implements RemoveLiquidityBase {
     }
 
     public buildCallWithPermit(
-        input: RemoveLiquidityBaseBuildCallInput & { userData: Hex },
+        input: RemoveLiquidityV3BuildCallInput,
         permit: Permit,
     ): RemoveLiquidityBuildCallOutput {
         const buildCallOutput = this.buildCall(input);

--- a/src/entities/removeLiquidity/types.ts
+++ b/src/entities/removeLiquidity/types.ts
@@ -84,9 +84,15 @@ export type RemoveLiquidityBaseBuildCallInput = {
     wethIsEth?: boolean;
 } & RemoveLiquidityBaseQueryOutput;
 
+export type RemoveLiquidityV3BuildCallInput =
+    RemoveLiquidityBaseBuildCallInput & {
+        userData: Hex;
+    };
+
 export type RemoveLiquidityBuildCallInput =
     | RemoveLiquidityBaseBuildCallInput
     | RemoveLiquidityV2BuildCallInput
+    | RemoveLiquidityV3BuildCallInput
     | RemoveLiquidityBoostedBuildCallInput;
 
 export type RemoveLiquidityBuildCallOutput = {

--- a/src/entities/removeLiquidityBoosted/index.ts
+++ b/src/entities/removeLiquidityBoosted/index.ts
@@ -46,9 +46,6 @@ export class RemoveLiquidityBoostedV3 implements RemoveLiquidityBase {
         const unwrapWrapped = input.tokensOut
             .map((t) => {
                 const tokenOut = poolStateTokenMap[t.toLowerCase() as Address];
-                if (!tokenOut) {
-                    throw new Error(`Invalid token address: ${t}`);
-                }
                 return tokenOut;
             })
             .sort((a, b) => a.index - b.index) // sort by index to match the order of the pool tokens

--- a/src/entities/removeLiquidityNested/index.ts
+++ b/src/entities/removeLiquidityNested/index.ts
@@ -11,6 +11,7 @@ import { RemoveLiquidityNestedV3 } from './removeLiquidityNestedV3';
 import { validateBuildCallInput } from './removeLiquidityNestedV2/validateInputs';
 import { Address, encodeFunctionData, Hex, zeroAddress } from 'viem';
 import { balancerCompositeLiquidityRouterNestedAbiExtended } from '@/abi';
+import { protocolVersionError } from '@/utils';
 
 export class RemoveLiquidityNested {
     async query(
@@ -21,8 +22,9 @@ export class RemoveLiquidityNested {
         validateNestedPoolState(nestedPoolState);
         switch (nestedPoolState.protocolVersion) {
             case 1: {
-                throw new Error(
-                    'RemoveLiquidityNested not supported for ProtocolVersion 1.',
+                throw protocolVersionError(
+                    'RemoveLiquidityNested',
+                    nestedPoolState.protocolVersion,
                 );
             }
             case 2: {

--- a/src/entities/removeLiquidityNested/removeLiquidityNestedV2/encodeCalls.ts
+++ b/src/entities/removeLiquidityNested/removeLiquidityNestedV2/encodeCalls.ts
@@ -1,5 +1,8 @@
 import { encodeFunctionData, Hex } from 'viem';
-import { removeLiquidityMissingTokenOutIndexError } from '@/utils';
+import {
+    poolTypeProtocolVersionError,
+    removeLiquidityMissingTokenOutIndexError,
+} from '@/utils';
 import { RemoveLiquidityNestedCallAttributesV2 } from './types';
 import { replaceWrapped } from '@/entities/utils';
 import { batchRelayerLibraryAbi } from '@/abi';
@@ -94,7 +97,11 @@ const getUserDataProportional = (poolType: PoolType, bptAmountIn: bigint) => {
                 bptAmountIn,
             );
         default:
-            throw new Error(`Unsupported pool type ${poolType}`);
+            throw poolTypeProtocolVersionError(
+                'RemoveLiquidityNested',
+                poolType,
+                2,
+            );
     }
 };
 
@@ -118,6 +125,10 @@ const getUserDataSingleTokenExactIn = (
                 tokenOutIndex,
             );
         default:
-            throw new Error(`Unsupported pool type ${poolType}`);
+            throw poolTypeProtocolVersionError(
+                'RemoveLiquidityNested',
+                poolType,
+                2,
+            );
     }
 };

--- a/src/entities/removeLiquidityNested/removeLiquidityNestedV2/encodeCalls.ts
+++ b/src/entities/removeLiquidityNested/removeLiquidityNestedV2/encodeCalls.ts
@@ -1,8 +1,5 @@
 import { encodeFunctionData, Hex } from 'viem';
-import {
-    poolTypeProtocolVersionError,
-    removeLiquidityMissingTokenOutIndexError,
-} from '@/utils';
+import { missingParameterError, poolTypeProtocolVersionError } from '@/utils';
 import { RemoveLiquidityNestedCallAttributesV2 } from './types';
 import { replaceWrapped } from '@/entities/utils';
 import { batchRelayerLibraryAbi } from '@/abi';
@@ -43,7 +40,11 @@ export const encodeCalls = (
             userData = getUserDataProportional(poolType, bptAmountIn.amount);
         } else {
             if (tokenOutIndex === undefined) {
-                throw removeLiquidityMissingTokenOutIndexError();
+                throw missingParameterError(
+                    'Remove Liquidity Nested SingleTokenExactIn',
+                    'tokenOutIndex',
+                    2,
+                );
             }
 
             // skip bpt index for ComposableStable pools
@@ -111,7 +112,11 @@ const getUserDataSingleTokenExactIn = (
     bptAmountIn: bigint,
 ) => {
     if (tokenOutIndex === undefined) {
-        throw removeLiquidityMissingTokenOutIndexError();
+        throw missingParameterError(
+            'Remove Liquidity Nested SingleTokenExactIn',
+            'tokenOutIndex',
+            2,
+        );
     }
     switch (poolType) {
         case PoolType.Weighted:

--- a/src/entities/removeLiquidityNested/removeLiquidityNestedV2/encodeCalls.ts
+++ b/src/entities/removeLiquidityNested/removeLiquidityNestedV2/encodeCalls.ts
@@ -1,5 +1,5 @@
 import { encodeFunctionData, Hex } from 'viem';
-import { removeLiquiditySingleTokenExactInShouldHaveTokenOutIndexError } from '@/utils';
+import { removeLiquidityMissingTokenOutIndexError } from '@/utils';
 import { RemoveLiquidityNestedCallAttributesV2 } from './types';
 import { replaceWrapped } from '@/entities/utils';
 import { batchRelayerLibraryAbi } from '@/abi';
@@ -40,7 +40,7 @@ export const encodeCalls = (
             userData = getUserDataProportional(poolType, bptAmountIn.amount);
         } else {
             if (tokenOutIndex === undefined) {
-                throw removeLiquiditySingleTokenExactInShouldHaveTokenOutIndexError;
+                throw removeLiquidityMissingTokenOutIndexError();
             }
 
             // skip bpt index for ComposableStable pools
@@ -104,7 +104,7 @@ const getUserDataSingleTokenExactIn = (
     bptAmountIn: bigint,
 ) => {
     if (tokenOutIndex === undefined) {
-        throw removeLiquiditySingleTokenExactInShouldHaveTokenOutIndexError;
+        throw removeLiquidityMissingTokenOutIndexError();
     }
     switch (poolType) {
         case PoolType.Weighted:

--- a/src/entities/removeLiquidityNested/removeLiquidityNestedV2/validateInputs.ts
+++ b/src/entities/removeLiquidityNested/removeLiquidityNestedV2/validateInputs.ts
@@ -1,4 +1,4 @@
-import { NATIVE_ASSETS } from '../../../utils';
+import { inputValidationError, NATIVE_ASSETS } from '../../../utils';
 import { Token } from '../../token';
 import { NestedPoolState } from '../../types';
 import {
@@ -35,8 +35,9 @@ const validateInputsSingleToken = (
     const tokenOut = mainTokens.find((t) => t.isSameAddress(input.tokenOut));
 
     if (tokenOut === undefined) {
-        throw new Error(
-            `Removing liquidity to ${input.tokenOut} requires it to exist within main tokens`,
+        throw inputValidationError(
+            'Remove Liquidity Nested',
+            `Removing liquidity to ${input.tokenOut} requires it to exist within mainTokens`,
         );
     }
 };
@@ -50,8 +51,9 @@ export const validateBuildCallInput = (
             a.token.isSameAddress(NATIVE_ASSETS[input.chainId].wrapped),
         )
     ) {
-        throw new Error(
-            'Removing liquidity to native asset requires wrapped native asset to exist within amounts out',
+        throw inputValidationError(
+            'Remove Liquidity Nested',
+            'Removing liquidity to native asset requires wrapped native asset to exist within amountsOut',
         );
     }
 };

--- a/src/entities/swap/index.ts
+++ b/src/entities/swap/index.ts
@@ -15,6 +15,11 @@ import {
 } from './types';
 import { InputValidator } from '../inputValidator/inputValidator';
 import { Address } from 'viem';
+import {
+    exceedingParameterError,
+    missingParameterError,
+    protocolVersionError,
+} from '@/utils';
 
 export * from './types';
 export * from './paths';
@@ -36,9 +41,7 @@ export class Swap {
                 this.swap = new SwapV3(swapInput);
                 break;
             default:
-                throw Error(
-                    `SDK does not support swap for vault version: ${_protocolVersion}`,
-                );
+                throw protocolVersionError('Swap', _protocolVersion);
         }
         this.protocolVersion = _protocolVersion;
     }
@@ -85,10 +88,10 @@ export class Swap {
     ): SwapBuildOutputExactIn | SwapBuildOutputExactOut {
         const isV2Input = 'sender' in input;
         if (this.protocolVersion === 3 && isV2Input)
-            throw Error('Cannot define sender/recipient in V3');
+            throw exceedingParameterError('Swap', 'sender/recipient', 3);
 
         if (this.protocolVersion === 2 && !isV2Input)
-            throw Error('Sender/recipient must be defined in V2');
+            throw missingParameterError('Swap', 'sender/recipient', 2);
 
         return this.swap.buildCall(input);
     }

--- a/src/entities/swap/paths/pathWithAmount.ts
+++ b/src/entities/swap/paths/pathWithAmount.ts
@@ -18,17 +18,6 @@ export class PathWithAmount {
         outputAmountRaw: bigint,
         isBuffer: boolean[] | undefined,
     ) {
-        if (pools.length === 0 || tokens.length < 2) {
-            throw new Error(
-                'Invalid path: must contain at least 1 pool and 2 tokens.',
-            );
-        }
-        if (tokens.length !== pools.length + 1) {
-            throw new Error(
-                'Invalid path: tokens length must equal pools length + 1',
-            );
-        }
-
         const tokenIn = new Token(
             chainId,
             tokens[0].address,

--- a/src/entities/swap/swaps/v2/auraBalSwaps/exitPool.ts
+++ b/src/entities/swap/swaps/v2/auraBalSwaps/exitPool.ts
@@ -24,7 +24,7 @@ export function encodeExitData(
     );
     if (tokenOutIndex === -1)
         throw inputValidationError(
-            'AuraBal Swap',
+            'auraBal Swap',
             `Remove Liquidity tokenOut ${token.address} not in BAL-WETH pool`,
         );
     const minAmountsOut = Array(balWethAssets.length).fill(0n);

--- a/src/entities/swap/swaps/v2/auraBalSwaps/exitPool.ts
+++ b/src/entities/swap/swaps/v2/auraBalSwaps/exitPool.ts
@@ -6,7 +6,7 @@ import {
     Hex,
 } from 'viem';
 import { Token } from '@/entities/token';
-import { BALANCER_RELAYER, ChainId } from '@/utils';
+import { BALANCER_RELAYER, ChainId, inputValidationError } from '@/utils';
 import { batchRelayerLibraryAbi } from '@/abi';
 import { Relayer } from '@/entities/relayer';
 import { balWethAssets, balWethId } from './constants';
@@ -23,7 +23,10 @@ export function encodeExitData(
         token.isSameAddress(t),
     );
     if (tokenOutIndex === -1)
-        throw new Error(`exit token not in BAL-WETH pool ${token.address}`);
+        throw inputValidationError(
+            'AuraBal Swap',
+            `Remove Liquidity tokenOut ${token.address} not in BAL-WETH pool`,
+        );
     const minAmountsOut = Array(balWethAssets.length).fill(0n);
     minAmountsOut[tokenOutIndex] = limit;
     // stable pool (no need to worry about phantomBpt)

--- a/src/entities/swap/swaps/v2/auraBalSwaps/joinPool.ts
+++ b/src/entities/swap/swaps/v2/auraBalSwaps/joinPool.ts
@@ -6,7 +6,12 @@ import {
     Hex,
 } from 'viem';
 import { Token } from '@/entities/token';
-import { BALANCER_RELAYER, ChainId, NATIVE_ASSETS } from '@/utils';
+import {
+    BALANCER_RELAYER,
+    ChainId,
+    inputValidationError,
+    NATIVE_ASSETS,
+} from '@/utils';
 import { batchRelayerLibraryAbi } from '@/abi';
 import { Relayer } from '@/entities/relayer';
 import { balWethAssets, balWethId } from './constants';
@@ -20,7 +25,10 @@ export function encodeJoinData(
 ): { joinPoolData: Hex; joinPoolOpRef: bigint; value: bigint } {
     const tokenInIndex = balWethAssets.findIndex((t) => token.isSameAddress(t));
     if (tokenInIndex === -1)
-        throw new Error(`Join token not in BAL-WETH pool ${token.address}`);
+        throw inputValidationError(
+            'AuraBal Swap',
+            `Add Liquidity token ${token.address} not in BAL-WETH pool`,
+        );
 
     const useNativeAsset =
         wethIsEth && token.isUnderlyingEqual(NATIVE_ASSETS[ChainId.MAINNET]);

--- a/src/entities/swap/swaps/v2/auraBalSwaps/joinPool.ts
+++ b/src/entities/swap/swaps/v2/auraBalSwaps/joinPool.ts
@@ -26,7 +26,7 @@ export function encodeJoinData(
     const tokenInIndex = balWethAssets.findIndex((t) => token.isSameAddress(t));
     if (tokenInIndex === -1)
         throw inputValidationError(
-            'AuraBal Swap',
+            'auraBal Swap',
             `Add Liquidity token ${token.address} not in BAL-WETH pool`,
         );
 

--- a/src/entities/swap/swaps/v2/auraBalSwaps/parseInputs.ts
+++ b/src/entities/swap/swaps/v2/auraBalSwaps/parseInputs.ts
@@ -7,7 +7,7 @@ import {
 } from './types';
 import { supportedTokens, auraBalToken } from './constants';
 import { SwapKind } from '@/types';
-import { ChainId } from '@/utils';
+import { ChainId, inputValidationError } from '@/utils';
 import { TokenAmount } from '@/entities/tokenAmount';
 
 export function isAuraBalSwap(input: SwapQueryInput): boolean {
@@ -29,22 +29,25 @@ function isMainnet(
         !(
             tokenIn.chainId === ChainId.MAINNET &&
             tokenOut.chainId === ChainId.MAINNET &&
-            swapAmount.token.chainId
+            swapAmount.token.chainId === ChainId.MAINNET
         )
     )
-        throw Error('auraBal Swap: Must be mainnet.');
+        throw inputValidationError('AuraBal Swap', 'Must be mainnet.');
     return true;
 }
 
 function isAddressEqual(token: Token, amount: TokenAmount): boolean {
     if (!token.isSameAddress(amount.token.address))
-        throw Error('auraBal Swap: tokenIn and swapAmount address must match.');
+        throw inputValidationError(
+            'AuraBal Swap',
+            'tokenIn and swapAmount address must match.',
+        );
     return true;
 }
 
-function isGivenIn(kind): boolean {
+function isGivenIn(kind: SwapKind): boolean {
     if (kind !== SwapKind.GivenIn)
-        throw Error('auraBal Swap: Must be SwapKind GivenIn.');
+        throw inputValidationError('AuraBal Swap', 'Must be SwapKind GivenIn.');
     return true;
 }
 
@@ -52,23 +55,33 @@ function hasSupportedTokens(tokenIn: Token, tokenOut: Token): boolean {
     const tokenInIsAuraBal = auraBalToken.isSameAddress(tokenIn.address);
     const tokenOutIsAuraBal = auraBalToken.isSameAddress(tokenOut.address);
     if (tokenInIsAuraBal && tokenOutIsAuraBal)
-        throw Error('auraBal Swap: Both tokens are auraBal');
+        throw inputValidationError('AuraBal Swap', 'Both tokens are auraBal');
     if (!tokenInIsAuraBal && !tokenOutIsAuraBal)
-        throw Error('auraBal Swap: Must have tokenIn or tokenOut as auraBal.');
+        throw inputValidationError(
+            'AuraBal Swap',
+            'Must have tokenIn or tokenOut as auraBal.',
+        );
 
     if (tokenInIsAuraBal) {
         if (!isSupportedToken(tokenOut))
-            throw Error('auraBal Swap: Unsupported tokenOut');
+            throw inputValidationError(
+                'AuraBal Swap',
+                `Unsupported tokenOut address ${tokenOut.address}`,
+            );
     } else if (tokenOutIsAuraBal) {
         if (!isSupportedToken(tokenIn))
-            throw Error('auraBal Swap: Unsupported tokenIn');
+            throw inputValidationError(
+                'AuraBal Swap',
+                `Unsupported tokenIn address ${tokenIn.address}`,
+            );
     }
     return true;
 }
 
 export function parseInputs(input: SwapQueryInput): AuraBalSwapQueryInput {
     const { tokenIn, tokenOut, swapAmount } = input;
-    if (!isAuraBalSwap(input)) throw Error('Not A Valid AuraBal Swap');
+    if (!isAuraBalSwap(input))
+        throw inputValidationError('AuraBal Swap', 'Not A Valid AuraBal Swap');
 
     const auraBalIn = auraBalToken.isSameAddress(tokenIn.address);
     return {

--- a/src/entities/swap/swaps/v2/auraBalSwaps/parseInputs.ts
+++ b/src/entities/swap/swaps/v2/auraBalSwaps/parseInputs.ts
@@ -32,14 +32,14 @@ function isMainnet(
             swapAmount.token.chainId === ChainId.MAINNET
         )
     )
-        throw inputValidationError('AuraBal Swap', 'Must be mainnet.');
+        throw inputValidationError('auraBal Swap', 'Must be mainnet.');
     return true;
 }
 
 function isAddressEqual(token: Token, amount: TokenAmount): boolean {
     if (!token.isSameAddress(amount.token.address))
         throw inputValidationError(
-            'AuraBal Swap',
+            'auraBal Swap',
             'tokenIn and swapAmount address must match.',
         );
     return true;
@@ -47,7 +47,7 @@ function isAddressEqual(token: Token, amount: TokenAmount): boolean {
 
 function isGivenIn(kind: SwapKind): boolean {
     if (kind !== SwapKind.GivenIn)
-        throw inputValidationError('AuraBal Swap', 'Must be SwapKind GivenIn.');
+        throw inputValidationError('auraBal Swap', 'Must be SwapKind GivenIn.');
     return true;
 }
 
@@ -55,24 +55,24 @@ function hasSupportedTokens(tokenIn: Token, tokenOut: Token): boolean {
     const tokenInIsAuraBal = auraBalToken.isSameAddress(tokenIn.address);
     const tokenOutIsAuraBal = auraBalToken.isSameAddress(tokenOut.address);
     if (tokenInIsAuraBal && tokenOutIsAuraBal)
-        throw inputValidationError('AuraBal Swap', 'Both tokens are auraBal');
+        throw inputValidationError('auraBal Swap', 'Both tokens are auraBal');
     if (!tokenInIsAuraBal && !tokenOutIsAuraBal)
         throw inputValidationError(
-            'AuraBal Swap',
+            'auraBal Swap',
             'Must have tokenIn or tokenOut as auraBal.',
         );
 
     if (tokenInIsAuraBal) {
         if (!isSupportedToken(tokenOut))
             throw inputValidationError(
-                'AuraBal Swap',
-                `Unsupported tokenOut address ${tokenOut.address}`,
+                'auraBal Swap',
+                `Unsupported tokenOut ${tokenOut.address}`,
             );
     } else if (tokenOutIsAuraBal) {
         if (!isSupportedToken(tokenIn))
             throw inputValidationError(
-                'AuraBal Swap',
-                `Unsupported tokenIn address ${tokenIn.address}`,
+                'auraBal Swap',
+                `Unsupported tokenIn ${tokenIn.address}`,
             );
     }
     return true;
@@ -81,7 +81,7 @@ function hasSupportedTokens(tokenIn: Token, tokenOut: Token): boolean {
 export function parseInputs(input: SwapQueryInput): AuraBalSwapQueryInput {
     const { tokenIn, tokenOut, swapAmount } = input;
     if (!isAuraBalSwap(input))
-        throw inputValidationError('AuraBal Swap', 'Not A Valid AuraBal Swap');
+        throw inputValidationError('auraBal Swap', 'Not A Valid AuraBal Swap');
 
     const auraBalIn = auraBalToken.isSameAddress(tokenIn.address);
     return {

--- a/src/entities/swap/swaps/v2/index.ts
+++ b/src/entities/swap/swaps/v2/index.ts
@@ -11,6 +11,7 @@ import {
     ChainId,
     MAX_UINT256,
     CHAINS,
+    protocolVersionError,
 } from '../../../../utils';
 import {
     Address,
@@ -39,9 +40,6 @@ export * from './types';
 // A Swap can be a single or multiple paths
 export class SwapV2 implements SwapBase {
     public constructor({ chainId, paths, swapKind }: SwapInput) {
-        if (paths.length === 0)
-            throw new Error('Invalid swap: must contain at least 1 path.');
-
         this.paths = paths.map(
             (p) =>
                 new PathWithAmount(
@@ -310,7 +308,11 @@ export class SwapV2 implements SwapBase {
     }
 
     buildCallWithPermit2(): SwapBuildOutputExactIn | SwapBuildOutputExactOut {
-        throw new Error('buildCallWithPermit2 is not supported on v2');
+        throw protocolVersionError(
+            'buildCallWithPermit2',
+            2,
+            'buildCallWithPermit2 is supported on Balancer v3 only.',
+        );
     }
 
     /**

--- a/src/entities/swap/swaps/v3/index.ts
+++ b/src/entities/swap/swaps/v3/index.ts
@@ -16,6 +16,7 @@ import {
     BALANCER_BATCH_ROUTER,
     MAX_UINT256,
     CHAINS,
+    missingParameterError,
 } from '../../../../utils';
 import {
     ExactInQueryOutput,
@@ -57,9 +58,6 @@ export class SwapV3 implements SwapBase {
         swapKind,
         userData = DEFAULT_USERDATA,
     }: SwapInput) {
-        if (paths.length === 0)
-            throw new Error('Invalid swap: must contain at least 1 path.');
-
         this.paths = paths.map(
             (p) =>
                 new PathWithAmount(
@@ -176,7 +174,11 @@ export class SwapV3 implements SwapBase {
                 amountOut: this.outputAmount,
             };
         }
-        throw Error('Unsupported V3 Query');
+        throw missingParameterError(
+            'Swap query',
+            'exactAmountIn or exactAmountOut',
+            3,
+        );
     }
 
     private getSwapsWithLimits(pathLimits?: bigint[]): {
@@ -240,11 +242,6 @@ export class SwapV3 implements SwapBase {
                     { blockNumber: block },
                 );
 
-            if (result[1].length !== 1)
-                throw Error(
-                    'Swaps only support paths with matching tokenIn>tokenOut',
-                );
-
             return {
                 to: BALANCER_BATCH_ROUTER[this.chainId],
                 swapKind: SwapKind.GivenIn,
@@ -265,11 +262,6 @@ export class SwapV3 implements SwapBase {
             ],
             { blockNumber: block },
         );
-
-        if (result[1].length !== 1)
-            throw Error(
-                'Swaps only support paths with matching tokenIn>tokenOut',
-            );
 
         return {
             to: BALANCER_BATCH_ROUTER[this.chainId],

--- a/src/entities/utils/areTokensInArray.ts
+++ b/src/entities/utils/areTokensInArray.ts
@@ -1,11 +1,19 @@
+import { inputValidationError } from '@/utils';
 import { Address } from '../../types';
 
-export function areTokensInArray(tokens: Address[], tokenArray: Address[]) {
-    const sanitisedTokens = tokens.map((t) => t.toLowerCase() as Address);
-    const sanitisedTokenArray = tokenArray.map((t) => t.toLowerCase());
-    for (const token of sanitisedTokens) {
-        if (!sanitisedTokenArray.includes(token)) {
-            throw new Error(`Token ${token} not found in array`);
+export function areTokensInArray(
+    action: string,
+    inputTokens: Address[],
+    tokens: Address[],
+) {
+    const _inputTokens = inputTokens.map((t) => t.toLowerCase() as Address);
+    const _tokens = tokens.map((t) => t.toLowerCase());
+    for (const token of _inputTokens) {
+        if (!_tokens.includes(token)) {
+            throw inputValidationError(
+                action,
+                `Token ${token} not found in array [${tokens.join(', ')}]`,
+            );
         }
     }
 }

--- a/src/entities/utils/cowAmmHelpers.ts
+++ b/src/entities/utils/cowAmmHelpers.ts
@@ -9,7 +9,7 @@ import {
 import { cowAmmPoolAbi } from '@/abi/cowAmmPool';
 import { HumanAmount } from '@/data';
 import { Address, InputAmount } from '@/types';
-import { CHAINS, WAD } from '@/utils';
+import { CHAINS, inputValidationError, WAD } from '@/utils';
 
 import { getSortedTokens } from './getSortedTokens';
 import { PoolState, PoolStateWithBalances } from '../types';
@@ -112,8 +112,9 @@ export function calculateProportionalAmountsCowAmm(
             t.address.toLowerCase() === referenceAmount.address.toLowerCase(),
     );
     if (referenceTokenIndex === -1) {
-        throw new Error(
-            'Reference amount must be relative to a token in the pool or its BPT',
+        throw inputValidationError(
+            'Calculate Proportional Amounts',
+            `Reference amount token ${referenceAmount.address} must be relative to a token in the pool or its BPT`,
         );
     }
 

--- a/src/entities/utils/proportionalAmountsHelpers.ts
+++ b/src/entities/utils/proportionalAmountsHelpers.ts
@@ -1,7 +1,7 @@
 import { Address, parseUnits } from 'viem';
 import { InputAmount } from '@/types';
 import { HumanAmount } from '@/data';
-import { isSameAddress, MathSol } from '@/utils';
+import { inputValidationError, isSameAddress, MathSol } from '@/utils';
 import { AddLiquidityProportionalInput } from '../addLiquidity/types';
 import {
     PoolState,
@@ -52,8 +52,9 @@ export function calculateProportionalAmounts(
             t.address.toLowerCase() === referenceAmount.address.toLowerCase(),
     );
     if (referenceTokenIndex === -1) {
-        throw new Error(
-            'Reference amount must be relative to a token in the pool or its BPT',
+        throw inputValidationError(
+            'Calculate Proportional Amounts',
+            `Reference amount token ${referenceAmount.address} must be relative to a token in the pool or its BPT`,
         );
     }
 

--- a/src/entities/utils/validateNestedPoolState.ts
+++ b/src/entities/utils/validateNestedPoolState.ts
@@ -1,3 +1,4 @@
+import { inputValidationError } from '@/utils';
 import { NestedPoolState } from '../types';
 import { isPoolToken } from './isPoolToken';
 
@@ -26,19 +27,22 @@ export function validateNestedPoolState(
         });
 
         if (poolsWithToken.length < 1)
-            throw new Error(
-                'NestedPoolState, main token must exist as a token of a pool',
+            throw inputValidationError(
+                'Validate Nested Pool State',
+                `Main token ${t.address} must exist as a token of a pool`,
             );
 
         if (poolsWithToken.length > 1)
-            throw new Error(
-                `NestedPoolState, main token can't be token of more than 1 pool`,
+            throw inputValidationError(
+                'Validate Nested Pool State',
+                `Main token ${t.address} can't be token of more than 1 pool`,
             );
 
         if (poolsWithToken[0]) {
             if (topLevel - poolsWithToken[0].level > 1)
-                throw new Error(
-                    'NestedPoolState, main token only supported to a max of 1 level of nesting',
+                throw inputValidationError(
+                    'Validate Nested Pool State',
+                    `Main token ${t.address} only supported to a max of 1 level of nesting`,
                 );
         }
     });

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,4 +1,4 @@
-import { AddLiquidityKind, RemoveLiquidityKind } from '..';
+import { AddLiquidityKind } from '..';
 
 export const removeLiquidityMissingTokenOutIndexError = () =>
     new SDKError(
@@ -39,16 +39,6 @@ export const addLiquidityProportionalOnlyError = (
         'Input Validation',
         `Add Liquidity ${kind}`,
         `Add Liquidity ${kind} not supported for pool type ${poolType}. Use Add Liquidity Proportional`,
-    );
-
-export const removeLiquidityProportionalOnlyError = (
-    kind: RemoveLiquidityKind,
-    poolType: string,
-) =>
-    new SDKError(
-        'Input Validation',
-        `Remove Liquidity ${kind}`,
-        `Remove Liquidity ${kind} not supported for pool type ${poolType}. Use Remove Liquidity Proportional`,
     );
 
 export const missingParameterError = (

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,5 +1,3 @@
-import { AddLiquidityKind } from '..';
-
 export const removeLiquidityMissingTokenOutIndexError = () =>
     new SDKError(
         'Input Validation',
@@ -19,16 +17,6 @@ export const removeLiquidityUnbalancedProtocolVersionError = () =>
         'Input Validation',
         'Remove Liquidity Unbalanced',
         'Remove Liquidity Unbalanced not supported on Balancer v3',
-    );
-
-export const addLiquidityPoolTypeError = (
-    kind: AddLiquidityKind,
-    poolType: string,
-) =>
-    new SDKError(
-        'Input Validation',
-        `Add Liquidity ${kind}`,
-        `Add Liquidity ${kind} not supported for pool type ${poolType}`,
     );
 
 export const missingParameterError = (

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -2,22 +2,24 @@ export const missingParameterError = (
     action: string,
     param: string,
     protocolVersion: number,
+    suggestion?: string,
 ) =>
-    new SDKError(
-        'Input Validation',
+    inputValidationError(
         action,
         `${action} input missing parameter ${param} for Balancer v${protocolVersion}`,
+        suggestion,
     );
 
 export const exceedingParameterError = (
     action: string,
     param: string,
     protocolVersion: number,
+    suggestion?: string,
 ) =>
-    new SDKError(
-        'Input Validation',
+    inputValidationError(
         action,
         `${action} input exceeding parameter ${param} for Balancer v${protocolVersion}`,
+        suggestion,
     );
 
 export const protocolVersionError = (
@@ -25,8 +27,7 @@ export const protocolVersionError = (
     protocolVersion: number,
     suggestion?: string,
 ) =>
-    new SDKError(
-        'Input Validation',
+    inputValidationError(
         action,
         `${action} not supported for Balancer v${protocolVersion}.`,
         suggestion,
@@ -37,8 +38,7 @@ export const poolTypeError = (
     poolType: string,
     suggestion?: string,
 ) =>
-    new SDKError(
-        'Input Validation',
+    inputValidationError(
         action,
         `${action} not supported for pool type ${poolType}.`,
         suggestion,
@@ -48,15 +48,19 @@ export const poolTypeProtocolVersionError = (
     action: string,
     poolType: string,
     protocolVersion: number,
+    suggestion?: string,
 ) =>
-    new SDKError(
-        'Input Validation',
+    inputValidationError(
         action,
         `${action} not supported for pool type ${poolType} on Balancer v${protocolVersion}.`,
+        suggestion,
     );
 
-export const inputValidationError = (action: string, message: string) =>
-    new SDKError('Input Validation', action, message);
+export const inputValidationError = (
+    action: string,
+    message: string,
+    suggestion?: string,
+) => new SDKError('Input Validation', action, message, suggestion);
 
 export class SDKError extends Error {
     constructor(

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -59,7 +59,7 @@ export const missingParameterError = (
     new SDKError(
         'Input Validation',
         action,
-        `${action} missing parameter: ${param} for Balancer v${protocolVersion}`,
+        `${action} missing parameter ${param} for Balancer v${protocolVersion}`,
     );
 
 export const exceedingParameterError = (
@@ -70,7 +70,7 @@ export const exceedingParameterError = (
     new SDKError(
         'Input Validation',
         action,
-        `${action} exceeding parameter: ${param} for Balancer v${protocolVersion}`,
+        `${action} exceeding parameter ${param} for Balancer v${protocolVersion}`,
     );
 
 export const protocolVersionError = (

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -12,13 +12,6 @@ export const addLiquidityMissingTokenInIndexError = () =>
         'Add Liquidity SingleToken should have tokenInIndex',
     );
 
-export const removeLiquidityUnbalancedProtocolVersionError = () =>
-    new SDKError(
-        'Input Validation',
-        'Remove Liquidity Unbalanced',
-        'Remove Liquidity Unbalanced not supported on Balancer v3',
-    );
-
 export const missingParameterError = (
     action: string,
     param: string,

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -112,6 +112,9 @@ export const poolTypeProtocolVersionError = (
         `${action} not supported for pool type ${poolType} on Balancer v${protocolVersion}`,
     );
 
+export const inputValidationError = (action: string, message: string) =>
+    new SDKError('Input Validation', action, message);
+
 export class SDKError extends Error {
     constructor(
         public name: string,

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -94,6 +94,24 @@ export const protocolVersionError = (action: string, protocolVersion: number) =>
         `${action} not supported for Balancer v${protocolVersion}`,
     );
 
+export const poolTypeError = (action: string, poolType: string) =>
+    new SDKError(
+        'Input Validation',
+        action,
+        `${action} not supported for pool type ${poolType}`,
+    );
+
+export const poolTypeProtocolVersionError = (
+    action: string,
+    poolType: string,
+    protocolVersion: number,
+) =>
+    new SDKError(
+        'Input Validation',
+        action,
+        `${action} not supported for pool type ${poolType} on Balancer v${protocolVersion}`,
+    );
+
 export class SDKError extends Error {
     constructor(
         public name: string,

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -59,7 +59,7 @@ export const missingParameterError = (
     new SDKError(
         'Input Validation',
         action,
-        `${action} missing parameter ${param} for Balancer v${protocolVersion}`,
+        `${action} input missing parameter ${param} for Balancer v${protocolVersion}`,
     );
 
 export const exceedingParameterError = (
@@ -70,7 +70,7 @@ export const exceedingParameterError = (
     new SDKError(
         'Input Validation',
         action,
-        `${action} exceeding parameter ${param} for Balancer v${protocolVersion}`,
+        `${action} input exceeding parameter ${param} for Balancer v${protocolVersion}`,
     );
 
 export const protocolVersionError = (

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,10 +1,3 @@
-export const removeLiquidityMissingTokenOutIndexError = () =>
-    new SDKError(
-        'Input Validation',
-        'Remove Liquidity SingleTokenExactIn',
-        'Remove Liquidity SingleTokenExactIn should have tokenOutIndex',
-    );
-
 export const missingParameterError = (
     action: string,
     param: string,

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -87,6 +87,13 @@ export const addLiquidityNativeAssetError = (poolType: string) =>
         `Add Liquidity With Native Asset not supported for ${poolType}`,
     );
 
+export const protocolVersionError = (action: string, protocolVersion: number) =>
+    new SDKError(
+        'Input Validation',
+        action,
+        `${action} not supported for Balancer v${protocolVersion}`,
+    );
+
 export class SDKError extends Error {
     constructor(
         public name: string,

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -5,13 +5,6 @@ export const removeLiquidityMissingTokenOutIndexError = () =>
         'Remove Liquidity SingleTokenExactIn should have tokenOutIndex',
     );
 
-export const addLiquidityMissingTokenInIndexError = () =>
-    new SDKError(
-        'Input Validation',
-        'Add Liquidity SingleToken',
-        'Add Liquidity SingleToken should have tokenInIndex',
-    );
-
 export const missingParameterError = (
     action: string,
     param: string,

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -51,13 +51,6 @@ export const removeLiquidityProportionalOnlyError = (
         `Remove Liquidity ${kind} not supported for pool type ${poolType}. Use Remove Liquidity Proportional`,
     );
 
-export const buildCallWithPermit2ProtocolVersionError = () =>
-    new SDKError(
-        'Input Validation',
-        'buildCallWithPermit2',
-        'buildCall with Permit2 signatures is available for Balancer v3 only',
-    );
-
 export const missingParameterError = (
     action: string,
     param: string,
@@ -80,25 +73,28 @@ export const exceedingParameterError = (
         `${action} exceeding parameter: ${param} for Balancer v${protocolVersion}`,
     );
 
-export const addLiquidityNativeAssetError = (poolType: string) =>
-    new SDKError(
-        'Input Validation',
-        'Add Liquidity With Native Asset',
-        `Add Liquidity With Native Asset not supported for ${poolType}`,
-    );
-
-export const protocolVersionError = (action: string, protocolVersion: number) =>
+export const protocolVersionError = (
+    action: string,
+    protocolVersion: number,
+    suggestion?: string,
+) =>
     new SDKError(
         'Input Validation',
         action,
-        `${action} not supported for Balancer v${protocolVersion}`,
+        `${action} not supported for Balancer v${protocolVersion}.`,
+        suggestion,
     );
 
-export const poolTypeError = (action: string, poolType: string) =>
+export const poolTypeError = (
+    action: string,
+    poolType: string,
+    suggestion?: string,
+) =>
     new SDKError(
         'Input Validation',
         action,
-        `${action} not supported for pool type ${poolType}`,
+        `${action} not supported for pool type ${poolType}.`,
+        suggestion,
     );
 
 export const poolTypeProtocolVersionError = (
@@ -109,7 +105,7 @@ export const poolTypeProtocolVersionError = (
     new SDKError(
         'Input Validation',
         action,
-        `${action} not supported for pool type ${poolType} on Balancer v${protocolVersion}`,
+        `${action} not supported for pool type ${poolType} on Balancer v${protocolVersion}.`,
     );
 
 export const inputValidationError = (action: string, message: string) =>
@@ -119,9 +115,11 @@ export class SDKError extends Error {
     constructor(
         public name: string,
         public action: string,
-        message: string,
+        public message: string,
+        public suggestion?: string,
     ) {
-        super(message);
+        const _message = suggestion ? `${message} ${suggestion}` : message;
+        super(_message);
         this.name = name;
         this.action = action;
 

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,41 +1,73 @@
 import { AddLiquidityKind, RemoveLiquidityKind } from '..';
 
-export const addLiquiditySingleTokenShouldHaveTokenInIndexError = Error(
-    'AddLiquidityKind.SingleToken should have tokenInIndex',
-);
+export const removeLiquidityMissingTokenOutIndexError = () =>
+    new SDKError(
+        'Input Validation',
+        'Remove Liquidity SingleTokenExactIn',
+        'Remove Liquidity SingleTokenExactIn should have tokenOutIndex',
+    );
 
-export const addLiquidityProportionalUnavailableError = new Error(
-    'AddLiquidityKind.Proportional is not available for V3. Please use ProportionalAmountsHelper to calculate proportional amountsIn and use AddLiquidityKind.Unbalanced instead.',
-);
+export const addLiquidityMissingTokenInIndexError = () =>
+    new SDKError(
+        'Input Validation',
+        'Add Liquidity SingleToken',
+        'Add Liquidity SingleToken should have tokenInIndex',
+    );
 
-export const removeLiquiditySingleTokenExactInShouldHaveTokenOutIndexError =
-    Error('RemoveLiquidityKind.SingleTokenExactIn should have tokenOutIndex');
+export const removeLiquidityUnbalancedProtocolVersionError = () =>
+    new SDKError(
+        'Input Validation',
+        'Remove Liquidity Unbalanced',
+        'Remove Liquidity Unbalanced not supported on Balancer v3',
+    );
 
-export const removeLiquidityUnbalancedNotSupportedOnV3 = Error(
-    'Unbalanced remove liquidity not supported on V3',
-);
-
-export const addLiquidityProportionalNotSupportedOnPoolTypeError = (
+export const addLiquidityPoolTypeError = (
+    kind: AddLiquidityKind,
     poolType: string,
 ) =>
-    Error(`Add Liquidity Proportional not supported on pool type: ${poolType}`);
+    new SDKError(
+        'Input Validation',
+        `Add Liquidity ${kind}`,
+        `Add Liquidity ${kind} not supported for pool type ${poolType}`,
+    );
 
 export const addLiquidityProportionalOnlyError = (
     kind: AddLiquidityKind,
     poolType: string,
 ) =>
-    Error(
-        `Add Liquidity ${kind} not supported for pool ${poolType}. Use Add Liquidity Proportional`,
+    new SDKError(
+        'Input Validation',
+        `Add Liquidity ${kind}`,
+        `Add Liquidity ${kind} not supported for pool type ${poolType}. Use Add Liquidity Proportional`,
     );
 
 export const removeLiquidityProportionalOnlyError = (
     kind: RemoveLiquidityKind,
     poolType: string,
 ) =>
-    Error(
-        `Remove Liquidity ${kind} not supported for pool ${poolType}. Use Remove Liquidity Proportional`,
+    new SDKError(
+        'Input Validation',
+        `Remove Liquidity ${kind}`,
+        `Remove Liquidity ${kind} not supported for pool type ${poolType}. Use Remove Liquidity Proportional`,
     );
 
-export const buildCallWithPermit2ProtocolVersionError = Error(
-    'buildCall with Permit2 signatures is only available for v3',
-);
+export const buildCallWithPermit2ProtocolVersionError = () =>
+    new SDKError(
+        'Input Validation',
+        'buildCallWithPermit2',
+        'buildCall with Permit2 signatures is available for Balancer v3 only',
+    );
+
+export class SDKError extends Error {
+    constructor(
+        public name: string,
+        public action: string,
+        message: string,
+    ) {
+        super(message);
+        this.name = name;
+        this.action = action;
+
+        Object.setPrototypeOf(this, SDKError.prototype);
+    }
+}

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -31,16 +31,6 @@ export const addLiquidityPoolTypeError = (
         `Add Liquidity ${kind} not supported for pool type ${poolType}`,
     );
 
-export const addLiquidityProportionalOnlyError = (
-    kind: AddLiquidityKind,
-    poolType: string,
-) =>
-    new SDKError(
-        'Input Validation',
-        `Add Liquidity ${kind}`,
-        `Add Liquidity ${kind} not supported for pool type ${poolType}. Use Add Liquidity Proportional`,
-    );
-
 export const missingParameterError = (
     action: string,
     param: string,

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -58,6 +58,35 @@ export const buildCallWithPermit2ProtocolVersionError = () =>
         'buildCall with Permit2 signatures is available for Balancer v3 only',
     );
 
+export const missingParameterError = (
+    action: string,
+    param: string,
+    protocolVersion: number,
+) =>
+    new SDKError(
+        'Input Validation',
+        action,
+        `${action} missing parameter: ${param} for Balancer v${protocolVersion}`,
+    );
+
+export const exceedingParameterError = (
+    action: string,
+    param: string,
+    protocolVersion: number,
+) =>
+    new SDKError(
+        'Input Validation',
+        action,
+        `${action} exceeding parameter: ${param} for Balancer v${protocolVersion}`,
+    );
+
+export const addLiquidityNativeAssetError = (poolType: string) =>
+    new SDKError(
+        'Input Validation',
+        'Add Liquidity With Native Asset',
+        `Add Liquidity With Native Asset not supported for ${poolType}`,
+    );
+
 export class SDKError extends Error {
     constructor(
         public name: string,

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,3 +1,4 @@
+import { inputValidationError } from '..';
 import { Token } from '../entities/token';
 import { TokenAmount, BigintIsh } from '../entities/tokenAmount';
 import { Address, SwapKind } from '../types';
@@ -23,14 +24,26 @@ export function checkInputs(
         tokenIn.chainId !== tokenOut.chainId ||
         tokenIn.chainId !== amount.token.chainId
     ) {
-        throw new Error('ChainId mismatch for inputs');
+        throw inputValidationError(
+            'Swap',
+            'tokenIn, tokenOut and amount should have the same chainId',
+        );
     }
 
     if (
         (swapKind === SwapKind.GivenIn && !tokenIn.isEqual(amount.token)) ||
         (swapKind === SwapKind.GivenOut && !tokenOut.isEqual(amount.token))
     ) {
-        throw new Error('Swap amount token does not match input token');
+        throw inputValidationError(
+            'Swap',
+            `Swap amount token ${
+                amount.token.address
+            } does not match input token ${
+                swapKind === SwapKind.GivenIn
+                    ? tokenIn.address
+                    : tokenOut.address
+            }`,
+        );
     }
 
     return amount;

--- a/test/cowAmm/addLiquidity.integration.test.ts
+++ b/test/cowAmm/addLiquidity.integration.test.ts
@@ -16,13 +16,13 @@ import {
     AddLiquidityInput,
     AddLiquidityKind,
     AddLiquidityProportionalInput,
-    addLiquidityProportionalOnlyError,
     AddLiquidityUnbalancedInput,
     ChainId,
     CHAINS,
     Hex,
     PoolState,
     PoolType,
+    poolTypeError,
     Slippage,
 } from 'src';
 
@@ -142,9 +142,10 @@ describe('add liquidity test', () => {
             await expect(() =>
                 doAddLiquidity({ ...txInput, addLiquidityInput }),
             ).rejects.toThrowError(
-                addLiquidityProportionalOnlyError(
-                    addLiquidityInput.kind,
-                    txInput.poolState.type,
+                poolTypeError(
+                    `Add Liquidity ${addLiquidityInput.kind}`,
+                    poolState.type,
+                    'Use Add Liquidity Proportional',
                 ),
             );
         });

--- a/test/cowAmm/removeLiquidity.integration.test.ts
+++ b/test/cowAmm/removeLiquidity.integration.test.ts
@@ -26,8 +26,8 @@ import {
     RemoveLiquidityKind,
     RemoveLiquidityInput,
     RemoveLiquidityProportionalInput,
-    removeLiquidityProportionalOnlyError,
     RemoveLiquidityUnbalancedInput,
+    poolTypeError,
 } from 'src';
 
 import { ANVIL_NETWORKS, startFork } from 'test/anvil/anvil-global-setup';
@@ -174,9 +174,10 @@ describe('remove liquidity test', () => {
             await expect(() =>
                 doRemoveLiquidity({ ...txInput, removeLiquidityInput }),
             ).rejects.toThrowError(
-                removeLiquidityProportionalOnlyError(
-                    removeLiquidityInput.kind,
-                    txInput.poolState.type,
+                poolTypeError(
+                    `Remove Liquidity ${removeLiquidityInput.kind}`,
+                    poolState.type,
+                    'Use Remove Liquidity Proportional',
                 ),
             );
         });

--- a/test/entities/swaps/swap.test.ts
+++ b/test/entities/swaps/swap.test.ts
@@ -1,5 +1,5 @@
 // pnpm test -- swap.test.ts
-import { ChainId, Slippage } from '@/index';
+import { ChainId, inputValidationError, Slippage } from '@/index';
 import { SwapKind } from '@/types';
 import {
     Swap,
@@ -76,7 +76,10 @@ describe('Swap', () => {
                     swapKind: SwapKind.GivenIn,
                 });
             }).toThrowError(
-                'Unsupported swap: all paths must use same Balancer version.',
+                inputValidationError(
+                    'Swap',
+                    'All paths must use same Balancer version.',
+                ),
             );
         });
         describe('path inputs show all start/end with same token', () => {
@@ -92,7 +95,10 @@ describe('Swap', () => {
                         swapKind: SwapKind.GivenIn,
                     });
                 }).toThrowError(
-                    'Unsupported swap: all paths must start/end with same token.',
+                    inputValidationError(
+                        'Swap',
+                        'All paths must start with same token.',
+                    ),
                 );
             });
             test('should throw if paths end with different token', () => {
@@ -107,7 +113,10 @@ describe('Swap', () => {
                         swapKind: SwapKind.GivenIn,
                     });
                 }).toThrowError(
-                    'Unsupported swap: all paths must start/end with same token.',
+                    inputValidationError(
+                        'Swap',
+                        'All paths must end with same token.',
+                    ),
                 );
             });
             describe('buffers', () => {
@@ -157,7 +166,10 @@ describe('Swap', () => {
                             swapKind: SwapKind.GivenIn,
                         });
                     }).toThrowError(
-                        'Unsupported swap: buffers not supported in V2.',
+                        inputValidationError(
+                            'Swap',
+                            'Swap with buffers not supported in Balancer v2.',
+                        ),
                     );
                 });
                 test('should throw if buffers not same length as pools', () => {
@@ -173,7 +185,10 @@ describe('Swap', () => {
                             swapKind: SwapKind.GivenIn,
                         });
                     }).toThrowError(
-                        'Unsupported swap: buffers and pools must have same length.',
+                        inputValidationError(
+                            'Swap',
+                            'buffers and pools must have same length.',
+                        ),
                     );
                 });
             });

--- a/test/entities/swaps/v2/auraBalSwaps/parseInputs.test.ts
+++ b/test/entities/swaps/v2/auraBalSwaps/parseInputs.test.ts
@@ -3,7 +3,7 @@ import { AuraBalSwapKind, Token, TokenAmount } from '@/entities';
 import { auraBalToken } from '@/entities/swap/swaps/v2/auraBalSwaps/constants';
 import { parseInputs } from '@/entities/swap/swaps/v2/auraBalSwaps/parseInputs';
 import { SwapKind } from '@/types';
-import { ChainId } from '@/utils';
+import { ChainId, inputValidationError } from '@/utils';
 
 const usdc = new Token(
     ChainId.MAINNET,
@@ -26,7 +26,10 @@ describe('auraBalSwaps:parseInputs', () => {
                 swapAmount: TokenAmount.fromHumanAmount(usdc, '1'),
             });
         }).rejects.toThrowError(
-            'auraBal Swap: Must have tokenIn or tokenOut as auraBal.',
+            inputValidationError(
+                'auraBal Swap',
+                'Must have tokenIn or tokenOut as auraBal.',
+            ),
         );
     });
     test('should throw for non-supported input token', async () => {
@@ -37,7 +40,12 @@ describe('auraBalSwaps:parseInputs', () => {
                 kind: SwapKind.GivenIn,
                 swapAmount: TokenAmount.fromHumanAmount(usdc, '1'),
             });
-        }).rejects.toThrowError('auraBal Swap: Unsupported tokenIn');
+        }).rejects.toThrowError(
+            inputValidationError(
+                'auraBal Swap',
+                `Unsupported tokenIn ${usdc.address}`,
+            ),
+        );
     });
     test('should throw for non-supported output token', async () => {
         await expect(async () => {
@@ -47,7 +55,12 @@ describe('auraBalSwaps:parseInputs', () => {
                 kind: SwapKind.GivenIn,
                 swapAmount: TokenAmount.fromHumanAmount(auraBalToken, '1'),
             });
-        }).rejects.toThrowError('auraBal Swap: Unsupported tokenOut');
+        }).rejects.toThrowError(
+            inputValidationError(
+                'auraBal Swap',
+                `Unsupported tokenOut ${usdc.address}`,
+            ),
+        );
     });
     test('should throw for ExactOut', async () => {
         await expect(async () => {
@@ -57,7 +70,9 @@ describe('auraBalSwaps:parseInputs', () => {
                 kind: SwapKind.GivenOut,
                 swapAmount: TokenAmount.fromHumanAmount(auraBalToken, '1'),
             });
-        }).rejects.toThrowError('auraBal Swap: Must be SwapKind GivenIn.');
+        }).rejects.toThrowError(
+            inputValidationError('auraBal Swap', 'Must be SwapKind GivenIn.'),
+        );
     });
     test('should throw when tokenIn and swapAmount tokens dont match', async () => {
         await expect(async () => {
@@ -68,7 +83,10 @@ describe('auraBalSwaps:parseInputs', () => {
                 swapAmount: TokenAmount.fromHumanAmount(usdc, '1'),
             });
         }).rejects.toThrowError(
-            'auraBal Swap: tokenIn and swapAmount address must match.',
+            inputValidationError(
+                'auraBal Swap',
+                'tokenIn and swapAmount address must match.',
+            ),
         );
     });
     test('valid fromAuraBal', async () => {

--- a/test/inputValidator.test.ts
+++ b/test/inputValidator.test.ts
@@ -13,6 +13,6 @@ describe('inputValidator', () => {
 
         expect(() => {
             inputValidator.validateAddLiquidity(addLiqInput, poolState);
-        }).toThrowError(/^Unsupported ChainId: 777777777$/);
+        }).toThrowError(/^Unsupported chainId: 777777777$/);
     });
 });

--- a/test/lib/utils/addLiquidityHelper.ts
+++ b/test/lib/utils/addLiquidityHelper.ts
@@ -382,8 +382,6 @@ export function assertAddLiquidityProportional(
         case 3:
             to = BALANCER_ROUTER[chainId];
             break;
-        default:
-            throw new Error(`Unsupported protocolVersion: ${protocolVersion}`);
     }
 
     let expectedQueryOutput: Omit<

--- a/test/lib/utils/addLiquidityHelper.ts
+++ b/test/lib/utils/addLiquidityHelper.ts
@@ -9,7 +9,6 @@ import {
     AddLiquidityProportionalInput,
     AddLiquidityQueryOutput,
     AddLiquiditySingleTokenInput,
-    addLiquidityMissingTokenInIndexError,
     AddLiquidityUnbalancedInput,
     AddLiquidityV3BuildCallInput,
     Address,
@@ -24,6 +23,7 @@ import {
     ChainId,
     isSameAddress,
     PublicWalletClient,
+    missingParameterError,
 } from 'src';
 import { getTokensForBalanceCheck } from './getTokensForBalanceCheck';
 import { TxOutput, sendTransactionGetBalances } from './helper';
@@ -284,7 +284,11 @@ export function assertAddLiquiditySingleToken(
         addLiquidityOutput;
 
     if (addLiquidityQueryOutput.tokenInIndex === undefined)
-        throw addLiquidityMissingTokenInIndexError();
+        throw missingParameterError(
+            'Add Liquidity SingleToken',
+            'tokenInIndex',
+            protocolVersion,
+        );
 
     const bptToken = new Token(
         addLiquidityInput.chainId,

--- a/test/lib/utils/addLiquidityHelper.ts
+++ b/test/lib/utils/addLiquidityHelper.ts
@@ -6,7 +6,7 @@ import {
     AddLiquidityProportionalInput,
     AddLiquidityQueryOutput,
     AddLiquiditySingleTokenInput,
-    addLiquiditySingleTokenShouldHaveTokenInIndexError,
+    addLiquidityMissingTokenInIndexError,
     AddLiquidityUnbalancedInput,
     Address,
     BALANCER_ROUTER,
@@ -276,7 +276,7 @@ export function assertAddLiquiditySingleToken(
         addLiquidityOutput;
 
     if (addLiquidityQueryOutput.tokenInIndex === undefined)
-        throw addLiquiditySingleTokenShouldHaveTokenInIndexError;
+        throw addLiquidityMissingTokenInIndexError();
 
     const bptToken = new Token(
         addLiquidityInput.chainId,

--- a/test/lib/utils/addLiquidityHelper.ts
+++ b/test/lib/utils/addLiquidityHelper.ts
@@ -1,13 +1,17 @@
+import { Hex, TestActions } from 'viem';
 import {
     AddLiquidity,
+    AddLiquidityBaseBuildCallInput,
     AddLiquidityBuildCallOutput,
     AddLiquidityBuildCallInput,
     AddLiquidityInput,
+    AddLiquidityKind,
     AddLiquidityProportionalInput,
     AddLiquidityQueryOutput,
     AddLiquiditySingleTokenInput,
     addLiquidityMissingTokenInIndexError,
     AddLiquidityUnbalancedInput,
+    AddLiquidityV3BuildCallInput,
     Address,
     BALANCER_ROUTER,
     NATIVE_ASSETS,
@@ -17,7 +21,6 @@ import {
     TokenAmount,
     VAULT_V2,
     Permit2Helper,
-    AddLiquidityKind,
     ChainId,
     isSameAddress,
     PublicWalletClient,
@@ -27,7 +30,6 @@ import { TxOutput, sendTransactionGetBalances } from './helper';
 import { AddLiquidityTxInput } from './types';
 import { AddLiquidityV2BaseBuildCallInput } from '@/entities/addLiquidity/addLiquidityV2/types';
 import { AddLiquidityV2ComposableStableQueryOutput } from '@/entities/addLiquidity/addLiquidityV2/composableStable/types';
-import { Hex, TestActions } from 'viem';
 
 type AddLiquidityOutput = {
     addLiquidityQueryOutput: AddLiquidityQueryOutput;
@@ -64,7 +66,7 @@ async function sdkAddLiquidity({
         poolState,
     );
 
-    let addLiquidityBuildInput: AddLiquidityBuildCallInput = {
+    let addLiquidityBuildInput: AddLiquidityBaseBuildCallInput = {
         ...addLiquidityQueryOutput,
         slippage,
         wethIsEth: !!wethIsEth,
@@ -75,6 +77,12 @@ async function sdkAddLiquidity({
             sender: testAddress,
             recipient: testAddress,
             fromInternalBalance: !!fromInternalBalance,
+        };
+    }
+    if (poolState.protocolVersion === 3) {
+        (addLiquidityBuildInput as AddLiquidityV3BuildCallInput) = {
+            ...addLiquidityBuildInput,
+            userData: addLiquidityInput.userData ?? '0x',
         };
     }
 
@@ -88,12 +96,12 @@ async function sdkAddLiquidity({
         });
 
         addLiquidityBuildCallOutput = addLiquidity.buildCallWithPermit2(
-            addLiquidityBuildInput,
+            addLiquidityBuildInput as AddLiquidityBuildCallInput,
             permit2,
         );
     } else {
         addLiquidityBuildCallOutput = addLiquidity.buildCall(
-            addLiquidityBuildInput,
+            addLiquidityBuildInput as AddLiquidityBuildCallInput,
         );
     }
 

--- a/test/lib/utils/removeLiquidityHelper.ts
+++ b/test/lib/utils/removeLiquidityHelper.ts
@@ -469,8 +469,6 @@ export function assertRemoveLiquidityProportional(
         case 3:
             to = BALANCER_ROUTER[chainId];
             break;
-        default:
-            throw new Error(`Unsupported protocolVersion: ${protocolVersion}`);
     }
 
     let expectedQueryOutput:

--- a/test/lib/utils/removeLiquidityHelper.ts
+++ b/test/lib/utils/removeLiquidityHelper.ts
@@ -2,25 +2,25 @@ import { Hex, zeroAddress } from 'viem';
 import {
     Address,
     BALANCER_ROUTER,
+    ChainId,
+    missingParameterError,
     NATIVE_ASSETS,
+    PermitHelper,
     PoolState,
+    RemoveLiquidityBaseBuildCallInput,
     RemoveLiquidityBuildCallOutput,
     RemoveLiquidityInput,
     RemoveLiquidityProportionalInput,
     RemoveLiquidityQueryOutput,
     RemoveLiquidityRecoveryInput,
     RemoveLiquiditySingleTokenExactInInput,
-    removeLiquidityMissingTokenOutIndexError,
     RemoveLiquiditySingleTokenExactOutInput,
     RemoveLiquidityUnbalancedInput,
+    RemoveLiquidityV3BuildCallInput,
     Slippage,
     Token,
     TokenAmount,
     VAULT_V2,
-    PermitHelper,
-    ChainId,
-    RemoveLiquidityBaseBuildCallInput,
-    RemoveLiquidityV3BuildCallInput,
 } from 'src';
 import { getTokensForBalanceCheck } from './getTokensForBalanceCheck';
 import { sendTransactionGetBalances, TxOutput } from './helper';
@@ -359,7 +359,11 @@ export function assertRemoveLiquiditySingleTokenExactIn(
     } = removeLiquidityOutput;
 
     if (removeLiquidityQueryOutput.tokenOutIndex === undefined)
-        throw removeLiquidityMissingTokenOutIndexError();
+        throw missingParameterError(
+            'Remove Liquidity SingleTokenExactIn',
+            'tokenOutIndex',
+            protocolVersion,
+        );
 
     const bptToken = new Token(
         removeLiquidityInput.chainId,

--- a/test/lib/utils/removeLiquidityHelper.ts
+++ b/test/lib/utils/removeLiquidityHelper.ts
@@ -11,7 +11,7 @@ import {
     RemoveLiquidityQueryOutput,
     RemoveLiquidityRecoveryInput,
     RemoveLiquiditySingleTokenExactInInput,
-    removeLiquiditySingleTokenExactInShouldHaveTokenOutIndexError,
+    removeLiquidityMissingTokenOutIndexError,
     RemoveLiquiditySingleTokenExactOutInput,
     RemoveLiquidityUnbalancedInput,
     Slippage,
@@ -345,7 +345,7 @@ export function assertRemoveLiquiditySingleTokenExactIn(
     } = removeLiquidityOutput;
 
     if (removeLiquidityQueryOutput.tokenOutIndex === undefined)
-        throw removeLiquiditySingleTokenExactInShouldHaveTokenOutIndexError;
+        throw removeLiquidityMissingTokenOutIndexError();
 
     const bptToken = new Token(
         removeLiquidityInput.chainId,

--- a/test/lib/utils/removeLiquidityRecoveryHelper.ts
+++ b/test/lib/utils/removeLiquidityRecoveryHelper.ts
@@ -3,10 +3,11 @@ import {
     ChainId,
     NATIVE_ASSETS,
     PoolState,
-    RemoveLiquidityBuildCallInput,
+    RemoveLiquidityBaseBuildCallInput,
     RemoveLiquidityBuildCallOutput,
     RemoveLiquidityQueryOutput,
     RemoveLiquidityRecoveryInput,
+    RemoveLiquidityV3BuildCallInput,
     Slippage,
     Token,
     TokenAmount,
@@ -15,7 +16,10 @@ import {
 import { getTokensForBalanceCheck } from './getTokensForBalanceCheck';
 import { sendTransactionGetBalances } from './helper';
 import { RemoveLiquidityRecoveryTxInput } from './types';
-import { RemoveLiquidityV2BaseBuildCallInput } from '@/entities/removeLiquidity/removeLiquidityV2/types';
+import {
+    RemoveLiquidityV2BaseBuildCallInput,
+    RemoveLiquidityV2BuildCallInput,
+} from '@/entities/removeLiquidity/removeLiquidityV2/types';
 import {
     RemoveLiquidityOutput,
     assertRemoveLiquidityBuildCallOutput,
@@ -41,7 +45,7 @@ export const sdkRemoveLiquidityRecovery = async ({
         poolState,
     );
 
-    let removeLiquidityBuildInput: RemoveLiquidityBuildCallInput = {
+    let removeLiquidityBuildInput: RemoveLiquidityBaseBuildCallInput = {
         ...removeLiquidityQueryOutput,
         slippage,
         wethIsEth: !!wethIsEth,
@@ -54,9 +58,17 @@ export const sdkRemoveLiquidityRecovery = async ({
             toInternalBalance: !!toInternalBalance,
         };
     }
+    if (poolState.protocolVersion === 3) {
+        (removeLiquidityBuildInput as RemoveLiquidityV3BuildCallInput) = {
+            ...removeLiquidityBuildInput,
+            userData: removeLiquidityRecoveryInput.userData ?? '0x',
+        };
+    }
 
     const removeLiquidityBuildCallOutput = removeLiquidity.buildCall(
-        removeLiquidityBuildInput,
+        removeLiquidityBuildInput as
+            | RemoveLiquidityV2BuildCallInput
+            | RemoveLiquidityV3BuildCallInput,
     );
 
     return {

--- a/test/v2/addLiquidity/gyro2.integration.test.ts
+++ b/test/v2/addLiquidity/gyro2.integration.test.ts
@@ -28,7 +28,7 @@ import {
     AddLiquidityUnbalancedInput,
     AddLiquiditySingleTokenInput,
     PoolType,
-    addLiquidityProportionalOnlyError,
+    poolTypeError,
 } from '../../../src';
 import {
     AddLiquidityTxInput,
@@ -173,9 +173,10 @@ describe('Gyro2 add liquidity test', () => {
                     addLiquidityInput,
                 }),
             ).rejects.toThrowError(
-                addLiquidityProportionalOnlyError(
-                    addLiquidityInput.kind,
+                poolTypeError(
+                    `Add Liquidity ${addLiquidityInput.kind}`,
                     poolState.type,
+                    'Use Add Liquidity Proportional',
                 ),
             );
         });
@@ -206,9 +207,10 @@ describe('Gyro2 add liquidity test', () => {
                     addLiquidityInput,
                 }),
             ).rejects.toThrowError(
-                addLiquidityProportionalOnlyError(
-                    addLiquidityInput.kind,
+                poolTypeError(
+                    `Add Liquidity ${addLiquidityInput.kind}`,
                     poolState.type,
+                    'Use Add Liquidity Proportional',
                 ),
             );
         });

--- a/test/v2/addLiquidity/gyro3.integration.test.ts
+++ b/test/v2/addLiquidity/gyro3.integration.test.ts
@@ -28,7 +28,7 @@ import {
     AddLiquidityUnbalancedInput,
     AddLiquiditySingleTokenInput,
     PoolType,
-    addLiquidityProportionalOnlyError,
+    poolTypeError,
 } from '../../../src';
 import {
     AddLiquidityTxInput,
@@ -172,9 +172,10 @@ describe('Gyro3 add liquidity test', () => {
                     addLiquidityInput,
                 }),
             ).rejects.toThrowError(
-                addLiquidityProportionalOnlyError(
-                    addLiquidityInput.kind,
+                poolTypeError(
+                    `Add Liquidity ${addLiquidityInput.kind}`,
                     poolState.type,
+                    'Use Add Liquidity Proportional',
                 ),
             );
         });
@@ -205,9 +206,10 @@ describe('Gyro3 add liquidity test', () => {
                     addLiquidityInput,
                 }),
             ).rejects.toThrowError(
-                addLiquidityProportionalOnlyError(
-                    addLiquidityInput.kind,
+                poolTypeError(
+                    `Add Liquidity ${addLiquidityInput.kind}`,
                     poolState.type,
+                    'Use Add Liquidity Proportional',
                 ),
             );
         });

--- a/test/v2/addLiquidity/gyroE.integration.test.ts
+++ b/test/v2/addLiquidity/gyroE.integration.test.ts
@@ -28,7 +28,7 @@ import {
     AddLiquidityUnbalancedInput,
     AddLiquiditySingleTokenInput,
     PoolType,
-    addLiquidityProportionalOnlyError,
+    poolTypeError,
 } from '../../../src';
 import {
     AddLiquidityTxInput,
@@ -171,9 +171,10 @@ describe('GyroE add liquidity test', () => {
                     addLiquidityInput,
                 }),
             ).rejects.toThrowError(
-                addLiquidityProportionalOnlyError(
-                    addLiquidityInput.kind,
+                poolTypeError(
+                    `Add Liquidity ${addLiquidityInput.kind}`,
                     poolState.type,
+                    'Use Add Liquidity Proportional',
                 ),
             );
         });
@@ -205,9 +206,10 @@ describe('GyroE add liquidity test', () => {
                     addLiquidityInput,
                 }),
             ).rejects.toThrowError(
-                addLiquidityProportionalOnlyError(
-                    addLiquidityInput.kind,
+                poolTypeError(
+                    `Add Liquidity ${addLiquidityInput.kind}`,
                     poolState.type,
+                    'Use Add Liquidity Proportional',
                 ),
             );
         });

--- a/test/v2/addLiquidity/gyroEV2.integration.test.ts
+++ b/test/v2/addLiquidity/gyroEV2.integration.test.ts
@@ -28,7 +28,7 @@ import {
     AddLiquidityUnbalancedInput,
     AddLiquiditySingleTokenInput,
     PoolType,
-    addLiquidityProportionalOnlyError,
+    poolTypeError,
 } from '../../../src';
 import { forkSetup } from '../../lib/utils/helper';
 import {
@@ -191,9 +191,10 @@ describe('GyroE V2 add liquidity test', () => {
                     addLiquidityInput,
                 }),
             ).rejects.toThrowError(
-                addLiquidityProportionalOnlyError(
-                    addLiquidityInput.kind,
+                poolTypeError(
+                    `Add Liquidity ${addLiquidityInput.kind}`,
                     poolState.type,
+                    'Use Add Liquidity Proportional',
                 ),
             );
         });
@@ -224,9 +225,10 @@ describe('GyroE V2 add liquidity test', () => {
                     addLiquidityInput,
                 }),
             ).rejects.toThrowError(
-                addLiquidityProportionalOnlyError(
-                    addLiquidityInput.kind,
+                poolTypeError(
+                    `Add Liquidity ${addLiquidityInput.kind}`,
                     poolState.type,
+                    'Use Add Liquidity Proportional',
                 ),
             );
         });

--- a/test/v2/addLiquidity/stable.integration.test.ts
+++ b/test/v2/addLiquidity/stable.integration.test.ts
@@ -28,7 +28,7 @@ import {
     AddLiquidityInput,
     InputAmount,
     PoolType,
-    addLiquidityPoolTypeError,
+    poolTypeError,
 } from 'src';
 import {
     AddLiquidityTxInput,
@@ -225,8 +225,8 @@ describe('add liquidity stable test', () => {
                     addLiquidityInput,
                 }),
             ).rejects.toThrowError(
-                addLiquidityPoolTypeError(
-                    addLiquidityInput.kind,
+                poolTypeError(
+                    `Add Liquidity ${addLiquidityInput.kind}`,
                     poolState.type,
                 ),
             );

--- a/test/v2/addLiquidity/stable.integration.test.ts
+++ b/test/v2/addLiquidity/stable.integration.test.ts
@@ -28,7 +28,7 @@ import {
     AddLiquidityInput,
     InputAmount,
     PoolType,
-    addLiquidityProportionalNotSupportedOnPoolTypeError,
+    addLiquidityPoolTypeError,
 } from 'src';
 import {
     AddLiquidityTxInput,
@@ -225,7 +225,8 @@ describe('add liquidity stable test', () => {
                     addLiquidityInput,
                 }),
             ).rejects.toThrowError(
-                addLiquidityProportionalNotSupportedOnPoolTypeError(
+                addLiquidityPoolTypeError(
+                    addLiquidityInput.kind,
                     poolState.type,
                 ),
             );

--- a/test/v2/removeLiquidity/gyro2.integration.test.ts
+++ b/test/v2/removeLiquidity/gyro2.integration.test.ts
@@ -27,7 +27,7 @@ import {
     InputAmount,
     PoolType,
     RemoveLiquiditySingleTokenExactOutInput,
-    removeLiquidityProportionalOnlyError,
+    poolTypeError,
 } from '../../../src';
 import {
     assertRemoveLiquidityProportional,
@@ -138,9 +138,10 @@ describe('Gyro2 remove liquidity test', () => {
             await expect(() =>
                 doRemoveLiquidity({ ...txInput, removeLiquidityInput }),
             ).rejects.toThrowError(
-                removeLiquidityProportionalOnlyError(
-                    removeLiquidityInput.kind,
+                poolTypeError(
+                    `Remove Liquidity ${removeLiquidityInput.kind}`,
                     poolState.type,
+                    'Use Remove Liquidity Proportional',
                 ),
             );
         });
@@ -169,9 +170,10 @@ describe('Gyro2 remove liquidity test', () => {
             await expect(() =>
                 doRemoveLiquidity({ ...txInput, removeLiquidityInput }),
             ).rejects.toThrowError(
-                removeLiquidityProportionalOnlyError(
-                    removeLiquidityInput.kind,
+                poolTypeError(
+                    `Remove Liquidity ${removeLiquidityInput.kind}`,
                     poolState.type,
+                    'Use Remove Liquidity Proportional',
                 ),
             );
         });
@@ -198,9 +200,10 @@ describe('Gyro2 remove liquidity test', () => {
             await expect(() =>
                 doRemoveLiquidity({ ...txInput, removeLiquidityInput }),
             ).rejects.toThrowError(
-                removeLiquidityProportionalOnlyError(
-                    removeLiquidityInput.kind,
+                poolTypeError(
+                    `Remove Liquidity ${removeLiquidityInput.kind}`,
                     poolState.type,
+                    'Use Remove Liquidity Proportional',
                 ),
             );
         });

--- a/test/v2/removeLiquidity/gyro3.integration.test.ts
+++ b/test/v2/removeLiquidity/gyro3.integration.test.ts
@@ -27,7 +27,7 @@ import {
     InputAmount,
     PoolType,
     RemoveLiquiditySingleTokenExactOutInput,
-    removeLiquidityProportionalOnlyError,
+    poolTypeError,
 } from '../../../src';
 import {
     assertRemoveLiquidityProportional,
@@ -138,9 +138,10 @@ describe('Gyro3 remove liquidity test', () => {
             await expect(() =>
                 doRemoveLiquidity({ ...txInput, removeLiquidityInput }),
             ).rejects.toThrowError(
-                removeLiquidityProportionalOnlyError(
-                    removeLiquidityInput.kind,
+                poolTypeError(
+                    `Remove Liquidity ${removeLiquidityInput.kind}`,
                     poolState.type,
+                    'Use Remove Liquidity Proportional',
                 ),
             );
         });
@@ -169,9 +170,10 @@ describe('Gyro3 remove liquidity test', () => {
             await expect(() =>
                 doRemoveLiquidity({ ...txInput, removeLiquidityInput }),
             ).rejects.toThrowError(
-                removeLiquidityProportionalOnlyError(
-                    removeLiquidityInput.kind,
+                poolTypeError(
+                    `Remove Liquidity ${removeLiquidityInput.kind}`,
                     poolState.type,
+                    'Use Remove Liquidity Proportional',
                 ),
             );
         });
@@ -198,9 +200,10 @@ describe('Gyro3 remove liquidity test', () => {
             await expect(() =>
                 doRemoveLiquidity({ ...txInput, removeLiquidityInput: input }),
             ).rejects.toThrowError(
-                removeLiquidityProportionalOnlyError(
-                    input.kind,
+                poolTypeError(
+                    `Remove Liquidity ${removeLiquidityInput.kind}`,
                     poolState.type,
+                    'Use Remove Liquidity Proportional',
                 ),
             );
         });

--- a/test/v2/removeLiquidity/gyro3.integration.test.ts
+++ b/test/v2/removeLiquidity/gyro3.integration.test.ts
@@ -201,7 +201,7 @@ describe('Gyro3 remove liquidity test', () => {
                 doRemoveLiquidity({ ...txInput, removeLiquidityInput: input }),
             ).rejects.toThrowError(
                 poolTypeError(
-                    `Remove Liquidity ${removeLiquidityInput.kind}`,
+                    `Remove Liquidity ${input.kind}`,
                     poolState.type,
                     'Use Remove Liquidity Proportional',
                 ),

--- a/test/v2/removeLiquidity/gyroE.integration.test.ts
+++ b/test/v2/removeLiquidity/gyroE.integration.test.ts
@@ -27,7 +27,7 @@ import {
     InputAmount,
     PoolType,
     RemoveLiquiditySingleTokenExactOutInput,
-    removeLiquidityProportionalOnlyError,
+    poolTypeError,
 } from '../../../src';
 import {
     assertRemoveLiquidityProportional,
@@ -138,9 +138,10 @@ describe('GyroE V1 remove liquidity test', () => {
             await expect(() =>
                 doRemoveLiquidity({ ...txInput, removeLiquidityInput }),
             ).rejects.toThrowError(
-                removeLiquidityProportionalOnlyError(
-                    removeLiquidityInput.kind,
+                poolTypeError(
+                    `Remove Liquidity ${removeLiquidityInput.kind}`,
                     poolState.type,
+                    'Use Remove Liquidity Proportional',
                 ),
             );
         });
@@ -169,9 +170,10 @@ describe('GyroE V1 remove liquidity test', () => {
             await expect(() =>
                 doRemoveLiquidity({ ...txInput, removeLiquidityInput }),
             ).rejects.toThrowError(
-                removeLiquidityProportionalOnlyError(
-                    removeLiquidityInput.kind,
+                poolTypeError(
+                    `Remove Liquidity ${removeLiquidityInput.kind}`,
                     poolState.type,
+                    'Use Remove Liquidity Proportional',
                 ),
             );
         });
@@ -198,9 +200,10 @@ describe('GyroE V1 remove liquidity test', () => {
             await expect(() =>
                 doRemoveLiquidity({ ...txInput, removeLiquidityInput: input }),
             ).rejects.toThrowError(
-                removeLiquidityProportionalOnlyError(
-                    input.kind,
+                poolTypeError(
+                    `Remove Liquidity ${input.kind}`,
                     poolState.type,
+                    'Use Remove Liquidity Proportional',
                 ),
             );
         });

--- a/test/v2/removeLiquidity/gyroEV2.integration.test.ts
+++ b/test/v2/removeLiquidity/gyroEV2.integration.test.ts
@@ -27,7 +27,7 @@ import {
     InputAmount,
     PoolType,
     RemoveLiquiditySingleTokenExactOutInput,
-    removeLiquidityProportionalOnlyError,
+    poolTypeError,
 } from '../../../src';
 import {
     assertRemoveLiquidityProportional,
@@ -157,9 +157,10 @@ describe('GyroE V2 remove liquidity test', () => {
             await expect(() =>
                 doRemoveLiquidity({ ...txInput, removeLiquidityInput }),
             ).rejects.toThrowError(
-                removeLiquidityProportionalOnlyError(
-                    removeLiquidityInput.kind,
+                poolTypeError(
+                    `Remove Liquidity ${removeLiquidityInput.kind}`,
                     poolState.type,
+                    'Use Remove Liquidity Proportional',
                 ),
             );
         });
@@ -188,9 +189,10 @@ describe('GyroE V2 remove liquidity test', () => {
             await expect(() =>
                 doRemoveLiquidity({ ...txInput, removeLiquidityInput }),
             ).rejects.toThrowError(
-                removeLiquidityProportionalOnlyError(
-                    removeLiquidityInput.kind,
+                poolTypeError(
+                    `Remove Liquidity ${removeLiquidityInput.kind}`,
                     poolState.type,
+                    'Use Remove Liquidity Proportional',
                 ),
             );
         });
@@ -217,9 +219,10 @@ describe('GyroE V2 remove liquidity test', () => {
             await expect(() =>
                 doRemoveLiquidity({ ...txInput, removeLiquidityInput: input }),
             ).rejects.toThrowError(
-                removeLiquidityProportionalOnlyError(
-                    input.kind,
+                poolTypeError(
+                    `Remove Liquidity ${input.kind}`,
                     poolState.type,
+                    'Use Remove Liquidity Proportional',
                 ),
             );
         });

--- a/test/v2/removeLiquidityNested/removeLiquidityNested.integration.test.ts
+++ b/test/v2/removeLiquidityNested/removeLiquidityNested.integration.test.ts
@@ -29,6 +29,7 @@ import {
     PublicWalletClient,
     RemoveLiquidityNestedCallInputV2,
     RemoveLiquidityNested,
+    inputValidationError,
 } from 'src';
 
 import { ANVIL_NETWORKS, startFork } from 'test/anvil/anvil-global-setup';
@@ -222,7 +223,10 @@ describe('remove liquidity nested test', () => {
                 wethIsEth,
             }),
         ).rejects.toThrow(
-            'Removing liquidity to native asset requires wrapped native asset to exist within amounts out',
+            inputValidationError(
+                'Remove Liquidity Nested',
+                'Removing liquidity to native asset requires wrapped native asset to exist within amountsOut',
+            ),
         );
     });
 });

--- a/test/v3/addLiquidity/addLiquidity.integration-gnosis.test.ts
+++ b/test/v3/addLiquidity/addLiquidity.integration-gnosis.test.ts
@@ -50,7 +50,7 @@ const chainId = ChainId.GNOSIS_CHAIN;
 const sDAI = TOKENS[chainId].sDAI;
 const BRLA = TOKENS[chainId].BRLA;
 
-describe('add liquidity test', () => {
+describe.skip('add liquidity test', () => {
     let client: PublicWalletClient & TestActions;
     let txInput: AddLiquidityTxInput;
     let poolState: PoolState;

--- a/test/v3/createPool/gyroECLP/gyroECLP.validation.test.ts
+++ b/test/v3/createPool/gyroECLP/gyroECLP.validation.test.ts
@@ -6,6 +6,7 @@ import {
     TokenType,
     CreatePool,
     CreatePoolGyroECLPInput,
+    inputValidationError,
 } from 'src';
 import { TOKENS } from 'test/lib/utils/addresses';
 
@@ -181,7 +182,10 @@ describe('create GyroECLP pool input validations', () => {
             },
         ];
         expect(() => buildCallWithModifiedInput({ tokens })).toThrowError(
-            'GyroECLP pools on v3 support only two tokens',
+            inputValidationError(
+                'Create Pool',
+                'GyroECLP pools support only two tokens on Balancer v3',
+            ),
         );
     });
 

--- a/test/v3/createPool/gyroECLP/gyroECLP.validation.test.ts
+++ b/test/v3/createPool/gyroECLP/gyroECLP.validation.test.ts
@@ -189,29 +189,53 @@ describe('create GyroECLP pool input validations', () => {
         );
     });
 
-    describe('validateParams', () => {
+    describe('Validate Base Params', () => {
         test('RotationVectorSWrong()', async () => {
             expect(() =>
                 buildCallWithModifiedInput({ eclpParams: { s: -1n } }),
-            ).toThrowError('s must be >= 0 and <= 1000000000000000000');
+            ).toThrowError(
+                inputValidationError(
+                    'Create Pool',
+                    'Invalid base ECLP parameters',
+                    's must be >= 0 and <= 1000000000000000000',
+                ),
+            );
 
             expect(() =>
                 buildCallWithModifiedInput({
                     eclpParams: { s: _ONE + 1n },
                 }),
-            ).toThrowError('s must be >= 0 and <= 1000000000000000000');
+            ).toThrowError(
+                inputValidationError(
+                    'Create Pool',
+                    'Invalid base ECLP parameters',
+                    's must be >= 0 and <= 1000000000000000000',
+                ),
+            );
         });
 
         test('RotationVectorCWrong()', async () => {
             expect(() =>
                 buildCallWithModifiedInput({ eclpParams: { c: -1n } }),
-            ).toThrowError('c must be >= 0 and <= 1000000000000000000');
+            ).toThrowError(
+                inputValidationError(
+                    'Create Pool',
+                    'Invalid base ECLP parameters',
+                    'c must be >= 0 and <= 1000000000000000000',
+                ),
+            );
 
             expect(() =>
                 buildCallWithModifiedInput({
                     eclpParams: { c: _ONE + 1n },
                 }),
-            ).toThrowError('c must be >= 0 and <= 1000000000000000000');
+            ).toThrowError(
+                inputValidationError(
+                    'Create Pool',
+                    'Invalid base ECLP parameters',
+                    'c must be >= 0 and <= 1000000000000000000',
+                ),
+            );
         });
 
         test('scnorm2 outside valid range', async () => {
@@ -219,7 +243,13 @@ describe('create GyroECLP pool input validations', () => {
                 buildCallWithModifiedInput({
                     eclpParams: { s: 1n, c: 1n },
                 }),
-            ).toThrowError('RotationVectorNotNormalized');
+            ).toThrowError(
+                inputValidationError(
+                    'Create Pool',
+                    'Invalid base ECLP parameters',
+                    'RotationVectorNotNormalized()',
+                ),
+            );
 
             expect(() =>
                 buildCallWithModifiedInput({
@@ -228,7 +258,13 @@ describe('create GyroECLP pool input validations', () => {
                         c: parseUnits('1', 18),
                     },
                 }),
-            ).toThrowError('RotationVectorNotNormalized');
+            ).toThrowError(
+                inputValidationError(
+                    'Create Pool',
+                    'Invalid base ECLP parameters',
+                    'RotationVectorNotNormalized()',
+                ),
+            );
         });
 
         test('lambda outside valid range', async () => {
@@ -237,7 +273,11 @@ describe('create GyroECLP pool input validations', () => {
                     eclpParams: { lambda: -1n },
                 }),
             ).toThrowError(
-                'lambda must be >= 0 and <= 100000000000000000000000000',
+                inputValidationError(
+                    'Create Pool',
+                    'Invalid base ECLP parameters',
+                    'lambda must be >= 0 and <= 100000000000000000000000000',
+                ),
             );
 
             expect(() =>
@@ -245,18 +285,28 @@ describe('create GyroECLP pool input validations', () => {
                     eclpParams: { lambda: _MAX_STRETCH_FACTOR + 1n },
                 }),
             ).toThrowError(
-                'lambda must be >= 0 and <= 100000000000000000000000000',
+                inputValidationError(
+                    'Create Pool',
+                    'Invalid base ECLP parameters',
+                    'lambda must be >= 0 and <= 100000000000000000000000000',
+                ),
             );
         });
     });
 
-    describe('validateDerivedParamsLimits', () => {
+    describe('Validate Derived Params', () => {
         test('DerivedTauAlphaYWrong()', async () => {
             expect(() =>
                 buildCallWithModifiedInput({
                     derivedEclpParams: { tauAlpha: { y: -1n } },
                 }),
-            ).toThrowError('tuaAlpha.y must be > 0');
+            ).toThrowError(
+                inputValidationError(
+                    'Create Pool',
+                    'Invalid derived ECLP parameters',
+                    'tuaAlpha.y must be > 0',
+                ),
+            );
         });
 
         test('DerivedTauBetaYWrong()', async () => {
@@ -264,7 +314,13 @@ describe('create GyroECLP pool input validations', () => {
                 buildCallWithModifiedInput({
                     derivedEclpParams: { tauBeta: { y: -1n } },
                 }),
-            ).toThrowError('tauBeta.y must be > 0');
+            ).toThrowError(
+                inputValidationError(
+                    'Create Pool',
+                    'Invalid derived ECLP parameters',
+                    'tauBeta.y must be > 0',
+                ),
+            );
         });
 
         test('DerivedTauXWrong()', async () => {
@@ -276,7 +332,13 @@ describe('create GyroECLP pool input validations', () => {
                         },
                     },
                 }),
-            ).toThrowError('tauBeta.x must be > tauAlpha.x');
+            ).toThrowError(
+                inputValidationError(
+                    'Create Pool',
+                    'Invalid derived ECLP parameters',
+                    'tauBeta.x must be > tauAlpha.x',
+                ),
+            );
         });
 
         test('DerivedTauAlphaNotNormalized()', async () => {
@@ -289,7 +351,13 @@ describe('create GyroECLP pool input validations', () => {
                         },
                     },
                 }),
-            ).toThrowError('RotationVectorNotNormalized()');
+            ).toThrowError(
+                inputValidationError(
+                    'Create Pool',
+                    'Invalid derived ECLP parameters',
+                    'RotationVectorNotNormalized()',
+                ),
+            );
 
             expect(() =>
                 buildCallWithModifiedInput({
@@ -300,7 +368,13 @@ describe('create GyroECLP pool input validations', () => {
                         },
                     },
                 }),
-            ).toThrowError('RotationVectorNotNormalized()');
+            ).toThrowError(
+                inputValidationError(
+                    'Create Pool',
+                    'Invalid derived ECLP parameters',
+                    'RotationVectorNotNormalized()',
+                ),
+            );
         });
 
         test('Derived parameters u, v, w, z limits', async () => {
@@ -308,25 +382,49 @@ describe('create GyroECLP pool input validations', () => {
                 buildCallWithModifiedInput({
                     derivedEclpParams: { u: _ONE_XP + 1n },
                 }),
-            ).toThrowError(`u must be <= ${_ONE_XP}`);
+            ).toThrowError(
+                inputValidationError(
+                    'Create Pool',
+                    'Invalid derived ECLP parameters',
+                    `u must be <= ${_ONE_XP}`,
+                ),
+            );
 
             expect(() =>
                 buildCallWithModifiedInput({
                     derivedEclpParams: { v: _ONE_XP + 1n },
                 }),
-            ).toThrowError(`v must be <= ${_ONE_XP}`);
+            ).toThrowError(
+                inputValidationError(
+                    'Create Pool',
+                    'Invalid derived ECLP parameters',
+                    `v must be <= ${_ONE_XP}`,
+                ),
+            );
 
             expect(() =>
                 buildCallWithModifiedInput({
                     derivedEclpParams: { w: _ONE_XP + 1n },
                 }),
-            ).toThrowError(`w must be <= ${_ONE_XP}`);
+            ).toThrowError(
+                inputValidationError(
+                    'Create Pool',
+                    'Invalid derived ECLP parameters',
+                    `w must be <= ${_ONE_XP}`,
+                ),
+            );
 
             expect(() =>
                 buildCallWithModifiedInput({
                     derivedEclpParams: { z: _ONE_XP + 1n },
                 }),
-            ).toThrowError(`z must be <= ${_ONE_XP}`);
+            ).toThrowError(
+                inputValidationError(
+                    'Create Pool',
+                    'Invalid derived ECLP parameters',
+                    `z must be <= ${_ONE_XP}`,
+                ),
+            );
         });
 
         test('DerivedDsqWrong()', async () => {
@@ -336,7 +434,13 @@ describe('create GyroECLP pool input validations', () => {
                         dSq: _ONE_XP - _DERIVED_DSQ_NORM_ACCURACY_XP - 1n,
                     },
                 }),
-            ).toThrowError('DerivedDsqWrong()');
+            ).toThrowError(
+                inputValidationError(
+                    'Create Pool',
+                    'Invalid derived ECLP parameters',
+                    'DerivedDsqWrong()',
+                ),
+            );
 
             expect(() =>
                 buildCallWithModifiedInput({
@@ -344,7 +448,13 @@ describe('create GyroECLP pool input validations', () => {
                         dSq: _ONE_XP + _DERIVED_DSQ_NORM_ACCURACY_XP + 1n,
                     },
                 }),
-            ).toThrowError('DerivedDsqWrong()');
+            ).toThrowError(
+                inputValidationError(
+                    'Create Pool',
+                    'Invalid derived ECLP parameters',
+                    'DerivedDsqWrong()',
+                ),
+            );
         });
     });
 });

--- a/test/v3/removeLiquidity/removeLiquidity.integration.test.ts
+++ b/test/v3/removeLiquidity/removeLiquidity.integration.test.ts
@@ -39,7 +39,7 @@ import {
     RemoveLiquiditySingleTokenExactOutInput,
     RemoveLiquidityUnbalancedInput,
     RemoveLiquidityRecoveryInput,
-    removeLiquidityUnbalancedNotSupportedOnV3,
+    removeLiquidityUnbalancedProtocolVersionError,
     vaultAdminAbi_V3,
     PublicWalletClient,
 } from 'src';
@@ -189,7 +189,7 @@ describe('remove liquidity test', () => {
                 await expect(() =>
                     doRemoveLiquidity({ ...txInput, removeLiquidityInput }),
                 ).rejects.toThrowError(
-                    removeLiquidityUnbalancedNotSupportedOnV3,
+                    removeLiquidityUnbalancedProtocolVersionError(),
                 );
             });
         });

--- a/test/v3/removeLiquidity/removeLiquidity.integration.test.ts
+++ b/test/v3/removeLiquidity/removeLiquidity.integration.test.ts
@@ -39,7 +39,7 @@ import {
     RemoveLiquiditySingleTokenExactOutInput,
     RemoveLiquidityUnbalancedInput,
     RemoveLiquidityRecoveryInput,
-    removeLiquidityUnbalancedProtocolVersionError,
+    protocolVersionError,
     vaultAdminAbi_V3,
     PublicWalletClient,
 } from 'src';
@@ -189,7 +189,10 @@ describe('remove liquidity test', () => {
                 await expect(() =>
                     doRemoveLiquidity({ ...txInput, removeLiquidityInput }),
                 ).rejects.toThrowError(
-                    removeLiquidityUnbalancedProtocolVersionError(),
+                    protocolVersionError(
+                        'Remove Liquidity Unbalanced',
+                        poolState.protocolVersion,
+                    ),
                 );
             });
         });

--- a/test/validateNestedPoolState.test.ts
+++ b/test/validateNestedPoolState.test.ts
@@ -17,7 +17,7 @@ describe('nested pool state validations', () => {
         test('should throw', () => {
             // Test the exact error message
             expect(() => validateNestedPoolState(missingMain)).toThrowError(
-                /^NestedPoolState, main token must exist as a token of a pool$/,
+                /^Main token 0x.* must exist as a token of a pool$/,
             );
         });
     });
@@ -27,7 +27,7 @@ describe('nested pool state validations', () => {
             expect(() =>
                 validateNestedPoolState(multiTokenPoolState),
             ).toThrowError(
-                /^NestedPoolState, main token can't be token of more than 1 pool$/,
+                /^Main token 0x.* can't be token of more than 1 pool$/,
             );
         });
     });
@@ -47,7 +47,7 @@ describe('nested pool state validations', () => {
         test('should throw', () => {
             // Test the exact error message
             expect(() => validateNestedPoolState(deepPoolState)).toThrowError(
-                /^NestedPoolState, main token only supported to a max of 1 level of nesting$/,
+                /^Main token 0x.* only supported to a max of 1 level of nesting$/,
             );
         });
     });


### PR DESCRIPTION
Closes #620 

Possible breaking changes:
- Some error messages were updated, so if consumers rely on parsing error messages, please double check if the message wasn't updated.

Main changes:
- Standardize SDK Input Validation errors as custom `SDKError` with `name`, `action` and `message`, such as:
    > SDKError
    > name: Input Validation
    > action: Remove Liquidity Unbalanced
    > message: Remove Liquidity Unbalanced not supported on Balancer v3
- Update error messages so they are more descriptive, in the sense that it's clear the action that originated it and any other relevant info, such as:
    - `buildCall input/version mis-match` -> `Add Liquidity input missing parameter sender for Balancer v2`
- Remove redundant checks already being done within input validation

Side changes:
- move `userData` to inside v3 buildCall input type