### PR TITLE
Refactor errors thrown by ECLP param validations 

### DIFF
--- a/src/entities/inputValidator/gyro/inputValidatorGyro.ts
+++ b/src/entities/inputValidator/gyro/inputValidatorGyro.ts
@@ -18,8 +18,8 @@ export class InputValidatorGyro extends InputValidatorBase {
 
         if (input.tokens.length !== 2) {
             throw inputValidationError(
-                'Create Gyro ECLP',
-                'This pool supports only two tokens on Balancer v3',
+                'Create Pool',
+                'GyroECLP pools support only two tokens on Balancer v3',
             );
         }
 
@@ -29,8 +29,8 @@ export class InputValidatorGyro extends InputValidatorBase {
             GyroECLPMath.validateParams(eclpParams);
         } catch (err) {
             throw inputValidationError(
-                'Create Gyro ECLP',
-                'Invalid base parameters',
+                'Create Pool',
+                'Invalid base ECLP parameters',
                 (err as Error).message,
             );
         }
@@ -39,8 +39,8 @@ export class InputValidatorGyro extends InputValidatorBase {
             GyroECLPMath.validateDerivedParams(eclpParams, derivedEclpParams);
         } catch (err) {
             throw inputValidationError(
-                'Create Gyro ECLP',
-                'Invalid derived parameters',
+                'Create Pool',
+                'Invalid derived ECLP parameters',
                 (err as Error).message,
             );
         }

--- a/src/entities/inputValidator/gyro/inputValidatorGyro.ts
+++ b/src/entities/inputValidator/gyro/inputValidatorGyro.ts
@@ -12,24 +12,39 @@ import {
 import { inputValidationError, poolTypeError } from '@/utils';
 import { CreatePoolGyroECLPInput } from '@/entities/createPool';
 import { GyroECLPMath } from '@balancer-labs/balancer-maths';
-
 export class InputValidatorGyro extends InputValidatorBase {
     validateCreatePool(input: CreatePoolGyroECLPInput) {
         super.validateCreatePool(input);
 
         if (input.tokens.length !== 2) {
             throw inputValidationError(
-                'Create Pool',
-                'GyroECLP pools support only two tokens on Balancer v3',
+                'Create Gyro ECLP',
+                'This pool supports only two tokens on Balancer v3',
             );
         }
 
         const { eclpParams, derivedEclpParams } = input;
 
-        GyroECLPMath.validateParams(eclpParams);
-        GyroECLPMath.validateDerivedParams(eclpParams, derivedEclpParams);
-    }
+        try {
+            GyroECLPMath.validateParams(eclpParams);
+        } catch (err) {
+            throw inputValidationError(
+                'Create Gyro ECLP',
+                'Invalid base parameters',
+                (err as Error).message,
+            );
+        }
 
+        try {
+            GyroECLPMath.validateDerivedParams(eclpParams, derivedEclpParams);
+        } catch (err) {
+            throw inputValidationError(
+                'Create Gyro ECLP',
+                'Invalid derived parameters',
+                (err as Error).message,
+            );
+        }
+    }
     validateAddLiquidity(
         addLiquidityInput: AddLiquidityInput,
         poolState: PoolState,

--- a/test/v3/createPool/gyroECLP/gyroECLP.validation.test.ts
+++ b/test/v3/createPool/gyroECLP/gyroECLP.validation.test.ts
@@ -183,8 +183,8 @@ describe('create GyroECLP pool input validations', () => {
         ];
         expect(() => buildCallWithModifiedInput({ tokens })).toThrowError(
             inputValidationError(
-                'Create Gyro ECLP',
-                'This pool supports only two tokens on Balancer v3',
+                'Create Pool',
+                'GyroECLP pools support only two tokens on Balancer v3',
             ),
         );
     });
@@ -195,8 +195,8 @@ describe('create GyroECLP pool input validations', () => {
                 buildCallWithModifiedInput({ eclpParams: { s: -1n } }),
             ).toThrowError(
                 inputValidationError(
-                    'Create Gyro ECLP',
-                    'Invalid base parameters',
+                    'Create Pool',
+                    'Invalid base ECLP parameters',
                     's must be >= 0 and <= 1000000000000000000',
                 ),
             );
@@ -207,8 +207,8 @@ describe('create GyroECLP pool input validations', () => {
                 }),
             ).toThrowError(
                 inputValidationError(
-                    'Create Gyro ECLP',
-                    'Invalid base parameters',
+                    'Create Pool',
+                    'Invalid base ECLP parameters',
                     's must be >= 0 and <= 1000000000000000000',
                 ),
             );
@@ -219,8 +219,8 @@ describe('create GyroECLP pool input validations', () => {
                 buildCallWithModifiedInput({ eclpParams: { c: -1n } }),
             ).toThrowError(
                 inputValidationError(
-                    'Create Gyro ECLP',
-                    'Invalid base parameters',
+                    'Create Pool',
+                    'Invalid base ECLP parameters',
                     'c must be >= 0 and <= 1000000000000000000',
                 ),
             );
@@ -231,8 +231,8 @@ describe('create GyroECLP pool input validations', () => {
                 }),
             ).toThrowError(
                 inputValidationError(
-                    'Create Gyro ECLP',
-                    'Invalid base parameters',
+                    'Create Pool',
+                    'Invalid base ECLP parameters',
                     'c must be >= 0 and <= 1000000000000000000',
                 ),
             );
@@ -245,8 +245,8 @@ describe('create GyroECLP pool input validations', () => {
                 }),
             ).toThrowError(
                 inputValidationError(
-                    'Create Gyro ECLP',
-                    'Invalid base parameters',
+                    'Create Pool',
+                    'Invalid base ECLP parameters',
                     'RotationVectorNotNormalized()',
                 ),
             );
@@ -260,8 +260,8 @@ describe('create GyroECLP pool input validations', () => {
                 }),
             ).toThrowError(
                 inputValidationError(
-                    'Create Gyro ECLP',
-                    'Invalid base parameters',
+                    'Create Pool',
+                    'Invalid base ECLP parameters',
                     'RotationVectorNotNormalized()',
                 ),
             );
@@ -274,8 +274,8 @@ describe('create GyroECLP pool input validations', () => {
                 }),
             ).toThrowError(
                 inputValidationError(
-                    'Create Gyro ECLP',
-                    'Invalid base parameters',
+                    'Create Pool',
+                    'Invalid base ECLP parameters',
                     'lambda must be >= 0 and <= 100000000000000000000000000',
                 ),
             );
@@ -286,8 +286,8 @@ describe('create GyroECLP pool input validations', () => {
                 }),
             ).toThrowError(
                 inputValidationError(
-                    'Create Gyro ECLP',
-                    'Invalid base parameters',
+                    'Create Pool',
+                    'Invalid base ECLP parameters',
                     'lambda must be >= 0 and <= 100000000000000000000000000',
                 ),
             );
@@ -302,8 +302,8 @@ describe('create GyroECLP pool input validations', () => {
                 }),
             ).toThrowError(
                 inputValidationError(
-                    'Create Gyro ECLP',
-                    'Invalid derived parameters',
+                    'Create Pool',
+                    'Invalid derived ECLP parameters',
                     'tuaAlpha.y must be > 0',
                 ),
             );
@@ -316,8 +316,8 @@ describe('create GyroECLP pool input validations', () => {
                 }),
             ).toThrowError(
                 inputValidationError(
-                    'Create Gyro ECLP',
-                    'Invalid derived parameters',
+                    'Create Pool',
+                    'Invalid derived ECLP parameters',
                     'tauBeta.y must be > 0',
                 ),
             );
@@ -334,8 +334,8 @@ describe('create GyroECLP pool input validations', () => {
                 }),
             ).toThrowError(
                 inputValidationError(
-                    'Create Gyro ECLP',
-                    'Invalid derived parameters',
+                    'Create Pool',
+                    'Invalid derived ECLP parameters',
                     'tauBeta.x must be > tauAlpha.x',
                 ),
             );
@@ -353,8 +353,8 @@ describe('create GyroECLP pool input validations', () => {
                 }),
             ).toThrowError(
                 inputValidationError(
-                    'Create Gyro ECLP',
-                    'Invalid derived parameters',
+                    'Create Pool',
+                    'Invalid derived ECLP parameters',
                     'RotationVectorNotNormalized()',
                 ),
             );
@@ -370,8 +370,8 @@ describe('create GyroECLP pool input validations', () => {
                 }),
             ).toThrowError(
                 inputValidationError(
-                    'Create Gyro ECLP',
-                    'Invalid derived parameters',
+                    'Create Pool',
+                    'Invalid derived ECLP parameters',
                     'RotationVectorNotNormalized()',
                 ),
             );
@@ -384,8 +384,8 @@ describe('create GyroECLP pool input validations', () => {
                 }),
             ).toThrowError(
                 inputValidationError(
-                    'Create Gyro ECLP',
-                    'Invalid derived parameters',
+                    'Create Pool',
+                    'Invalid derived ECLP parameters',
                     `u must be <= ${_ONE_XP}`,
                 ),
             );
@@ -396,8 +396,8 @@ describe('create GyroECLP pool input validations', () => {
                 }),
             ).toThrowError(
                 inputValidationError(
-                    'Create Gyro ECLP',
-                    'Invalid derived parameters',
+                    'Create Pool',
+                    'Invalid derived ECLP parameters',
                     `v must be <= ${_ONE_XP}`,
                 ),
             );
@@ -408,8 +408,8 @@ describe('create GyroECLP pool input validations', () => {
                 }),
             ).toThrowError(
                 inputValidationError(
-                    'Create Gyro ECLP',
-                    'Invalid derived parameters',
+                    'Create Pool',
+                    'Invalid derived ECLP parameters',
                     `w must be <= ${_ONE_XP}`,
                 ),
             );
@@ -420,8 +420,8 @@ describe('create GyroECLP pool input validations', () => {
                 }),
             ).toThrowError(
                 inputValidationError(
-                    'Create Gyro ECLP',
-                    'Invalid derived parameters',
+                    'Create Pool',
+                    'Invalid derived ECLP parameters',
                     `z must be <= ${_ONE_XP}`,
                 ),
             );
@@ -436,8 +436,8 @@ describe('create GyroECLP pool input validations', () => {
                 }),
             ).toThrowError(
                 inputValidationError(
-                    'Create Gyro ECLP',
-                    'Invalid derived parameters',
+                    'Create Pool',
+                    'Invalid derived ECLP parameters',
                     'DerivedDsqWrong()',
                 ),
             );
@@ -450,8 +450,8 @@ describe('create GyroECLP pool input validations', () => {
                 }),
             ).toThrowError(
                 inputValidationError(
-                    'Create Gyro ECLP',
-                    'Invalid derived parameters',
+                    'Create Pool',
+                    'Invalid derived ECLP parameters',
                     'DerivedDsqWrong()',
                 ),
             );

--- a/test/v3/createPool/gyroECLP/gyroECLP.validation.test.ts
+++ b/test/v3/createPool/gyroECLP/gyroECLP.validation.test.ts
@@ -183,35 +183,59 @@ describe('create GyroECLP pool input validations', () => {
         ];
         expect(() => buildCallWithModifiedInput({ tokens })).toThrowError(
             inputValidationError(
-                'Create Pool',
-                'GyroECLP pools support only two tokens on Balancer v3',
+                'Create Gyro ECLP',
+                'This pool supports only two tokens on Balancer v3',
             ),
         );
     });
 
-    describe('validateParams', () => {
+    describe('Validate Base Params', () => {
         test('RotationVectorSWrong()', async () => {
             expect(() =>
                 buildCallWithModifiedInput({ eclpParams: { s: -1n } }),
-            ).toThrowError('s must be >= 0 and <= 1000000000000000000');
+            ).toThrowError(
+                inputValidationError(
+                    'Create Gyro ECLP',
+                    'Invalid base parameters',
+                    's must be >= 0 and <= 1000000000000000000',
+                ),
+            );
 
             expect(() =>
                 buildCallWithModifiedInput({
                     eclpParams: { s: _ONE + 1n },
                 }),
-            ).toThrowError('s must be >= 0 and <= 1000000000000000000');
+            ).toThrowError(
+                inputValidationError(
+                    'Create Gyro ECLP',
+                    'Invalid base parameters',
+                    's must be >= 0 and <= 1000000000000000000',
+                ),
+            );
         });
 
         test('RotationVectorCWrong()', async () => {
             expect(() =>
                 buildCallWithModifiedInput({ eclpParams: { c: -1n } }),
-            ).toThrowError('c must be >= 0 and <= 1000000000000000000');
+            ).toThrowError(
+                inputValidationError(
+                    'Create Gyro ECLP',
+                    'Invalid base parameters',
+                    'c must be >= 0 and <= 1000000000000000000',
+                ),
+            );
 
             expect(() =>
                 buildCallWithModifiedInput({
                     eclpParams: { c: _ONE + 1n },
                 }),
-            ).toThrowError('c must be >= 0 and <= 1000000000000000000');
+            ).toThrowError(
+                inputValidationError(
+                    'Create Gyro ECLP',
+                    'Invalid base parameters',
+                    'c must be >= 0 and <= 1000000000000000000',
+                ),
+            );
         });
 
         test('scnorm2 outside valid range', async () => {
@@ -219,7 +243,13 @@ describe('create GyroECLP pool input validations', () => {
                 buildCallWithModifiedInput({
                     eclpParams: { s: 1n, c: 1n },
                 }),
-            ).toThrowError('RotationVectorNotNormalized');
+            ).toThrowError(
+                inputValidationError(
+                    'Create Gyro ECLP',
+                    'Invalid base parameters',
+                    'RotationVectorNotNormalized()',
+                ),
+            );
 
             expect(() =>
                 buildCallWithModifiedInput({
@@ -228,7 +258,13 @@ describe('create GyroECLP pool input validations', () => {
                         c: parseUnits('1', 18),
                     },
                 }),
-            ).toThrowError('RotationVectorNotNormalized');
+            ).toThrowError(
+                inputValidationError(
+                    'Create Gyro ECLP',
+                    'Invalid base parameters',
+                    'RotationVectorNotNormalized()',
+                ),
+            );
         });
 
         test('lambda outside valid range', async () => {
@@ -237,7 +273,11 @@ describe('create GyroECLP pool input validations', () => {
                     eclpParams: { lambda: -1n },
                 }),
             ).toThrowError(
-                'lambda must be >= 0 and <= 100000000000000000000000000',
+                inputValidationError(
+                    'Create Gyro ECLP',
+                    'Invalid base parameters',
+                    'lambda must be >= 0 and <= 100000000000000000000000000',
+                ),
             );
 
             expect(() =>
@@ -245,18 +285,28 @@ describe('create GyroECLP pool input validations', () => {
                     eclpParams: { lambda: _MAX_STRETCH_FACTOR + 1n },
                 }),
             ).toThrowError(
-                'lambda must be >= 0 and <= 100000000000000000000000000',
+                inputValidationError(
+                    'Create Gyro ECLP',
+                    'Invalid base parameters',
+                    'lambda must be >= 0 and <= 100000000000000000000000000',
+                ),
             );
         });
     });
 
-    describe('validateDerivedParamsLimits', () => {
+    describe('Validate Derived Params', () => {
         test('DerivedTauAlphaYWrong()', async () => {
             expect(() =>
                 buildCallWithModifiedInput({
                     derivedEclpParams: { tauAlpha: { y: -1n } },
                 }),
-            ).toThrowError('tuaAlpha.y must be > 0');
+            ).toThrowError(
+                inputValidationError(
+                    'Create Gyro ECLP',
+                    'Invalid derived parameters',
+                    'tuaAlpha.y must be > 0',
+                ),
+            );
         });
 
         test('DerivedTauBetaYWrong()', async () => {
@@ -264,7 +314,13 @@ describe('create GyroECLP pool input validations', () => {
                 buildCallWithModifiedInput({
                     derivedEclpParams: { tauBeta: { y: -1n } },
                 }),
-            ).toThrowError('tauBeta.y must be > 0');
+            ).toThrowError(
+                inputValidationError(
+                    'Create Gyro ECLP',
+                    'Invalid derived parameters',
+                    'tauBeta.y must be > 0',
+                ),
+            );
         });
 
         test('DerivedTauXWrong()', async () => {
@@ -276,7 +332,13 @@ describe('create GyroECLP pool input validations', () => {
                         },
                     },
                 }),
-            ).toThrowError('tauBeta.x must be > tauAlpha.x');
+            ).toThrowError(
+                inputValidationError(
+                    'Create Gyro ECLP',
+                    'Invalid derived parameters',
+                    'tauBeta.x must be > tauAlpha.x',
+                ),
+            );
         });
 
         test('DerivedTauAlphaNotNormalized()', async () => {
@@ -289,7 +351,13 @@ describe('create GyroECLP pool input validations', () => {
                         },
                     },
                 }),
-            ).toThrowError('RotationVectorNotNormalized()');
+            ).toThrowError(
+                inputValidationError(
+                    'Create Gyro ECLP',
+                    'Invalid derived parameters',
+                    'RotationVectorNotNormalized()',
+                ),
+            );
 
             expect(() =>
                 buildCallWithModifiedInput({
@@ -300,7 +368,13 @@ describe('create GyroECLP pool input validations', () => {
                         },
                     },
                 }),
-            ).toThrowError('RotationVectorNotNormalized()');
+            ).toThrowError(
+                inputValidationError(
+                    'Create Gyro ECLP',
+                    'Invalid derived parameters',
+                    'RotationVectorNotNormalized()',
+                ),
+            );
         });
 
         test('Derived parameters u, v, w, z limits', async () => {
@@ -308,25 +382,49 @@ describe('create GyroECLP pool input validations', () => {
                 buildCallWithModifiedInput({
                     derivedEclpParams: { u: _ONE_XP + 1n },
                 }),
-            ).toThrowError(`u must be <= ${_ONE_XP}`);
+            ).toThrowError(
+                inputValidationError(
+                    'Create Gyro ECLP',
+                    'Invalid derived parameters',
+                    `u must be <= ${_ONE_XP}`,
+                ),
+            );
 
             expect(() =>
                 buildCallWithModifiedInput({
                     derivedEclpParams: { v: _ONE_XP + 1n },
                 }),
-            ).toThrowError(`v must be <= ${_ONE_XP}`);
+            ).toThrowError(
+                inputValidationError(
+                    'Create Gyro ECLP',
+                    'Invalid derived parameters',
+                    `v must be <= ${_ONE_XP}`,
+                ),
+            );
 
             expect(() =>
                 buildCallWithModifiedInput({
                     derivedEclpParams: { w: _ONE_XP + 1n },
                 }),
-            ).toThrowError(`w must be <= ${_ONE_XP}`);
+            ).toThrowError(
+                inputValidationError(
+                    'Create Gyro ECLP',
+                    'Invalid derived parameters',
+                    `w must be <= ${_ONE_XP}`,
+                ),
+            );
 
             expect(() =>
                 buildCallWithModifiedInput({
                     derivedEclpParams: { z: _ONE_XP + 1n },
                 }),
-            ).toThrowError(`z must be <= ${_ONE_XP}`);
+            ).toThrowError(
+                inputValidationError(
+                    'Create Gyro ECLP',
+                    'Invalid derived parameters',
+                    `z must be <= ${_ONE_XP}`,
+                ),
+            );
         });
 
         test('DerivedDsqWrong()', async () => {
@@ -336,7 +434,13 @@ describe('create GyroECLP pool input validations', () => {
                         dSq: _ONE_XP - _DERIVED_DSQ_NORM_ACCURACY_XP - 1n,
                     },
                 }),
-            ).toThrowError('DerivedDsqWrong()');
+            ).toThrowError(
+                inputValidationError(
+                    'Create Gyro ECLP',
+                    'Invalid derived parameters',
+                    'DerivedDsqWrong()',
+                ),
+            );
 
             expect(() =>
                 buildCallWithModifiedInput({
@@ -344,7 +448,13 @@ describe('create GyroECLP pool input validations', () => {
                         dSq: _ONE_XP + _DERIVED_DSQ_NORM_ACCURACY_XP + 1n,
                     },
                 }),
-            ).toThrowError('DerivedDsqWrong()');
+            ).toThrowError(
+                inputValidationError(
+                    'Create Gyro ECLP',
+                    'Invalid derived parameters',
+                    'DerivedDsqWrong()',
+                ),
+            );
         });
     });
 });


### PR DESCRIPTION
### Summary 
- Use SDKError `message` to differentiate between base vs derived param validations
- Use error message thrown by [balancer maths](https://github.com/balancer/balancer-maths/blob/0dcd1db8f8efb1e150787dd2c60274c461f0fc12/typescript/src/gyro/gyroECLPMath.ts#L80-L109) as the SDKError `suggestion`