### PR TITLE
Fix map pool type

### DIFF
--- a/.changeset/hungry-rocks-jam.md
+++ b/.changeset/hungry-rocks-jam.md
@@ -1,0 +1,5 @@
+---
+"@balancer/sdk": patch
+---
+
+Only mapPoolType for V2. V3 can use string as given.

--- a/src/data/providers/balancer-api/modules/boosted-pool-state/index.ts
+++ b/src/data/providers/balancer-api/modules/boosted-pool-state/index.ts
@@ -40,7 +40,10 @@ export class BoostedPools {
         const poolGetPool: PoolStateWithUnderlyings = {
             ...data.poolGetPool,
             tokens: data.poolGetPool.poolTokens,
-            type: mapPoolType(data.poolGetPool.type),
+            type:
+                data.poolGetPool.protocolVersion === 2
+                    ? mapPoolType(data.poolGetPool.type)
+                    : data.poolGetPool.type,
         };
         return poolGetPool;
     }

--- a/src/data/providers/balancer-api/modules/nested-pool-state/index.ts
+++ b/src/data/providers/balancer-api/modules/nested-pool-state/index.ts
@@ -7,7 +7,7 @@ import {
 } from '../../../../../entities';
 import { Address, Hex } from '../../../../../types';
 import { mapPoolType } from '@/utils/poolTypeMapper';
-import { API_CHAIN_NAMES, isSameAddress } from '@/utils';
+import { API_CHAIN_NAMES, isSameAddress, SDKError } from '@/utils';
 
 export type PoolGetPool = {
     id: Hex;
@@ -100,7 +100,11 @@ export class NestedPools {
 
 export function mapPoolToNestedPoolStateV3(pool: PoolGetPool): NestedPoolState {
     if (pool.protocolVersion !== 3) {
-        throw new Error('Pool protocol version is not 3');
+        throw new SDKError(
+            'BalancerApi',
+            'mapPoolToNestedPoolStateV3',
+            'Pool protocol version is not 3',
+        );
     }
 
     const pools: NestedPoolV3[] = [

--- a/src/data/providers/balancer-api/modules/nested-pool-state/index.ts
+++ b/src/data/providers/balancer-api/modules/nested-pool-state/index.ts
@@ -99,11 +99,15 @@ export class NestedPools {
 }
 
 export function mapPoolToNestedPoolStateV3(pool: PoolGetPool): NestedPoolState {
+    if (pool.protocolVersion !== 3) {
+        throw new Error('Pool protocol version is not 3');
+    }
+
     const pools: NestedPoolV3[] = [
         {
             id: pool.id,
             address: pool.address,
-            type: mapPoolType(pool.type),
+            type: pool.type,
             level: 1,
             tokens: pool.poolTokens.map((t) => {
                 const minimalToken: PoolTokenWithUnderlying = {

--- a/src/data/providers/balancer-api/modules/pool-state/index.ts
+++ b/src/data/providers/balancer-api/modules/pool-state/index.ts
@@ -53,7 +53,10 @@ export class Pools {
         const poolGetPool: PoolState = {
             ...data.poolGetPool,
             tokens: data.poolGetPool.poolTokens,
-            type: mapPoolType(data.poolGetPool.type),
+            type:
+                data.poolGetPool.protocolVersion === 2
+                    ? mapPoolType(data.poolGetPool.type)
+                    : data.poolGetPool.type,
         };
         return poolGetPool;
     }
@@ -71,7 +74,10 @@ export class Pools {
         const poolStateWithBalances: PoolStateWithBalances = {
             ...data.poolGetPool,
             tokens: data.poolGetPool.poolTokens,
-            type: mapPoolType(data.poolGetPool.type),
+            type:
+                data.poolGetPool.protocolVersion === 2
+                    ? mapPoolType(data.poolGetPool.type)
+                    : data.poolGetPool.type,
             totalShares: data.poolGetPool.dynamicData.totalShares,
         };
         return poolStateWithBalances;

--- a/src/entities/addLiquidityNested/addLiquidityNestedV2/index.ts
+++ b/src/entities/addLiquidityNested/addLiquidityNestedV2/index.ts
@@ -8,7 +8,7 @@ import { balancerRelayerAbiExtended } from '../../../abi';
 import { doAddLiquidityNestedQuery } from './doAddLiquidityNestedQuery';
 import { getQueryCallsAttributes } from './getQueryCallsAttributes';
 import { validateBuildCallInput, validateQueryInput } from './validateInputs';
-import { NestedPoolState } from '../../types';
+import { NestedPoolStateV2 } from '../../types';
 import {
     AddLiquidityNestedBuildCallOutput,
     AddLiquidityNestedInput,
@@ -21,7 +21,7 @@ import {
 export class AddLiquidityNestedV2 {
     async query(
         input: AddLiquidityNestedInput,
-        nestedPoolState: NestedPoolState,
+        nestedPoolState: NestedPoolStateV2,
     ): Promise<AddLiquidityNestedQueryOutputV2> {
         const amountsIn = validateQueryInput(input, nestedPoolState);
 

--- a/src/entities/removeLiquidityNested/removeLiquidityNestedV2/index.ts
+++ b/src/entities/removeLiquidityNested/removeLiquidityNestedV2/index.ts
@@ -6,7 +6,7 @@ import { BALANCER_RELAYER, ZERO_ADDRESS } from '../../../utils';
 
 import { Relayer } from '../../relayer';
 import { TokenAmount } from '../../tokenAmount';
-import { NestedPoolState } from '../../types';
+import { NestedPoolStateV2 } from '../../types';
 
 import { encodeCalls } from './encodeCalls';
 import { doRemoveLiquidityNestedQuery } from './doRemoveLiquidityNestedQuery';
@@ -25,7 +25,7 @@ export class RemoveLiquidityNestedV2 {
         input:
             | RemoveLiquidityNestedProportionalInputV2
             | RemoveLiquidityNestedSingleTokenInputV2,
-        nestedPoolState: NestedPoolState,
+        nestedPoolState: NestedPoolStateV2,
     ): Promise<RemoveLiquidityNestedQueryOutputV2> {
         const isProportional = validateQueryInput(input, nestedPoolState);
         const { callsAttributes, bptAmountIn } = getQueryCallsAttributes(

--- a/src/entities/types.ts
+++ b/src/entities/types.ts
@@ -60,15 +60,16 @@ export type RemoveLiquidityAmounts = {
 type NestedPoolBase = {
     id: Hex;
     address: Address;
-    type: PoolType;
     level: number; // 0 is the bottom and the highest level is the top
 };
 
 export type NestedPoolV2 = NestedPoolBase & {
+    type: PoolType;
     tokens: MinimalToken[]; // each token should have at least one
 };
 
 export type NestedPoolV3 = NestedPoolBase & {
+    type: string;
     tokens: PoolTokenWithUnderlying[]; // each token should have at least one
 };
 

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,4 +1,4 @@
-import { inputValidationError } from '..';
+import { inputValidationError } from './errors';
 import { Token } from '../entities/token';
 import { TokenAmount, BigintIsh } from '../entities/tokenAmount';
 import { Address, SwapKind } from '../types';


### PR DESCRIPTION
V3 does not need a specific pool type for add/removes/swaps to work. We were using `mapPoolType` in API provider which would throw if we don't manually add each new type to supported types. I've changed it to just use the type passed (as string) whenever its V3.