### PR TITLE
Fix Install check

### DIFF
--- a/.changeset/kind-schools-exist.md
+++ b/.changeset/kind-schools-exist.md
@@ -1,0 +1,5 @@
+---
+"@balancer/sdk": patch
+---
+
+Fix Install check in our CI pipeline

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -16,13 +16,12 @@ runs:
         path: ~/.pnpm-store
         key: ${{ matrix.node-version }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
         restore-keys: ${{ matrix.node-version }}-pnpm-
+    - name: Install Dependencies
+      run: pnpm i
+      shell: bash
     - name: Cache node_modules
       uses: actions/cache@v3
       id: cache-node-modules
       with:
         path: node_modules
         key: ${{ matrix.node-version }}-modules-${{ hashFiles('pnpm-lock.yaml') }}
-    - name: Install Dependencies
-      if: steps.cache-node-modules.outputs.cache-hit != 'true'
-      run: pnpm i
-      shell: bash

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,4 +1,5 @@
 name: 'Setup'
+description: 'Sets up the Node.js environment with pnpm, configures caching for dependencies, and installs project packages.'
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
### Issue
Install check started failing "out of the blue" after attempting to do a release

1. [This PR](https://github.com/balancer/b-sdk/pull/634) was merged w/ install check passing
2. [Release PR](https://github.com/balancer/b-sdk/pull/637) was merged
3. Install check [starts failing](https://github.com/balancer/b-sdk/actions/runs/14200966111/job/39789229064) which blocks new release

### Summary
- Moved install of dependencies before attempting to cache `node_modules`