### PR TITLE
Cache node_modules before install

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -16,12 +16,13 @@ runs:
         path: ~/.pnpm-store
         key: ${{ matrix.node-version }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
         restore-keys: ${{ matrix.node-version }}-pnpm-
-    - name: Install Dependencies
-      run: pnpm i
-      shell: bash
     - name: Cache node_modules
       uses: actions/cache@v3
       id: cache-node-modules
       with:
         path: node_modules
         key: ${{ matrix.node-version }}-modules-${{ hashFiles('pnpm-lock.yaml') }}
+    - name: Install Dependencies
+      run: pnpm i
+      shell: bash
+


### PR DESCRIPTION
Closes #639 

Per @johngrantuk 
> Looks like npm had an outage yesterday which might be the reason: https://status.npmjs.org/

### Summary
- Moved install after cache lookup for node_modules
