### PR TITLE
Fix ReClamm init lint issues

### DIFF
--- a/.changeset/every-snails-wear.md
+++ b/.changeset/every-snails-wear.md
@@ -1,0 +1,5 @@
+---
+"@balancer/sdk": patch
+---
+
+Fix ReClamm init lint issues

--- a/package.json
+++ b/package.json
@@ -14,9 +14,7 @@
     "module": "dist/index.mjs",
     "types": "dist/index.d.ts",
     "typings": "dist/index.d.ts",
-    "files": [
-        "dist/"
-    ],
+    "files": ["dist/"],
     "scripts": {
         "build": "tsup",
         "format": "biome format --write .",

--- a/src/utils/calculateReClammInitAmounts.ts
+++ b/src/utils/calculateReClammInitAmounts.ts
@@ -1,13 +1,13 @@
-import {
-    type InputAmount,
-    type MinimalToken,
-    isSameAddress,
-    MathSol,
-    getSortedTokens,
-    Token,
-    TokenAmount,
-} from 'src';
 import { computeInitialBalanceRatio } from '@balancer-labs/balancer-maths';
+
+import { InputAmount } from '@/types';
+import { MinimalToken } from '@/data/types';
+import { getSortedTokens } from '@/entities/utils/getSortedTokens';
+import { Token } from '@/entities/token';
+import { TokenAmount } from '@/entities/tokenAmount';
+
+import { isSameAddress } from './helpers';
+import { MathSol } from './math';
 
 export async function calculateReClammInitAmounts({
     chainId,


### PR DESCRIPTION
Not sure this is the best way to remove the circular dependency, but I couldn't find a better/easier way to do it 😅 

Feel free to suggest a better approach 🙃 