### PR TITLE
feat: idea on validation

### DIFF
--- a/src/entities/inputValidator/inputValidatorBase.ts
+++ b/src/entities/inputValidator/inputValidatorBase.ts
@@ -14,6 +14,9 @@ import { AddLiquidityInput } from '@/entities/addLiquidity/types';
 import { areTokensInArray } from '@/entities/utils/areTokensInArray';
 import { isSameAddress, NATIVE_ASSETS, inputValidationError } from '@/utils';
 
+import { CreatePoolV2 } from '../createPool/createPoolV2';
+import { CreatePoolV3 } from '../createPool/createPoolV3';
+
 export class InputValidatorBase {
     validateInitPool(initPoolInput: InitPoolInput, poolState: PoolState): void {
         areTokensInArray(
@@ -26,7 +29,30 @@ export class InputValidatorBase {
         }
     }
 
-    validateCreatePool(_input: CreatePoolInput) {}
+    validateCreatePool(input: CreatePoolInput) {
+        switch (input.protocolVersion) {
+            case 2: {
+                const buildResult = new CreatePoolV2().buildCall(input);
+                if (!buildResult.to) {
+                    throw inputValidationError(
+                        'Create Pool',
+                        'Target address not available',
+                    );
+                }
+                break;
+            }
+            case 3: {
+                const buildResult = new CreatePoolV3().buildCall(input);
+                if (!buildResult.to) {
+                    throw inputValidationError(
+                        'Create Pool',
+                        'Target address not available',
+                    );
+                }
+                break;
+            }
+        }
+    }
 
     validateAddLiquidity(
         addLiquidityInput: AddLiquidityInput,

--- a/test/inputValidator.test.ts
+++ b/test/inputValidator.test.ts
@@ -1,7 +1,13 @@
 // pnpm test -- inputValidator.test.ts
-import { AddLiquidityInput, PoolState } from '@/entities';
+import { AddLiquidityInput, CreatePoolInput, PoolState } from '@/entities';
 import { InputValidator } from '@/entities/inputValidator/inputValidator';
 import { describe, expect, test } from 'vitest';
+
+import { TokenConfig } from '../src/entities/createPool/types';
+import { TokenType } from '@/types';
+import { TOKENS } from './lib/utils';
+import { zeroAddress, parseUnits } from 'viem';
+import { ChainId } from '@/utils';
 
 describe('inputValidator', () => {
     test('should throw when unsupported chain', () => {
@@ -14,5 +20,44 @@ describe('inputValidator', () => {
         expect(() => {
             inputValidator.validateAddLiquidity(addLiqInput, poolState);
         }).toThrowError(/^Unsupported chainId: 777777777$/);
+    });
+    test('should throw when target address not available', () => {
+        const chainId = ChainId.SEPOLIA;
+        const invalidChainId = ChainId.OPTIMISM;
+
+        const inputValidator = new InputValidator();
+        const createReClammPoolInput = {
+            poolType: 'ReClamm',
+            name: 'ReClamm Bal Dai',
+            symbol: '50BAL-50DAI',
+            tokens: [
+                {
+                    address: TOKENS[chainId].BAL.address,
+                    rateProvider: zeroAddress,
+                    tokenType: TokenType.STANDARD,
+                    paysYieldFees: false,
+                },
+                {
+                    address: TOKENS[chainId].DAI.address,
+                    rateProvider: zeroAddress,
+                    tokenType: TokenType.STANDARD,
+                    paysYieldFees: false,
+                },
+            ],
+            swapFeePercentage: parseUnits('0.01', 18),
+            pauseManager: zeroAddress,
+            swapFeeManager: zeroAddress,
+            initialMinPrice: parseUnits('0.5', 18),
+            initialMaxPrice: parseUnits('8', 18),
+            initialTargetPrice: parseUnits('3', 18),
+            priceShiftDailyRate: parseUnits('1', 18),
+            centerednessMargin: parseUnits('0.2', 18),
+            chainId: invalidChainId,
+            protocolVersion: 3,
+        };
+
+        expect(() => {
+            inputValidator.validateCreatePool(createReClammPoolInput);
+        }).toThrowError('Target address not available');
     });
 });


### PR DESCRIPTION
Closes #635

Idea about adding more config validation. The idea is to validate if the to parameter of the buildCall exists. Because if it does, it means the action (create, add)... is possible. This would allow us to better manage if a given action is possible on a chain or not.

The approach does not look clean though as I am reusing CreatePoolV2/V3 as part of the CreatePool class. Unfortunately I can't do this validation earlier due to infinite looping.

Looking for ideas on the approach and see if this approach can be broadened to the rest of the entities.