### PR TITLE
Add hyperEVM native asset config

### DIFF
--- a/.changeset/five-chicken-strive.md
+++ b/.changeset/five-chicken-strive.md
@@ -1,0 +1,5 @@
+---
+"@balancer/sdk": patch
+---
+
+Add hyperEVM native asset config

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -29,6 +29,8 @@ export const ZERO_ADDRESS: Address =
 export const EMPTY_SENDER = { account: ZERO_ADDRESS };
 
 const NATIVE_ADDRESS: Address = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
+const HYPER_EVM_NATIVE_ADDRESS: Address =
+    '0x2222222222222222222222222222222222222222';
 
 export const MAX_UINT112 = 5192296858534827628530496329220095n;
 export const MAX_UINT256 =
@@ -248,6 +250,14 @@ export const NATIVE_ASSETS = {
         'S',
         'Sonic',
         '0x039e2fb66102314ce7b64ce5ce3e5183bc94ad38',
+    ),
+    [ChainId.HYPER_EVM]: new Token(
+        ChainId.HYPER_EVM,
+        HYPER_EVM_NATIVE_ADDRESS,
+        18,
+        'HYPE',
+        'Hype',
+        '0x5555555555555555555555555555555555555555',
     ),
 };
 


### PR DESCRIPTION
FE throwing this error when trying to build call for init pool on hyperEVM with `wethIsEth` set to `true`

```
Cannot read properties of undefined (reading 'wrapped')
```

I think is thrown by `isSameAddress` because we are missing native asset config for hyperEVM 

https://github.com/balancer/b-sdk/blob/96d8262109aa4b3561d3970f61ac7d01f34bf6b0/src/entities/inputValidator/inputValidatorBase.ts#L52-L68



