### PR TITLE
Remove deprecated token type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -53,5 +53,4 @@ export type InputAmount = InputToken & {
 export enum TokenType {
     STANDARD = 0,
     TOKEN_WITH_RATE = 1,
-    ERC4626_TOKEN = 2,
 }

--- a/test/v3/createPool/gyroECLP/gyroECLP.validation.test.ts
+++ b/test/v3/createPool/gyroECLP/gyroECLP.validation.test.ts
@@ -144,7 +144,7 @@ describe('create GyroECLP pool input validations', () => {
             {
                 address: DAI.address,
                 rateProvider: zeroAddress,
-                tokenType: TokenType.ERC4626_TOKEN,
+                tokenType: TokenType.TOKEN_WITH_RATE,
                 paysYieldFees: false,
             },
         ];

--- a/test/v3/createPool/stable/stable.validation.test.ts
+++ b/test/v3/createPool/stable/stable.validation.test.ts
@@ -144,7 +144,7 @@ describe('create stable pool input validations', () => {
             {
                 address: TOKENS[chainId].USDC.address, // USDC
                 rateProvider: zeroAddress,
-                tokenType: TokenType.ERC4626_TOKEN,
+                tokenType: TokenType.TOKEN_WITH_RATE,
                 paysYieldFees: false,
             },
         ];

--- a/test/v3/createPool/weighted/weighted.validation.test.ts
+++ b/test/v3/createPool/weighted/weighted.validation.test.ts
@@ -129,7 +129,7 @@ describe('create weighted pool input validations', () => {
                 address: TOKENS[chainId].WETH.address, // WETH
                 weight: parseEther(`${1 / 2}`),
                 rateProvider: zeroAddress,
-                tokenType: TokenType.ERC4626_TOKEN,
+                tokenType: TokenType.TOKEN_WITH_RATE,
                 paysYieldFees: false,
             },
         ];


### PR DESCRIPTION
vaguely remember the 3rd token type before v3 launch but does not exist at SC level anymore

https://github.com/balancer/balancer-v3-monorepo/blob/019e50a1218fce21b88d87b08eed4ef3fdf012a3/pkg/interfaces/contracts/vault/VaultTypes.sol#L192-L195