### PR TITLE
Dependabot Setup

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    allow:
+      - dependency-name: "@balancer-labs/balancer-maths"
+      - dependency-name: "viem"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
This Dependabot config is restrictive. It will:
Check for npm updates weekly in the root directory.
Only create PRs for two packages:
@balancer-labs/balancer-maths
viem
Ignore all other dependencies, including:
big.js, decimal.js-light, @types/big.js
Dev dependencies like typescript, vitest, @biomejs/biome, @graphql-codegen/cli, etc.
Limit to 5 open PRs at once.