### PR TITLE
Fix boosted V3 proportional remove: per-index tokensOut inference

### DIFF
--- a/.changeset/chubby-trains-ask.md
+++ b/.changeset/chubby-trains-ask.md
@@ -1,0 +1,9 @@
+---
+"@balancer/sdk": major
+---
+
+# Fix boosted V3 proportional remove tokensOut when the same address exits two pool legs
+
+RemoveLiquidityBoostedV3 no longer infers unwrapWrapped from a flat address map plus sort. tokensOut is interpreted per pool token index (same order as poolState.tokens sorted by index): each entry must be either that leg's pool token address or, for ERC4626 legs, its underlying address. This fixes incorrect unwrap flags (and reverts such as BufferNotInitialized) when one pool token is an ERC4626 share whose underlying is the same token as another pool leg.
+
+**Breaking change**: Callers must pass tokensOut in vault / pool token index order. Previously, unique addresses could be passed in any order because the SDK sorted by resolved index; that behavior is removed. Pass one address per pool token slot, aligned with sorted index. Concrete example: partialBoostedPool_WETH_stataUSDT has WETH at index 0 and stataUSDT at index 1; callers previously passing [USDT, WETH] must now pass [WETH, USDT].

--- a/src/entities/priceImpact/addLiquidityUnbalancedBoosted.ts
+++ b/src/entities/priceImpact/addLiquidityUnbalancedBoosted.ts
@@ -68,6 +68,9 @@ export async function addLiquidityUnbalancedBoosted(
         chainId: input.chainId,
         rpcUrl: input.rpcUrl,
         bptIn: bptOut.toInputAmount(),
+        // poolTokens is already sorted by index (via getSortedTokens), so this
+        // satisfies the tokensOut pool-index-order contract on
+        // RemoveLiquidityBoostedProportionalInput.
         tokensOut: poolTokens.map((t) => t.address),
         kind: RemoveLiquidityKind.Proportional,
     };

--- a/src/entities/removeLiquidityBoosted/index.ts
+++ b/src/entities/removeLiquidityBoosted/index.ts
@@ -1,4 +1,4 @@
-import { Address, encodeFunctionData, zeroAddress } from 'viem';
+import { encodeFunctionData, zeroAddress } from 'viem';
 
 import {
     RemoveLiquidityBase,
@@ -24,8 +24,8 @@ import {
     RemoveLiquidityBoostedQueryOutput,
 } from './types';
 import { InputValidator } from '../inputValidator/inputValidator';
-import { buildPoolStateTokenMap } from '@/entities/utils';
 import { AddressProvider } from '@/entities/inputValidator/utils/addressProvider';
+import { inferUnwrapWrapped } from './inferUnwrapWrapped';
 
 export class RemoveLiquidityBoostedV3 implements RemoveLiquidityBase {
     private readonly inputValidator: InputValidator = new InputValidator();
@@ -40,16 +40,12 @@ export class RemoveLiquidityBoostedV3 implements RemoveLiquidityBase {
             type: 'Boosted',
         });
 
-        const poolStateTokenMap = buildPoolStateTokenMap(poolState);
+        const poolTokens = [...poolState.tokens].sort(
+            (a, b) => a.index - b.index,
+        );
 
-        // Infer if token should be unwrapped using the tokensOut provided by user
-        const unwrapWrapped = input.tokensOut
-            .map((t) => {
-                const tokenOut = poolStateTokenMap[t.toLowerCase() as Address];
-                return tokenOut;
-            })
-            .sort((a, b) => a.index - b.index) // sort by index to match the order of the pool tokens
-            .map((t) => t.isUnderlyingToken);
+        // Infer per-slot unwrap flags using pool index order
+        const unwrapWrapped = inferUnwrapWrapped(poolState.tokens, input.tokensOut);
 
         const [tokensOut, underlyingAmountsOut] =
             await doRemoveLiquidityProportionalQuery(
@@ -64,11 +60,13 @@ export class RemoveLiquidityBoostedV3 implements RemoveLiquidityBase {
             );
 
         const amountsOut = underlyingAmountsOut.map((amount, i) => {
-            const tokenOut = tokensOut[i];
-            const { decimals } =
-                poolStateTokenMap[tokenOut.toLowerCase() as Address];
-
-            const token = new Token(input.chainId, tokenOut, decimals);
+            const pt = poolTokens[i];
+            const address = tokensOut[i];
+            const decimals =
+                unwrapWrapped[i] && pt.underlyingToken
+                    ? pt.underlyingToken.decimals
+                    : pt.decimals;
+            const token = new Token(input.chainId, address, decimals);
             return TokenAmount.fromRawAmount(token, amount);
         });
 

--- a/src/entities/removeLiquidityBoosted/index.ts
+++ b/src/entities/removeLiquidityBoosted/index.ts
@@ -45,7 +45,10 @@ export class RemoveLiquidityBoostedV3 implements RemoveLiquidityBase {
         );
 
         // Infer per-slot unwrap flags using pool index order
-        const unwrapWrapped = inferUnwrapWrapped(poolState.tokens, input.tokensOut);
+        const unwrapWrapped = inferUnwrapWrapped(
+            poolState.tokens,
+            input.tokensOut,
+        );
 
         const [tokensOut, underlyingAmountsOut] =
             await doRemoveLiquidityProportionalQuery(

--- a/src/entities/removeLiquidityBoosted/inferUnwrapWrapped.ts
+++ b/src/entities/removeLiquidityBoosted/inferUnwrapWrapped.ts
@@ -1,0 +1,47 @@
+import { Address } from 'viem';
+
+import { PoolTokenWithUnderlying } from '@/entities/types';
+import { isSameAddress, inputValidationError } from '@/utils';
+
+/**
+ * Derives the per-slot `unwrapWrapped` boolean array for a boosted proportional
+ * remove-liquidity query.
+ *
+ * @param poolTokens - Pool tokens (any order; sorted internally by `index`).
+ * @param tokensOut  - One address per pool slot, aligned with sorted `index`.
+ *                    Each entry must be either the pool token address (→ false)
+ *                    or, for ERC4626 slots, the underlying address (→ true).
+ *
+ * This is a pure function: all validation that is input-shape dependent
+ * (e.g. length mismatch) is handled by the caller via InputValidator before
+ * this helper is invoked.
+ */
+export function inferUnwrapWrapped(
+    poolTokens: PoolTokenWithUnderlying[],
+    tokensOut: Address[],
+): boolean[] {
+    const sorted = [...poolTokens].sort((a, b) => a.index - b.index);
+
+    return sorted.map((pt, i) => {
+        const desired = tokensOut[i];
+
+        if (isSameAddress(desired, pt.address)) {
+            return false;
+        }
+
+        if (
+            pt.underlyingToken !== null &&
+            isSameAddress(desired, pt.underlyingToken.address)
+        ) {
+            return true;
+        }
+
+        const underlyingHint = pt.underlyingToken
+            ? ` or its underlying ${pt.underlyingToken.address}`
+            : '';
+        throw inputValidationError(
+            'Remove Liquidity Boosted',
+            `tokensOut[${i}] (${desired}) is not valid for pool token index ${i}: expected pool token ${pt.address}${underlyingHint}`,
+        );
+    });
+}

--- a/src/entities/removeLiquidityBoosted/types.ts
+++ b/src/entities/removeLiquidityBoosted/types.ts
@@ -8,6 +8,18 @@ export type RemoveLiquidityBoostedProportionalInput = {
     chainId: number;
     rpcUrl: string;
     bptIn: InputAmount;
+    /**
+     * One address per pool token, in the same order as `poolState.tokens`
+     * sorted by `index`. For each slot `i`:
+     *   - Pass the pool token address to receive the pool token as-is (no unwrap).
+     *   - Pass the ERC4626 underlying address to receive the unwrapped asset.
+     *   - Any other address throws a validation error.
+     *
+     * The ordering requirement is strict: unlike the previous flat-map
+     * implementation, addresses are resolved per slot, not as an unordered
+     * multiset. This is necessary to correctly handle pools where a plain
+     * token and the underlying of an ERC4626 share the same address.
+     */
     tokensOut: Address[];
     kind: RemoveLiquidityKind.Proportional;
     sender?: Address;

--- a/test/mockData/boostedPool.ts
+++ b/test/mockData/boostedPool.ts
@@ -60,6 +60,33 @@ export const boostedPool_steakUSDC_csUSDL: PoolStateWithUnderlyings = {
     ],
 };
 
+// ZCHF (plain) + svZCHF (ERC4626 with underlying = ZCHF)
+// Duplicate-address case: tokensOut[0] and tokensOut[1] can both be the ZCHF address
+export const boostedPool_ZCHF_svZCHF: PoolStateWithUnderlyings = {
+    id: '0x849d43118c2e3c4856af26ee96f1a9d72bc2774f',
+    address: '0x849d43118c2e3c4856af26ee96f1a9d72bc2774f',
+    type: 'Stable',
+    protocolVersion: 3,
+    tokens: [
+        {
+            index: 0,
+            address: '0xb58e61c3098d85632df34eecfb899a1ed80921cb', // ZCHF (plain)
+            decimals: 18,
+            underlyingToken: null,
+        },
+        {
+            index: 1,
+            address: '0xe5f130253ff137f9917c0107659a4c5262abf6b0', // svZCHF (ERC4626)
+            decimals: 18,
+            underlyingToken: {
+                address: '0xb58e61c3098d85632df34eecfb899a1ed80921cb', // ZCHF again
+                decimals: 18,
+                index: 1,
+            },
+        },
+    ],
+};
+
 // gnosis-chain
 
 export const boostedPool_sDAI_BRLA: PoolStateWithUnderlyings = {

--- a/test/v3/removeLiquidityBoosted/inferUnwrapWrapped.test.ts
+++ b/test/v3/removeLiquidityBoosted/inferUnwrapWrapped.test.ts
@@ -43,7 +43,8 @@ const duplicateAddressPool = {
 // a distinct underlying.
 const PLAIN_A = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' as `0x${string}`;
 const ERC4626_B = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' as `0x${string}`;
-const UNDERLYING_B = '0xcccccccccccccccccccccccccccccccccccccccc' as `0x${string}`;
+const UNDERLYING_B =
+    '0xcccccccccccccccccccccccccccccccccccccccc' as `0x${string}`;
 
 const standardPool = {
     tokens: [
@@ -124,8 +125,7 @@ describe('inferUnwrapWrapped', () => {
 
     describe('address comparison', () => {
         it('matches addresses case-insensitively (mixed-case checksummed vs lowercased)', () => {
-            const mixedCasePlain =
-                PLAIN_TOKEN.toLowerCase() as `0x${string}`;
+            const mixedCasePlain = PLAIN_TOKEN.toLowerCase() as `0x${string}`;
             const mixedCaseERC4626 = ERC4626_TOKEN.toUpperCase().replace(
                 /^0X/,
                 '0x',

--- a/test/v3/removeLiquidityBoosted/inferUnwrapWrapped.test.ts
+++ b/test/v3/removeLiquidityBoosted/inferUnwrapWrapped.test.ts
@@ -1,0 +1,141 @@
+// pnpm test -- inferUnwrapWrapped.test.ts
+//
+// Unit tests for the inferUnwrapWrapped helper (no fork required).
+
+import { describe, it, expect } from 'vitest';
+import { inferUnwrapWrapped } from '@/entities/removeLiquidityBoosted/inferUnwrapWrapped';
+
+// Pool token addresses used across tests
+const PLAIN_TOKEN = '0xb58e61c3098d85632df34eecfb899a1ed80921cb'; // ZCHF
+const ERC4626_TOKEN = '0xe5f130253ff137f9917c0107659a4c5262abf6b0'; // svZCHF (underlying = ZCHF)
+const OTHER_TOKEN = '0x1111111111111111111111111111111111111111';
+
+// Minimal PoolStateWithUnderlyings representing ZCHF + svZCHF.
+// Token[0] is a plain token; token[1] is ERC4626 whose underlying shares the
+// same address as token[0] — the duplicate-address scenario that broke the
+// flat-map inference.
+const duplicateAddressPool = {
+    id: '0x849d43118c2e3c4856af26ee96f1a9d72bc2774f',
+    address: '0x849d43118c2e3c4856af26ee96f1a9d72bc2774f' as `0x${string}`,
+    type: 'Stable',
+    protocolVersion: 3 as const,
+    tokens: [
+        {
+            index: 0,
+            address: PLAIN_TOKEN as `0x${string}`,
+            decimals: 18,
+            underlyingToken: null,
+        },
+        {
+            index: 1,
+            address: ERC4626_TOKEN as `0x${string}`,
+            decimals: 18,
+            underlyingToken: {
+                address: PLAIN_TOKEN as `0x${string}`,
+                decimals: 18,
+                index: 1,
+            },
+        },
+    ],
+};
+
+// Standard two-token boosted pool: plain token A, ERC4626 token B with
+// a distinct underlying.
+const PLAIN_A = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' as `0x${string}`;
+const ERC4626_B = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' as `0x${string}`;
+const UNDERLYING_B = '0xcccccccccccccccccccccccccccccccccccccccc' as `0x${string}`;
+
+const standardPool = {
+    tokens: [
+        { index: 0, address: PLAIN_A, decimals: 6, underlyingToken: null },
+        {
+            index: 1,
+            address: ERC4626_B,
+            decimals: 18,
+            underlyingToken: { address: UNDERLYING_B, decimals: 6, index: 1 },
+        },
+    ],
+};
+
+describe('inferUnwrapWrapped', () => {
+    describe('duplicate-address pool (ZCHF + svZCHF)', () => {
+        it('returns [false, true] when tokensOut = [PLAIN_TOKEN, PLAIN_TOKEN] — slot 0 keeps pool token, slot 1 unwraps ERC4626 to underlying', () => {
+            const result = inferUnwrapWrapped(duplicateAddressPool.tokens, [
+                PLAIN_TOKEN as `0x${string}`,
+                PLAIN_TOKEN as `0x${string}`,
+            ]);
+            expect(result).toEqual([false, true]);
+        });
+
+        it('returns [false, false] when tokensOut = [PLAIN_TOKEN, ERC4626_TOKEN] — both legs keep pool tokens', () => {
+            const result = inferUnwrapWrapped(duplicateAddressPool.tokens, [
+                PLAIN_TOKEN as `0x${string}`,
+                ERC4626_TOKEN as `0x${string}`,
+            ]);
+            expect(result).toEqual([false, false]);
+        });
+    });
+
+    describe('standard (non-duplicate) pool', () => {
+        it('returns [true, true] when both tokensOut are underlying addresses', () => {
+            const result = inferUnwrapWrapped(standardPool.tokens, [
+                PLAIN_A, // PLAIN_A has no underlying; matching its own address = false
+                UNDERLYING_B,
+            ]);
+            expect(result).toEqual([false, true]);
+        });
+
+        it('returns [false, false] when both tokensOut are pool token addresses', () => {
+            const result = inferUnwrapWrapped(standardPool.tokens, [
+                PLAIN_A,
+                ERC4626_B,
+            ]);
+            expect(result).toEqual([false, false]);
+        });
+
+        it('returns [false, true] for a partial-boosted pool when slot 0 wants plain token and slot 1 wants underlying', () => {
+            const result = inferUnwrapWrapped(standardPool.tokens, [
+                PLAIN_A,
+                UNDERLYING_B,
+            ]);
+            expect(result).toEqual([false, true]);
+        });
+    });
+
+    describe('validation', () => {
+        it('throws a validation error when tokensOut[i] is neither the pool token address nor its underlying address', () => {
+            expect(() =>
+                inferUnwrapWrapped(duplicateAddressPool.tokens, [
+                    PLAIN_TOKEN as `0x${string}`,
+                    OTHER_TOKEN as `0x${string}`,
+                ]),
+            ).toThrow(/tokensOut\[1\]/);
+        });
+
+        it('throws referencing the correct pool token index in the error message', () => {
+            expect(() =>
+                inferUnwrapWrapped(standardPool.tokens, [
+                    OTHER_TOKEN as `0x${string}`,
+                    ERC4626_B,
+                ]),
+            ).toThrow(/tokensOut\[0\]/);
+        });
+    });
+
+    describe('address comparison', () => {
+        it('matches addresses case-insensitively (mixed-case checksummed vs lowercased)', () => {
+            const mixedCasePlain =
+                PLAIN_TOKEN.toLowerCase() as `0x${string}`;
+            const mixedCaseERC4626 = ERC4626_TOKEN.toUpperCase().replace(
+                /^0X/,
+                '0x',
+            ) as `0x${string}`;
+
+            const result = inferUnwrapWrapped(duplicateAddressPool.tokens, [
+                mixedCasePlain,
+                mixedCaseERC4626,
+            ]);
+            expect(result).toEqual([false, false]);
+        });
+    });
+});

--- a/test/v3/removeLiquidityBoosted/removeLiquidityBoostedDuplicateAddress.integration.test.ts
+++ b/test/v3/removeLiquidityBoosted/removeLiquidityBoostedDuplicateAddress.integration.test.ts
@@ -1,0 +1,121 @@
+// pnpm test test/v3/removeLiquidityBoosted/removeLiquidityBoostedDuplicateAddress.integration.test.ts
+//
+// Regression test for the duplicate-address tokensOut bug.
+//
+// The ZCHF + svZCHF pool on Mainnet has:
+//   token[0] = ZCHF (plain, no underlying)
+//   token[1] = svZCHF (ERC4626, underlying = ZCHF — same address as token[0])
+//
+// When a caller passes tokensOut = [ZCHF, ZCHF] the old flat-map inference
+// overwrites the plain-token entry with the underlying entry, producing
+// unwrapWrapped = [true, true]. That causes a BufferNotInitialized revert
+// because ZCHF at slot 0 has no ERC4626 buffer.
+//
+// EXPECTED STATUS:
+//   FAIL before the inference fix (todo: wire-query) — query reverts
+//   PASS after the fix — unwrapWrapped = [false, true], correct amountsOut
+
+import { config } from 'dotenv';
+config();
+
+import { RemoveLiquidityKind, RemoveLiquidityBoostedV3 } from 'src';
+import { ANVIL_NETWORKS, startFork } from '../../anvil/anvil-global-setup';
+import { boostedPool_ZCHF_svZCHF } from 'test/mockData/boostedPool';
+import type { RemoveLiquidityBoostedProportionalInput } from 'src';
+
+// Mainnet addresses
+const ZCHF_ADDRESS = '0xb58e61c3098d85632df34eecfb899a1ed80921cb';
+const SVZCHF_ADDRESS = '0xe5f130253ff137f9917c0107659a4c5262abf6b0';
+
+// Fork block at which the ZCHF + svZCHF pool exists and has liquidity.
+// Must be pinned so the test is deterministic — do not use the MAINNET default.
+const FORK_BLOCK = 24935946n;
+
+describe('RemoveLiquidityBoostedV3 — duplicate tokensOut address (ZCHF + svZCHF)', () => {
+    let rpcUrl: string;
+
+    beforeAll(async () => {
+        ({ rpcUrl } = await startFork(
+            ANVIL_NETWORKS.MAINNET,
+            undefined,
+            FORK_BLOCK,
+        ));
+    });
+
+    test('query with tokensOut = [ZCHF, ZCHF] resolves unwrapWrapped = [false, true]', async () => {
+        const removeLiquidity = new RemoveLiquidityBoostedV3();
+
+        const input: RemoveLiquidityBoostedProportionalInput = {
+            chainId: 1,
+            rpcUrl,
+            bptIn: {
+                address: boostedPool_ZCHF_svZCHF.address,
+                decimals: 18,
+                rawAmount: 1_000_000_000_000_000_000n, // 1 BPT — query only, no balance required
+            },
+            // Both entries are the ZCHF address: slot 0 should stay unwrapped
+            // (it IS the pool token), slot 1 should unwrap (it is the underlying
+            // of svZCHF). This is the case the flat-map inference gets wrong.
+            tokensOut: [ZCHF_ADDRESS, ZCHF_ADDRESS],
+            kind: RemoveLiquidityKind.Proportional,
+        };
+
+        const queryOutput = await removeLiquidity.query(
+            input,
+            boostedPool_ZCHF_svZCHF,
+        );
+
+        // Per-index unwrap flags must be correct
+        expect(queryOutput.unwrapWrapped).toEqual([false, true]);
+
+        // amountsOut must have one entry per pool token
+        expect(queryOutput.amountsOut).toHaveLength(
+            boostedPool_ZCHF_svZCHF.tokens.length,
+        );
+
+        // Both output token addresses are ZCHF (the plain token at slot 0 and
+        // the underlying of svZCHF at slot 1 share the same address)
+        expect(queryOutput.amountsOut[0].token.address.toLowerCase()).toEqual(
+            ZCHF_ADDRESS.toLowerCase(),
+        );
+        expect(queryOutput.amountsOut[1].token.address.toLowerCase()).toEqual(
+            ZCHF_ADDRESS.toLowerCase(),
+        );
+
+        // Amounts must be positive — the pool has real liquidity at this block
+        expect(queryOutput.amountsOut[0].amount).toBeGreaterThan(0n);
+        expect(queryOutput.amountsOut[1].amount).toBeGreaterThan(0n);
+    });
+
+    test('query with tokensOut = [ZCHF, svZCHF] resolves unwrapWrapped = [false, false] (no unwrap on either leg)', async () => {
+        const removeLiquidity = new RemoveLiquidityBoostedV3();
+
+        const input: RemoveLiquidityBoostedProportionalInput = {
+            chainId: 1,
+            rpcUrl,
+            bptIn: {
+                address: boostedPool_ZCHF_svZCHF.address,
+                decimals: 18,
+                rawAmount: 1_000_000_000_000_000_000n,
+            },
+            tokensOut: [ZCHF_ADDRESS, SVZCHF_ADDRESS],
+            kind: RemoveLiquidityKind.Proportional,
+        };
+
+        const queryOutput = await removeLiquidity.query(
+            input,
+            boostedPool_ZCHF_svZCHF,
+        );
+
+        expect(queryOutput.unwrapWrapped).toEqual([false, false]);
+        expect(queryOutput.amountsOut).toHaveLength(
+            boostedPool_ZCHF_svZCHF.tokens.length,
+        );
+        expect(queryOutput.amountsOut[0].token.address.toLowerCase()).toEqual(
+            ZCHF_ADDRESS.toLowerCase(),
+        );
+        expect(queryOutput.amountsOut[1].token.address.toLowerCase()).toEqual(
+            SVZCHF_ADDRESS.toLowerCase(),
+        );
+    });
+});

--- a/test/v3/removeLiquidityBoosted/removeLiquidityPartialBoosted.integration.test.ts
+++ b/test/v3/removeLiquidityBoosted/removeLiquidityPartialBoosted.integration.test.ts
@@ -109,7 +109,7 @@ describe('V3 remove liquidity partial boosted', () => {
                 decimals: 18,
                 rawAmount: bptAmount,
             },
-            tokensOut: [USDT.address, WETH.address],
+            tokensOut: [WETH.address, USDT.address],
             kind: RemoveLiquidityKind.Proportional,
         };
 
@@ -144,7 +144,7 @@ describe('V3 remove liquidity partial boosted', () => {
         expect(queryOutput.amountsOut.length).to.eq(
             partialBoostedPool_WETH_stataUSDT.tokens.length,
         );
-        validateTokenAmounts(queryOutput.amountsOut, [usdtToken, wethToken]);
+        validateTokenAmounts(queryOutput.amountsOut, [wethToken, usdtToken]);
     });
 
     describe('remove liquidity transaction', async () => {


### PR DESCRIPTION
RemoveLiquidityBoostedV3.query previously inferred unwrapWrapped by building a flat address → metadata map over all pool tokens and underlyings, then sorting the resolved entries by index. This fails in two related ways when a pool contains a plain token whose address is also the underlying of an ERC4626 slot (e.g. a ZCHF + svZCHF stable pool):

The flat map overwrites the plain-token entry with the ERC4626-underlying entry for the same address, so both slots resolve as isUnderlyingToken: true → unwrapWrapped: [true, true].
The amountsOut decimals lookup used the same flat map, meaning both entries picked up the metadata for the wrong slot.
Together these produced unwrapWrapped: [true, true] and an on-chain BufferNotInitialized revert for the non-ERC4626 leg.

## Fix boosted V3 proportional remove: per-index `tokensOut` inference
### Problem
`RemoveLiquidityBoostedV3.query` previously inferred `unwrapWrapped` by building a flat `address → metadata` map over all pool tokens and underlyings, then sorting the resolved entries by index. This fails when a pool contains a plain token whose address is also the underlying of an ERC4626 slot (e.g. a ZCHF + svZCHF stable pool):
1. The flat map overwrites the plain-token entry with the ERC4626-underlying entry for the same address, so both slots resolve as `isUnderlyingToken: true` → `unwrapWrapped: [true, true]`.
2. The `amountsOut` decimals lookup used the same flat map, so both entries picked up the metadata for the wrong slot.
Together these produced `unwrapWrapped: [true, true]` and an on-chain `BufferNotInitialized` revert for the non-ERC4626 leg.
### Changes
**`src/entities/removeLiquidityBoosted/inferUnwrapWrapped.ts`** *(new)*
Pure helper that resolves `unwrapWrapped[i]` per pool slot: for each `i`, `tokensOut[i]` is compared to `poolTokens[i].address` (→ `false`) and, if the slot has an underlying, to `poolTokens[i].underlyingToken.address` (→ `true`). Any other address throws a clear validation error referencing the exact slot index.
**`src/entities/removeLiquidityBoosted/index.ts`**
- Replaced the old map+sort `unwrapWrapped` block with a call to `inferUnwrapWrapped`.
- Fixed `amountsOut` construction to derive decimals from `poolTokens[i]` directly (using `underlyingToken.decimals` when unwrapping, `pt.decimals` otherwise) instead of looking up the flat map.
- Removed the now-unused `buildPoolStateTokenMap` import.
**`src/entities/removeLiquidityBoosted/types.ts`**
Added JSDoc on `tokensOut` documenting the pool-index-order contract, the three valid cases (pool token / ERC4626 underlying / validation error), and the reason the ordering requirement exists.
**`src/entities/priceImpact/addLiquidityUnbalancedBoosted.ts`**
Added an inline comment on the `tokensOut: poolTokens.map(t => t.address)` line noting that `poolTokens` is already sorted by index (via `getSortedTokens`), so it satisfies the new contract without modification.
**`test/v3/removeLiquidityBoosted/inferUnwrapWrapped.test.ts`**
Activated all 8 unit assertions (previously `it.todo` stubs), covering: duplicate-address pool (ZCHF + svZCHF), standard pool, validation errors with correct slot-index references, and case-insensitive address matching.
**`test/v3/removeLiquidityBoosted/removeLiquidityPartialBoosted.integration.test.ts`**
Updated `tokensOut` from `[USDT.address, WETH.address]` to `[WETH.address, USDT.address]` (WETH is at pool index 0, stataUSDT/USDT at index 1) and aligned the `validateTokenAmounts` assertion order to match.
### Breaking change
Callers must now pass `tokensOut` in **pool token index order** (matching `poolState.tokens` sorted by `index`). The previous implementation sorted by resolved index after the fact, tolerating any unique-address ordering; that behaviour is removed.
**Example:** `partialBoostedPool_WETH_stataUSDT` has WETH at index 0 and stataUSDT at index 1. Callers previously passing `[USDT, WETH]` must now pass `[WETH, USDT]`.