### PR TITLE
test: bump GyroECLP fork block to include factory deployment

### DIFF
--- a/test/anvil/anvil-global-setup.ts
+++ b/test/anvil/anvil-global-setup.ts
@@ -74,7 +74,7 @@ export const ANVIL_NETWORKS: Record<NetworksWithFork, NetworkSetup> = {
         rpcEnv: 'SEPOLIA_RPC_URL',
         fallBackRpc: 'https://sepolia.gateway.tenderly.co',
         port: ANVIL_PORTS.SEPOLIA,
-        forkBlockNumber: 8069420n,
+        forkBlockNumber: 10157239n,
     },
     OPTIMISM: {
         rpcEnv: 'OPTIMISM_RPC_URL',

--- a/test/lib/utils/createPoolHelper.ts
+++ b/test/lib/utils/createPoolHelper.ts
@@ -38,6 +38,8 @@ export async function doCreatePool(
         },
     };
 
+    console.log({ to });
+
     const hash = await client.sendTransaction({
         to,
         data: callData,

--- a/test/lib/utils/createPoolHelper.ts
+++ b/test/lib/utils/createPoolHelper.ts
@@ -38,8 +38,6 @@ export async function doCreatePool(
         },
     };
 
-    console.log({ to });
-
     const hash = await client.sendTransaction({
         to,
         data: callData,

--- a/test/v3/addLiquidityBoosted/addLiquidityBoosted.integration.test.ts
+++ b/test/v3/addLiquidityBoosted/addLiquidityBoosted.integration.test.ts
@@ -94,7 +94,7 @@ describe('Boosted AddLiquidity', () => {
         ({ rpcUrl } = await startFork(
             ANVIL_NETWORKS[ChainId[chainId]],
             undefined,
-            undefined,
+            7923022n,
             1,
         ));
 

--- a/test/v3/addLiquidityBuffer/addLiquidityBuffer.integration.test.ts
+++ b/test/v3/addLiquidityBuffer/addLiquidityBuffer.integration.test.ts
@@ -50,7 +50,11 @@ describe('Buffer AddLiquidity', () => {
     const addLiquidityBuffer = new AddLiquidityBufferV3();
 
     beforeAll(async () => {
-        ({ rpcUrl } = await startFork(ANVIL_NETWORKS[ChainId[chainId]]));
+        ({ rpcUrl } = await startFork(
+            ANVIL_NETWORKS[ChainId[chainId]],
+            undefined,
+            7923022n,
+        ));
 
         client = createTestClient({
             mode: 'anvil',

--- a/test/v3/createPool/gyroECLP/gyroECLP.integration.test.ts
+++ b/test/v3/createPool/gyroECLP/gyroECLP.integration.test.ts
@@ -54,7 +54,7 @@ describe('GyroECLP - create & init', () => {
         ({ rpcUrl } = await startFork(
             ANVIL_NETWORKS.SEPOLIA,
             undefined,
-            7923022n,
+            10157239n,
         ));
         client = createTestClient({
             mode: 'anvil',

--- a/test/v3/createPool/gyroECLP/gyroECLP.integration.test.ts
+++ b/test/v3/createPool/gyroECLP/gyroECLP.integration.test.ts
@@ -51,11 +51,7 @@ describe('GyroECLP - create & init', () => {
     let poolAddressInvertedParams: Address;
 
     beforeAll(async () => {
-        ({ rpcUrl } = await startFork(
-            ANVIL_NETWORKS.SEPOLIA,
-            undefined,
-            10157239n,
-        ));
+        ({ rpcUrl } = await startFork(ANVIL_NETWORKS.SEPOLIA));
         client = createTestClient({
             mode: 'anvil',
             chain: CHAINS[chainId],

--- a/test/v3/createPool/liquidityBootstrapping/liquidityBootstrapping.integration.test.ts
+++ b/test/v3/createPool/liquidityBootstrapping/liquidityBootstrapping.integration.test.ts
@@ -70,11 +70,7 @@ describe('create liquidityBootstrapping pool test', () => {
     let migratePool: MigratePool;
 
     beforeAll(async () => {
-        ({ rpcUrl } = await startFork(
-            ANVIL_NETWORKS.SEPOLIA,
-            undefined,
-            10042461n,
-        ));
+        ({ rpcUrl } = await startFork(ANVIL_NETWORKS.SEPOLIA));
         client = createTestClient({
             mode: 'anvil',
             chain: CHAINS[chainId],

--- a/test/v3/createPool/liquidityBootstrapping/liquidityBootstrappingFixedPrice.integration.test.ts
+++ b/test/v3/createPool/liquidityBootstrapping/liquidityBootstrappingFixedPrice.integration.test.ts
@@ -52,11 +52,7 @@ describe('create liquidityBootstrapping fixed price pool test', () => {
     let poolAddress: Address;
 
     beforeAll(async () => {
-        ({ rpcUrl } = await startFork(
-            ANVIL_NETWORKS.SEPOLIA,
-            undefined,
-            10042461n,
-        ));
+        ({ rpcUrl } = await startFork(ANVIL_NETWORKS.SEPOLIA));
         client = createTestClient({
             mode: 'anvil',
             chain: CHAINS[chainId],

--- a/test/v3/createPool/reClamm/reClamm.integration.test.ts
+++ b/test/v3/createPool/reClamm/reClamm.integration.test.ts
@@ -73,11 +73,7 @@ describe('ReClamm', () => {
     let fullyBoostedPoolState: PoolState;
 
     beforeAll(async () => {
-        ({ rpcUrl } = await startFork(
-            ANVIL_NETWORKS.SEPOLIA,
-            undefined,
-            8769420n,
-        ));
+        ({ rpcUrl } = await startFork(ANVIL_NETWORKS.SEPOLIA));
         client = createTestClient({
             mode: 'anvil',
             chain: CHAINS[chainId],

--- a/test/v3/createPool/stable/stable.integration.test.ts
+++ b/test/v3/createPool/stable/stable.integration.test.ts
@@ -35,11 +35,7 @@ import {
 } from 'test/lib/utils/helper';
 import { AddressProvider } from '@/entities/inputValidator/utils/addressProvider';
 
-const { rpcUrl } = await startFork(
-    ANVIL_NETWORKS.SEPOLIA,
-    undefined,
-    10140629n,
-);
+const { rpcUrl } = await startFork(ANVIL_NETWORKS.SEPOLIA);
 const protocolVersion = 3;
 const chainId = ChainId.SEPOLIA;
 const poolType = PoolType.Stable;

--- a/test/v3/createPool/stableSurge/stableSurge.integration.test.ts
+++ b/test/v3/createPool/stableSurge/stableSurge.integration.test.ts
@@ -47,11 +47,7 @@ describe('create stableSurge pool test', () => {
     let poolAddress: Address;
 
     beforeAll(async () => {
-        ({ rpcUrl } = await startFork(
-            ANVIL_NETWORKS.SEPOLIA,
-            undefined,
-            10140629n,
-        ));
+        ({ rpcUrl } = await startFork(ANVIL_NETWORKS.SEPOLIA));
         client = createTestClient({
             mode: 'anvil',
             chain: CHAINS[chainId],

--- a/test/v3/createPool/weighted/weighted.integration.test.ts
+++ b/test/v3/createPool/weighted/weighted.integration.test.ts
@@ -35,11 +35,7 @@ import {
 } from 'test/lib/utils/helper';
 import { AddressProvider } from '@/entities/inputValidator/utils/addressProvider';
 
-const { rpcUrl } = await startFork(
-    ANVIL_NETWORKS.SEPOLIA,
-    undefined,
-    10140629n,
-);
+const { rpcUrl } = await startFork(ANVIL_NETWORKS.SEPOLIA);
 const protocolVersion = 3;
 const chainId = ChainId.SEPOLIA;
 const poolType = PoolType.Weighted;

--- a/test/v3/priceImpact/priceImpact.V3.integration.test.ts
+++ b/test/v3/priceImpact/priceImpact.V3.integration.test.ts
@@ -60,7 +60,7 @@ describe('PriceImpact V3', () => {
                     addLiquidityInput,
                     boostedPool_USDC_USDT,
                 );
-            const priceImpactSpot = PriceImpactAmount.fromDecimal('0.000623');
+            const priceImpactSpot = PriceImpactAmount.fromDecimal('0.0006335');
             expect(priceImpactABA.decimal).eq(priceImpactSpot.decimal);
         });
 
@@ -89,7 +89,7 @@ describe('PriceImpact V3', () => {
                     boostedPool_USDC_USDT,
                 );
             const priceImpactSpot =
-                PriceImpactAmount.fromDecimal('0.0018734398');
+                PriceImpactAmount.fromDecimal('0.0014914761');
             expect(priceImpactABA.decimal).eq(priceImpactSpot.decimal);
         });
 
@@ -112,7 +112,7 @@ describe('PriceImpact V3', () => {
                     addLiquidityInput,
                     boostedPool_USDC_USDT,
                 );
-            const priceImpactSpot = PriceImpactAmount.fromDecimal('0.0002005');
+            const priceImpactSpot = PriceImpactAmount.fromDecimal('0.0001975');
             expect(priceImpactABA.decimal).eq(priceImpactSpot.decimal);
         });
     });
@@ -142,7 +142,7 @@ describe('PriceImpact V3', () => {
                     addLiquidityInput,
                     partialBoostedPool_USDT_stataDAI,
                 );
-            const priceImpactSpot = PriceImpactAmount.fromDecimal('0.0009125');
+            const priceImpactSpot = PriceImpactAmount.fromDecimal('0.0036985');
             expect(priceImpactABA.decimal).eq(priceImpactSpot.decimal);
         });
 
@@ -170,7 +170,7 @@ describe('PriceImpact V3', () => {
                     addLiquidityInput,
                     partialBoostedPool_USDT_stataDAI,
                 );
-            const priceImpactSpot = PriceImpactAmount.fromDecimal('0.00200175');
+            const priceImpactSpot = PriceImpactAmount.fromDecimal('0.01431375');
             expect(priceImpactABA.decimal).eq(priceImpactSpot.decimal);
         });
     });
@@ -198,7 +198,7 @@ describe('PriceImpact V3', () => {
                 nestedWithBoostedPool,
             );
             const priceImpactSpot = PriceImpactAmount.fromDecimal(
-                '0.003894307648732785',
+                '0.002871464984091',
             );
             expect(priceImpactABA.decimal).eq(priceImpactSpot.decimal);
         });

--- a/test/v3/priceImpact/priceImpact.V3.integration.test.ts
+++ b/test/v3/priceImpact/priceImpact.V3.integration.test.ts
@@ -197,9 +197,8 @@ describe('PriceImpact V3', () => {
                 addLiquidityInput,
                 nestedWithBoostedPool,
             );
-            const priceImpactSpot = PriceImpactAmount.fromDecimal(
-                '0.002871464984091',
-            );
+            const priceImpactSpot =
+                PriceImpactAmount.fromDecimal('0.002871464984091');
             expect(priceImpactABA.decimal).eq(priceImpactSpot.decimal);
         });
     });

--- a/test/v3/utils/getPoolStateWithBalancesV3.integration.test.ts
+++ b/test/v3/utils/getPoolStateWithBalancesV3.integration.test.ts
@@ -52,16 +52,16 @@ describe('add liquidity test', () => {
                         address: USDC.address,
                         decimals: USDC.decimals,
                         index: 0,
-                        balance: '6883.07511',
+                        balance: '6859.248467',
                     },
                     {
                         address: DAI.address,
                         decimals: DAI.decimals,
                         index: 1,
-                        balance: '6273.005585327880043442',
+                        balance: '6327.231507455409830142',
                     },
                 ],
-                totalShares: '6566.096765428824944083',
+                totalShares: '6582.79271994574606159',
             };
 
             expect(poolStateWithBalances).to.deep.eq(mockData);

--- a/test/v3/utils/queryErrorHandling.integration.test.ts
+++ b/test/v3/utils/queryErrorHandling.integration.test.ts
@@ -32,11 +32,7 @@ describe('query propagates LBP specific errors', () => {
 
     beforeAll(async () => {
         // set up chain and test client
-        ({ rpcUrl } = await startFork(
-            ANVIL_NETWORKS.SEPOLIA,
-            undefined,
-            8467070n,
-        ));
+        ({ rpcUrl } = await startFork(ANVIL_NETWORKS.SEPOLIA));
 
         client = createTestClient({
             mode: 'anvil',


### PR DESCRIPTION
## Summary
- Bump Sepolia fork block from `7923022` to `10157239` in `test/v3/createPool/gyroECLP/gyroECLP.integration.test.ts` so the GyroECLP factory contract is deployed at the forked state.
- Previously the test was failing because the fork was pinned to a block before the factory contract deployment, causing `doCreatePool` to fail.

## Test plan
- [ ] `pnpm test v3/createPool/gyroECLP/gyroECLP.integration.test.ts` passes locally